### PR TITLE
Fix GitHub Pages styling for custom domain

### DIFF
--- a/gh-pages/404.md
+++ b/gh-pages/404.md
@@ -11,13 +11,13 @@ permalink: /404.html
 The page you're looking for doesn't exist or has been moved.
 
 <div style="margin: 2rem 0;">
-<a href="/mcp-windows/" class="button-link">← Back to Home</a>
+<a href="/" class="button-link">← Back to Home</a>
 </div>
 
 ## Quick Links
 
-- [Features](/mcp-windows/features/) — All tools and operations
-- [Changelog](/mcp-windows/changelog/) — Release notes and version history
+- [Features](/features/) — All tools and operations
+- [Changelog](/changelog/) — Release notes and version history
 - [GitHub Repository](https://github.com/sbroenne/mcp-windows) — Source code and issues
 
 </div>

--- a/gh-pages/CNAME
+++ b/gh-pages/CNAME
@@ -1,0 +1,1 @@
+windowsmcpserver.dev

--- a/gh-pages/_config.yml
+++ b/gh-pages/_config.yml
@@ -4,12 +4,9 @@
 # Site settings
 title: "Windows MCP Server"
 description: "AI-powered Windows automation through GitHub Copilot & Claude"
-url: "https://sbroenne.github.io"
-baseurl: "/mcp-windows"
+url: "https://windowsmcpserver.dev"
+baseurl: ""
 repository: "sbroenne/mcp-windows"
-
-# Theme
-theme: jekyll-theme-cayman
 
 # Plugins
 plugins:

--- a/gh-pages/_layouts/default.html
+++ b/gh-pages/_layouts/default.html
@@ -29,7 +29,7 @@
         "priceCurrency": "USD"
       },
       "description": "Control Windows with Natural Language through AI assistants like GitHub Copilot and Claude. Automate mouse, keyboard, windows, and screenshots.",
-      "url": "https://sbroenne.github.io/mcp-windows/",
+      "url": "https://windowsmcpserver.dev/",
       "softwareVersion": "1.0",
       "programmingLanguage": "C#",
       "downloadUrl": "https://github.com/sbroenne/mcp-windows/releases",

--- a/gh-pages/index.md
+++ b/gh-pages/index.md
@@ -3,7 +3,7 @@ layout: default
 title: "Windows MCP Server - AI-Powered Windows Automation via GitHub Copilot & Claude"
 description: "Control Windows with natural language through AI assistants like GitHub Copilot and Claude. Automate mouse, keyboard, windows, and screenshots. One-click install for Visual Studio Code."
 keywords: "Windows automation, MCP server, AI Windows, mouse control, keyboard control, window management, screenshot capture, GitHub Copilot Windows, Claude Windows, RPA, QA automation"
-canonical_url: "https://sbroenne.github.io/mcp-windows/"
+canonical_url: "https://windowsmcpserver.dev/"
 ---
 
 <div class="hero">
@@ -64,7 +64,7 @@ It works with any MCP-compatible AI assistant like GitHub Copilot, Claude Deskto
 </div>
 </div>
 
-<p><a href="/mcp-windows/features/">See all tools and operations →</a></p>
+<p><a href="/features/">See all tools and operations →</a></p>
 
 ## Why Choose Windows MCP?
 
@@ -139,14 +139,14 @@ Download pre-built binaries from the [GitHub Releases page](https://github.com/s
 
 ## Documentation
 
-📖 **[Complete Feature Reference](/mcp-windows/features/)** — All tools and operations
+📖 **[Complete Feature Reference](/features/)** — All tools and operations
 
-📋 **[Changelog](/mcp-windows/changelog/)** — Release notes and version history
+📋 **[Changelog](/changelog/)** — Release notes and version history
 
 ## More Information
 
 - [GitHub Repository](https://github.com/sbroenne/mcp-windows) — Source code, issues, and contributions
-- [Contributing Guide](/mcp-windows/contributing/) — How to contribute
+- [Contributing Guide](/contributing/) — How to contribute
 
 ## Related Projects
 


### PR DESCRIPTION
## Problem
The site at windowsmcpserver.dev was missing styling because:
1. The Cayman theme CSS was overriding our custom CSS
2. The baseurl was set to /mcp-windows/ but the custom domain serves from root

## Changes
- Update URL to windowsmcpserver.dev
- Remove baseurl since custom domain is at root  
- Remove jekyll-theme-cayman to use only custom CSS
- Add CNAME file for custom domain
- Fix internal links to not use /mcp-windows/ prefix
- Update structured data URL