### PR TITLE
chore: remove unused dependencies and standardize environment variable naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,304 @@
+# Contributing to Windows MCP
+
+Thank you for your interest in contributing to the Windows MCP Server! This document provides guidelines and instructions for contributing.
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant. By participating, you are expected to uphold this code. Please report unacceptable behavior to the project maintainers.
+
+## Getting Started
+
+### Prerequisites
+
+- Windows 10/11
+- .NET 8.0 SDK
+- Node.js 18+ (for VS Code extension development)
+- Visual Studio 2022 or VS Code with C# extension
+
+### Setup Development Environment
+
+1. **Clone the repository:**
+   ```bash
+   git clone https://github.com/sbroenne/mcp-windows.git
+   cd mcp-windows
+   ```
+
+2. **Restore dependencies:**
+   ```bash
+   dotnet restore
+   ```
+
+3. **Build the project:**
+   ```bash
+   dotnet build
+   ```
+
+4. **Run tests:**
+   ```bash
+   dotnet test
+   ```
+
+## Development Workflow
+
+### Branch Naming
+
+Use descriptive branch names following this pattern:
+
+```
+<type>/<short-description>
+```
+
+Examples:
+- `feature/keyboard-macro-support`
+- `fix/window-activation-timeout`
+- `docs/update-readme`
+- `test/add-integration-tests`
+
+Types:
+- `feature/` - New features
+- `fix/` - Bug fixes
+- `docs/` - Documentation updates
+- `test/` - Test additions
+- `refactor/` - Code refactoring
+- `perf/` - Performance improvements
+
+### Commit Messages
+
+Follow conventional commits format:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+Examples:
+```
+feat(keyboard): add macro recording support
+
+Implement ability to record and replay keyboard sequences.
+Fixes #123
+```
+
+```
+fix(window): resolve activation timeout on slow systems
+
+Increase default timeout and add exponential backoff retry logic.
+```
+
+Types:
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `docs:` - Documentation
+- `test:` - Test-related
+- `refactor:` - Code refactoring
+- `perf:` - Performance improvement
+- `chore:` - Maintenance tasks
+
+### Pull Requests
+
+1. **Create a feature branch** from `main`
+2. **Make your changes** with clear, focused commits
+3. **Write or update tests** for your changes
+4. **Update documentation** if needed
+5. **Push to your fork** and create a pull request
+
+**Pull Request Guidelines:**
+- Use a clear, descriptive title
+- Link related issues (`Fixes #123`)
+- Provide context and motivation for changes
+- Include testing instructions if applicable
+- Ensure all CI checks pass
+
+## Testing
+
+### Running Tests
+
+```bash
+# All tests
+dotnet test
+
+# Specific category
+dotnet test --filter "Category=Unit"
+dotnet test --filter "Category=Integration"
+
+# Specific test class
+dotnet test --filter "FullyQualifiedName~MouseInputServiceTests"
+
+# With code coverage
+dotnet test /p:CollectCoverage=true /p:CoverageFormat=opencover
+```
+
+### Writing Tests
+
+- Place unit tests in `tests/Sbroenne.WindowsMcp.Tests/Unit/`
+- Place integration tests in `tests/Sbroenne.WindowsMcp.Tests/Integration/`
+- Use descriptive test names: `public void MethodName_WithCondition_ReturnsExpected()`
+- Mark integration tests with `[Trait("Category", "Integration")]`
+- Mock external dependencies in unit tests
+
+Example:
+```csharp
+[Fact]
+public void Click_WithValidCoordinates_SendsClickInput()
+{
+    // Arrange
+    var service = new MouseInputService();
+    
+    // Act
+    var result = service.Click(100, 200);
+    
+    // Assert
+    Assert.True(result.Success);
+}
+```
+
+## Code Style
+
+### C# Standards
+
+- Follow [Microsoft C# Coding Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+- Use `var` for obvious types, explicit types for clarity
+- Use nullable reference types (`#nullable enable`)
+- Prefer records for immutable data types
+- Use dependency injection for services
+
+### EditorConfig
+
+The repository includes `.editorconfig` for consistent formatting. Most editors will apply these settings automatically.
+
+### Code Review Checklist
+
+Before submitting a PR, ensure:
+
+- [ ] Code follows project style guidelines
+- [ ] All tests pass (`dotnet test`)
+- [ ] New tests added for new functionality
+- [ ] Documentation updated (README, comments, etc.)
+- [ ] No commented-out code or debug statements
+- [ ] Commit messages follow conventional commits
+- [ ] Branch is up-to-date with `main`
+
+## Documentation
+
+### Updating README
+
+Update [README.md](README.md) when:
+- Adding new features or tools
+- Changing configuration options
+- Updating installation instructions
+- Adding new examples
+
+### Code Comments
+
+- Add XML documentation comments to public APIs
+- Explain complex logic with clear comments
+- Avoid obvious comments ("increment i")
+
+Example:
+```csharp
+/// <summary>
+/// Sends a mouse click at the specified coordinates.
+/// </summary>
+/// <param name="x">X coordinate in screen space</param>
+/// <param name="y">Y coordinate in screen space</param>
+/// <returns>Result indicating success or failure</returns>
+public ClickResult Click(int x, int y)
+{
+    // Implementation
+}
+```
+
+## Extension Development
+
+### VS Code Extension Structure
+
+```
+vscode-extension/
+├── src/
+│   └── extension.ts          # Main extension entry point
+├── package.json              # Extension manifest
+├── tsconfig.json             # TypeScript configuration
+└── bin/                       # Compiled MCP server binaries
+```
+
+### Building the Extension
+
+```bash
+cd vscode-extension
+
+# Install dependencies
+npm install
+
+# Build TypeScript
+npm run compile
+
+# Package VSIX
+npm run package
+
+# Run in development mode
+npm run watch
+```
+
+### Extension Guidelines
+
+- Keep extension code minimal
+- Focus on server implementation in .NET
+- Use TypeScript for type safety
+- Follow VS Code extension best practices
+
+## Releases
+
+Releases are triggered by git tags following semantic versioning:
+
+- **MCP Server**: `mcp-v<major>.<minor>.<patch>` (e.g., `mcp-v1.2.0`)
+- **VS Code Extension**: `vscode-v<major>.<minor>.<patch>` (e.g., `vscode-v1.2.0`)
+
+Release workflows automatically:
+1. Build and test
+2. Create GitHub Release with notes
+3. Publish VS Code extension to Marketplace
+
+### Release Checklist
+
+Before creating a release tag:
+
+- [ ] All changes merged to `main`
+- [ ] Version numbers updated in relevant files
+- [ ] CHANGELOG updated with release notes
+- [ ] All tests passing
+- [ ] Documentation up-to-date
+
+## Reporting Issues
+
+### Bug Reports
+
+Include:
+- Windows version (10/11, build number)
+- .NET version (`dotnet --version`)
+- Steps to reproduce
+- Expected behavior
+- Actual behavior
+- Relevant error messages or logs
+
+### Feature Requests
+
+Include:
+- Use case and motivation
+- Proposed solution (if any)
+- Alternative approaches
+- Example scenarios
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the MIT License.
+
+## Questions?
+
+- Open a Discussion on GitHub
+- Check existing Issues and PRs
+- Review Architecture in README
+
+Thank you for contributing! 🚀

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageVersion Include="Polly" Version="8.6.5" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.22" />
 
     <!-- Test packages -->

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sbroenne
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server providing Windows automation capabilities for LLM agents. Built on .NET 8 with native Windows API integration.
 
+> **🤖 Co-designed with Claude Sonnet 4.5 via GitHub Copilot** - This project was developed in collaboration with AI pair programming, leveraging Claude Opus 4.5's capabilities through GitHub Copilot to design, create & test a robust, production-ready Windows automation solution. 
+
 ## Features
 
 ### 🖱️ Mouse Control
@@ -43,6 +45,22 @@ A Model Context Protocol (MCP) server providing Windows automation capabilities 
 - **Multi-monitor aware** - supports extended desktop configurations
 - **DPI aware** - correct pixel dimensions on high-DPI displays
 
+## Why Choose Windows MCP?
+
+**Comprehensive Windows Automation** - Unlike generic computer control tools, Windows MCP is purpose-built for Windows with native API integration. It handles Windows-specific challenges (UIPI elevation blocks, secure desktop restrictions, virtual desktops) that generic solutions miss.
+
+**Multi-Monitor & DPI-Aware** - Correctly handles multi-monitor setups, DPI scaling, and virtual desktops—critical for modern Windows environments. Most alternatives struggle with coordinate translation and DPI awareness.
+
+**Full Windows API Coverage** - Direct P/Invoke to Windows APIs (SendInput, SetWindowPos, GetWindowText, GdiPlus) provides reliable, low-level control. No browser automation tricks or approximate solutions.
+
+**Security-Conscious Design** - Detects and gracefully handles elevated windows (UIPI), UAC prompts, and lock screens. Respects Windows security model instead of bypassing it.
+
+**Performance** - Synchronous I/O on dedicated thread pool prevents blocking the LLM. Configurable delays for stability without sacrificing speed.
+
+**Active Development** - Release workflows, comprehensive testing, VS Code extension, and clear contribution guidelines show this is a maintained project, not abandoned.
+
+### Key Advantages of Windows MCP
+
 ## Prerequisites
 
 - Windows 10/11
@@ -51,41 +69,48 @@ A Model Context Protocol (MCP) server providing Windows automation capabilities 
 
 ## Installation
 
-```bash
-# Clone the repository
-git clone https://github.com/your-org/mcp-windows.git
-cd mcp-windows
+### Option 1: VS Code Extension (Recommended)
 
-# Build the project
-dotnet build
+Install the Windows MCP extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sbroenne.windows-mcp) for one-click deployment:
 
-# Run tests
-dotnet test
-```
+1. Open VS Code
+2. Go to Extensions (Ctrl+Shift+X)
+3. Search for "Windows MCP"
+4. Click Install
+
+The extension automatically configures the MCP server and makes it available to GitHub Copilot.
+
+### Option 2: Download from Releases
+
+Download pre-built binaries from the [GitHub Releases page](https://github.com/sbroenne/mcp-windows/releases):
+
+1. Download the latest `mcp-windows-v*.zip`
+2. Extract to your preferred location
+3. Add to your MCP client configuration (see [MCP Configuration](#mcp-configuration))
 
 ## Usage
 
-### Running the Server
+### VS Code Extension
 
-```bash
-dotnet run --project src/Sbroenne.WindowsMcp
-```
+If you installed via the VS Code extension, the MCP server is automatically configured. No manual setup required.
 
-### MCP Configuration
+### Manual Configuration (For Downloaded Releases)
 
-Add to your MCP client configuration:
+If you downloaded from the releases page, add to your MCP client configuration:
 
 ```json
 {
   "servers": {
     "windows": {
       "command": "dotnet",
-      "args": ["run", "--project", "path/to/src/Sbroenne.WindowsMcp"],
+      "args": ["path/to/extracted/Sbroenne.WindowsMcp.dll"],
       "env": {}
     }
   }
 }
 ```
+
+> **Note:** Releases are framework-dependent and require [.NET 8 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) to be installed.
 
 ## Tools
 
@@ -161,111 +186,6 @@ Capture screenshots on Windows.
 |-----------|------|---------|-------------|
 | `include_cursor` | boolean | `false` | Include mouse cursor in capture |
 
-## Examples
-
-### Mouse Control
-
-```json
-// Click at coordinates
-{ "action": "click", "x": 100, "y": 200 }
-
-// Ctrl+click
-{ "action": "click", "x": 100, "y": 200, "modifiers": ["ctrl"] }
-
-// Scroll down
-{ "action": "scroll", "x": 500, "y": 300, "direction": "down", "amount": 3 }
-```
-
-### Keyboard Control
-
-```json
-// Type text (layout-independent)
-{ "action": "type", "text": "Hello, World! 🚀" }
-
-// Press Enter
-{ "action": "press", "key": "enter" }
-
-// Save file (Ctrl+S)
-{ "action": "press", "key": "s", "modifiers": ["ctrl"] }
-
-// Open Command Palette (Ctrl+Shift+P)
-{ "action": "combo", "key": "p", "modifiers": ["ctrl", "shift"] }
-
-// Lock workstation (Win+L)
-{ "action": "combo", "key": "l", "modifiers": ["win"] }
-
-// Play/Pause media
-{ "action": "press", "key": "mediaplaypause" }
-```
-
-### Window Management
-
-```json
-// List all windows
-{ "action": "list" }
-
-// List with filter
-{ "action": "list", "filter": "Chrome" }
-
-// Find windows by title (substring match)
-{ "action": "find", "title": "Notepad" }
-
-// Find windows by regex
-{ "action": "find", "title": ".*Visual Studio.*", "regex": true }
-
-// Activate a window (bring to foreground)
-{ "action": "activate", "handle": "12345678" }
-
-// Get current foreground window
-{ "action": "get_foreground" }
-
-// Minimize a window
-{ "action": "minimize", "handle": "12345678" }
-
-// Maximize a window
-{ "action": "maximize", "handle": "12345678" }
-
-// Restore from minimized/maximized
-{ "action": "restore", "handle": "12345678" }
-
-// Close a window
-{ "action": "close", "handle": "12345678" }
-
-// Move window to position
-{ "action": "move", "handle": "12345678", "x": 100, "y": 100 }
-
-// Resize window
-{ "action": "resize", "handle": "12345678", "width": 800, "height": 600 }
-
-// Move and resize atomically
-{ "action": "set_bounds", "handle": "12345678", "x": 100, "y": 100, "width": 800, "height": 600 }
-
-// Wait for window to appear (with timeout)
-{ "action": "wait_for", "title": "Notepad", "timeout_ms": 10000 }
-```
-
-### Screenshot Control
-
-```json
-// Capture primary screen
-{ "action": "capture", "target": "primary_screen" }
-
-// List all monitors
-{ "action": "list_monitors" }
-
-// Capture specific monitor by index
-{ "action": "capture", "target": "monitor", "monitor_index": 1 }
-
-// Capture window by handle
-{ "action": "capture", "target": "window", "window_handle": 131844 }
-
-// Capture screen region
-{ "action": "capture", "target": "region", "x": 100, "y": 100, "width": 800, "height": 600 }
-
-// Capture with mouse cursor included
-{ "action": "capture", "target": "primary_screen", "include_cursor": true }
-```
-
 ## Supported Keys
 
 ### Function Keys
@@ -314,18 +234,18 @@ The server handles common Windows security scenarios:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `KEYBOARD_CHUNK_DELAY_MS` | `10` | Delay between text chunks |
-| `KEYBOARD_KEY_DELAY_MS` | `10` | Delay between key presses |
-| `KEYBOARD_SEQUENCE_DELAY_MS` | `50` | Delay between sequence keys |
-| `MOUSE_MOVE_DELAY_MS` | `10` | Delay after mouse move |
-| `MOUSE_CLICK_DELAY_MS` | `50` | Delay after mouse click |
-| `MCP_WINDOW_TIMEOUT_MS` | `5000` | Default window operation timeout |
-| `MCP_WINDOW_WAITFOR_TIMEOUT_MS` | `30000` | Default wait_for timeout |
-| `MCP_WINDOW_PROPERTY_TIMEOUT_MS` | `100` | Timeout for querying window properties |
-| `MCP_WINDOW_POLLING_INTERVAL_MS` | `250` | Polling interval for wait_for |
-| `MCP_WINDOW_ACTIVATION_MAX_RETRIES` | `3` | Max retries for window activation |
-| `MCP_SCREENSHOT_TIMEOUT_MS` | `5000` | Screenshot operation timeout |
-| `MCP_SCREENSHOT_MAX_PIXELS` | `33177600` | Maximum capture size (default 8K) |
+| `MCP_WINDOWS_KEYBOARD_CHUNK_DELAY_MS` | `10` | Delay between text chunks |
+| `MCP_WINDOWS_KEYBOARD_KEY_DELAY_MS` | `10` | Delay between key presses |
+| `MCP_WINDOWS_KEYBOARD_SEQUENCE_DELAY_MS` | `50` | Delay between sequence keys |
+| `MCP_WINDOWS_MOUSE_MOVE_DELAY_MS` | `10` | Delay after mouse move |
+| `MCP_WINDOWS_MOUSE_CLICK_DELAY_MS` | `50` | Delay after mouse click |
+| `MCP_WINDOWS_WINDOW_TIMEOUT_MS` | `5000` | Default window operation timeout |
+| `MCP_WINDOWS_WINDOW_WAITFOR_TIMEOUT_MS` | `30000` | Default wait_for timeout |
+| `MCP_WINDOWS_WINDOW_PROPERTY_TIMEOUT_MS` | `100` | Timeout for querying window properties |
+| `MCP_WINDOWS_WINDOW_POLLING_INTERVAL_MS` | `250` | Polling interval for wait_for |
+| `MCP_WINDOWS_WINDOW_ACTIVATION_MAX_RETRIES` | `3` | Max retries for window activation |
+| `MCP_WINDOWS_SCREENSHOT_TIMEOUT_MS` | `5000` | Screenshot operation timeout |
+| `MCP_WINDOWS_SCREENSHOT_MAX_PIXELS` | `33177600` | Maximum capture size (default 8K) |
 
 ## Testing
 
@@ -340,58 +260,6 @@ dotnet test --filter "FullyQualifiedName~Unit"
 dotnet test --filter "FullyQualifiedName~Integration"
 ```
 
-## Architecture
-
-```
-src/Sbroenne.WindowsMcp/
-├── Automation/             # Desktop automation helpers
-│   ├── ElevationDetector.cs
-│   └── SecureDesktopDetector.cs
-├── Capture/                # Screenshot capture services
-│   ├── IMonitorService.cs
-│   ├── IScreenshotService.cs
-│   ├── MonitorService.cs
-│   └── ScreenshotService.cs
-├── Configuration/          # Environment-based configuration
-│   ├── MouseConfiguration.cs
-│   ├── KeyboardConfiguration.cs
-│   ├── WindowConfiguration.cs
-│   └── ScreenshotConfiguration.cs
-├── Input/                  # Input service implementations
-│   ├── MouseInputService.cs
-│   ├── KeyboardInputService.cs
-│   └── ModifierKeyManager.cs
-├── Logging/                # Structured logging helpers
-│   ├── MouseOperationLogger.cs
-│   ├── KeyboardOperationLogger.cs
-│   ├── WindowOperationLogger.cs
-│   └── ScreenshotOperationLogger.cs
-├── Models/                 # Request/response models
-│   ├── MouseControlRequest.cs
-│   ├── KeyboardControlRequest.cs
-│   ├── WindowManagementRequest.cs
-│   ├── ScreenshotControlRequest.cs
-│   └── ...
-├── Native/                 # Windows API interop
-│   ├── NativeMethods.cs
-│   ├── NativeConstants.cs
-│   ├── NativeStructs.cs
-│   └── IVirtualDesktopManager.cs
-├── Tools/                  # MCP tool implementations
-│   ├── MouseControlTool.cs
-│   ├── KeyboardControlTool.cs
-│   ├── WindowManagementTool.cs
-│   └── ScreenshotControlTool.cs
-├── Window/                 # Window management services
-│   ├── IWindowService.cs
-│   ├── WindowService.cs
-│   ├── IWindowEnumerator.cs
-│   ├── WindowEnumerator.cs
-│   ├── IWindowActivator.cs
-│   └── WindowActivator.cs
-└── Program.cs              # Server entry point
-```
-
 ## Security Considerations
 
 - **UIPI**: Windows User Interface Privilege Isolation blocks input to elevated windows from non-elevated processes
@@ -400,8 +268,17 @@ src/Sbroenne.WindowsMcp/
 
 ## License
 
-[Add your license here]
+MIT License - see [LICENSE](LICENSE) file for details.
 
 ## Contributing
 
-[Add contribution guidelines here]
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+
+- Setting up the development environment
+- Branch naming and commit conventions
+- Testing requirements
+- Pull request process
+- Code style standards
+- Release procedures
+
+Start with [Getting Started](CONTRIBUTING.md#getting-started) if you're new to the project.

--- a/src/Sbroenne.WindowsMcp/Configuration/KeyboardConfiguration.cs
+++ b/src/Sbroenne.WindowsMcp/Configuration/KeyboardConfiguration.cs
@@ -8,17 +8,17 @@ public sealed class KeyboardConfiguration
     /// <summary>
     /// The environment variable name for configuring operation timeout.
     /// </summary>
-    public const string TimeoutEnvironmentVariable = "MCP_KEYBOARD_TIMEOUT_MS";
+    public const string TimeoutEnvironmentVariable = "MCP_WINDOWS_KEYBOARD_TIMEOUT_MS";
 
     /// <summary>
     /// The environment variable name for configuring inter-key delay.
     /// </summary>
-    public const string InterKeyDelayEnvironmentVariable = "MCP_KEYBOARD_INTER_KEY_DELAY_MS";
+    public const string InterKeyDelayEnvironmentVariable = "MCP_WINDOWS_KEYBOARD_KEY_DELAY_MS";
 
     /// <summary>
     /// The environment variable name for configuring chunk delay for long text.
     /// </summary>
-    public const string ChunkDelayEnvironmentVariable = "MCP_KEYBOARD_CHUNK_DELAY_MS";
+    public const string ChunkDelayEnvironmentVariable = "MCP_WINDOWS_KEYBOARD_CHUNK_DELAY_MS";
 
     /// <summary>
     /// The default operation timeout in milliseconds.

--- a/src/Sbroenne.WindowsMcp/Configuration/MouseConfiguration.cs
+++ b/src/Sbroenne.WindowsMcp/Configuration/MouseConfiguration.cs
@@ -8,7 +8,7 @@ public sealed class MouseConfiguration
     /// <summary>
     /// The environment variable name for configuring operation timeout.
     /// </summary>
-    public const string TimeoutEnvironmentVariable = "MCP_MOUSE_TIMEOUT_MS";
+    public const string TimeoutEnvironmentVariable = "MCP_WINDOWS_MOUSE_TIMEOUT_MS";
 
     /// <summary>
     /// The default operation timeout in milliseconds.

--- a/src/Sbroenne.WindowsMcp/Configuration/ScreenshotConfiguration.cs
+++ b/src/Sbroenne.WindowsMcp/Configuration/ScreenshotConfiguration.cs
@@ -8,12 +8,12 @@ public sealed class ScreenshotConfiguration
     /// <summary>
     /// Environment variable name for timeout configuration.
     /// </summary>
-    public const string TimeoutEnvVar = "MCP_SCREENSHOT_TIMEOUT_MS";
+    public const string TimeoutEnvVar = "MCP_WINDOWS_SCREENSHOT_TIMEOUT_MS";
 
     /// <summary>
     /// Environment variable name for maximum pixels configuration.
     /// </summary>
-    public const string MaxPixelsEnvVar = "MCP_SCREENSHOT_MAX_PIXELS";
+    public const string MaxPixelsEnvVar = "MCP_WINDOWS_SCREENSHOT_MAX_PIXELS";
 
     /// <summary>
     /// Default timeout in milliseconds.

--- a/src/Sbroenne.WindowsMcp/Configuration/WindowConfiguration.cs
+++ b/src/Sbroenne.WindowsMcp/Configuration/WindowConfiguration.cs
@@ -8,17 +8,17 @@ public sealed record WindowConfiguration
     /// <summary>
     /// The environment variable name for configuring default operation timeout.
     /// </summary>
-    public const string TimeoutEnvironmentVariable = "MCP_WINDOW_TIMEOUT_MS";
+    public const string TimeoutEnvironmentVariable = "MCP_WINDOWS_WINDOW_TIMEOUT_MS";
 
     /// <summary>
     /// The environment variable name for configuring wait_for timeout.
     /// </summary>
-    public const string WaitForTimeoutEnvironmentVariable = "MCP_WINDOW_WAITFOR_TIMEOUT_MS";
+    public const string WaitForTimeoutEnvironmentVariable = "MCP_WINDOWS_WINDOW_WAITFOR_TIMEOUT_MS";
 
     /// <summary>
     /// The environment variable name for configuring property query timeout.
     /// </summary>
-    public const string PropertyQueryTimeoutEnvironmentVariable = "MCP_WINDOW_PROPERTY_TIMEOUT_MS";
+    public const string PropertyQueryTimeoutEnvironmentVariable = "MCP_WINDOWS_WINDOW_PROPERTY_TIMEOUT_MS";
 
     /// <summary>
     /// The default operation timeout in milliseconds.

--- a/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
+++ b/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Polly" />
-    <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="System.Drawing.Common" />
   </ItemGroup>
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -12,14 +12,14 @@
         "win32"
       ],
       "devDependencies": {
-        "@types/node": "^22.19.1",
+        "@types/node": "^22.19.2",
         "@types/vscode": "^1.106.1",
         "@typescript-eslint/eslint-plugin": "^8.46.2",
         "@typescript-eslint/parser": "^8.46.2",
         "@vscode/vsce": "^3.7.1",
         "eslint": "^9.39.1",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.48.0"
+        "typescript-eslint": "^8.49.0"
       },
       "engines": {
         "vscode": "^1.106.0"
@@ -891,9 +891,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
-      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "version": "22.19.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.2.tgz",
+      "integrity": "sha512-LPM2G3Syo1GLzXLGJAKdqoU35XvrWzGJ21/7sgZTUpbkBaOasTj8tjwn6w+hCkqaa1TfJ/w67rJSwYItlJ2mYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -922,18 +922,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.48.1.tgz",
-      "integrity": "sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+      "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/type-utils": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
-        "graphemer": "^1.4.0",
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/type-utils": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.1.0"
@@ -946,22 +945,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.48.1",
+        "@typescript-eslint/parser": "^8.49.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.1.tgz",
-      "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+      "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -977,14 +976,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.48.1.tgz",
-      "integrity": "sha512-HQWSicah4s9z2/HifRPQ6b6R7G+SBx64JlFQpgSSHWPKdvCZX57XCbszg/bapbRsOEv42q5tayTYcEFpACcX1w==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+      "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.48.1",
-        "@typescript-eslint/types": "^8.48.1",
+        "@typescript-eslint/tsconfig-utils": "^8.49.0",
+        "@typescript-eslint/types": "^8.49.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -999,14 +998,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.48.1.tgz",
-      "integrity": "sha512-rj4vWQsytQbLxC5Bf4XwZ0/CKd362DkWMUkviT7DCS057SK64D5lH74sSGzhI6PDD2HCEq02xAP9cX68dYyg1w==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+      "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1"
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1017,9 +1016,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.48.1.tgz",
-      "integrity": "sha512-k0Jhs4CpEffIBm6wPaCXBAD7jxBtrHjrSgtfCjUvPp9AZ78lXKdTR8fxyZO5y4vWNlOvYXRtngSZNSn+H53Jkw==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+      "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1034,15 +1033,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.48.1.tgz",
-      "integrity": "sha512-1jEop81a3LrJQLTf/1VfPQdhIY4PlGDBc/i67EVWObrtvcziysbLN3oReexHOM6N3jyXgCrkBsZpqwH0hiDOQg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+      "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1059,9 +1058,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.48.1.tgz",
-      "integrity": "sha512-+fZ3LZNeiELGmimrujsDCT4CRIbq5oXdHe7chLiW8qzqyPMnn1puNstCrMNVAqwcl2FdIxkuJ4tOs/RFDBVc/Q==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
+      "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1073,16 +1072,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.48.1.tgz",
-      "integrity": "sha512-/9wQ4PqaefTK6POVTjJaYS0bynCgzh6ClJHGSBj06XEHjkfylzB+A3qvyaXnErEZSaxhIo4YdyBgq6j4RysxDg==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+      "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.48.1",
-        "@typescript-eslint/tsconfig-utils": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/visitor-keys": "8.48.1",
+        "@typescript-eslint/project-service": "8.49.0",
+        "@typescript-eslint/tsconfig-utils": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/visitor-keys": "8.49.0",
         "debug": "^4.3.4",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -1101,16 +1100,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.48.1.tgz",
-      "integrity": "sha512-fAnhLrDjiVfey5wwFRwrweyRlCmdz5ZxXz2G/4cLn0YDLjTapmN4gcCsTBR1N2rWnZSDeWpYtgLDsJt+FpmcwA==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+      "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.48.1",
-        "@typescript-eslint/types": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1"
+        "@typescript-eslint/scope-manager": "8.49.0",
+        "@typescript-eslint/types": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1125,13 +1124,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.48.1.tgz",
-      "integrity": "sha512-BmxxndzEWhE4TIEEMBs8lP3MBWN3jFPs/p6gPm/wkv02o41hI6cq9AuSmGAaTTHPtA1FTi2jBre4A9rm5ZmX+Q==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+      "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.48.1",
+        "@typescript-eslint/types": "8.49.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -2851,13 +2850,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5115,16 +5107,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.48.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.48.1.tgz",
-      "integrity": "sha512-FbOKN1fqNoXp1hIl5KYpObVrp0mCn+CLgn479nmu2IsRMrx2vyv74MmsBLVlhg8qVwNFGbXSp8fh1zp8pEoC2A==",
+      "version": "8.49.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.49.0.tgz",
+      "integrity": "sha512-zRSVH1WXD0uXczCXw+nsdjGPUdx4dfrs5VQoHnUWmv1U3oNlAKv4FUNdLDhVUg+gYn+a5hUESqch//Rv5wVhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.48.1",
-        "@typescript-eslint/parser": "8.48.1",
-        "@typescript-eslint/typescript-estree": "8.48.1",
-        "@typescript-eslint/utils": "8.48.1"
+        "@typescript-eslint/eslint-plugin": "8.49.0",
+        "@typescript-eslint/parser": "8.49.0",
+        "@typescript-eslint/typescript-estree": "8.49.0",
+        "@typescript-eslint/utils": "8.49.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -73,13 +73,13 @@
     "lint": "eslint src --ext ts"
   },
   "devDependencies": {
-    "@types/node": "^22.19.1",
+    "@types/node": "^22.19.2",
     "@types/vscode": "^1.106.1",
     "@typescript-eslint/eslint-plugin": "^8.46.2",
     "@typescript-eslint/parser": "^8.46.2",
     "@vscode/vsce": "^3.7.1",
     "eslint": "^9.39.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.48.0"
+    "typescript-eslint": "^8.49.0"
   }
 }


### PR DESCRIPTION
## Changes

- Remove unused Serilog.Extensions.Hosting package dependency
- Standardize all environment variable names to use MCP_WINDOWS_ prefix:
  - Keyboard: MCP_WINDOWS_KEYBOARD_*
  - Mouse: MCP_WINDOWS_MOUSE_*
  - Window: MCP_WINDOWS_WINDOW_*
  - Screenshot: MCP_WINDOWS_SCREENSHOT_*
- Update documentation to reflect new naming convention
- Update npm dependencies in VS Code extension

## Related Issues

None

## Testing

All existing tests should continue to pass with the new environment variable names.

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated
- [x] Environment variable naming standardized