### PR TITLE
fix: add Description attributes to tool parameters

### DIFF
--- a/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
@@ -68,16 +68,17 @@ public sealed partial class KeyboardControlTool : IDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the keyboard operation including success status and operation details.</returns>
     [McpServerTool(Name = "keyboard_control", Title = "Keyboard Control", Destructive = true, UseStructuredContent = true)]
+    [Description("Control keyboard input on Windows. Supports type (text), press (key), key_down, key_up, combo, sequence, release_all, and get_keyboard_layout actions.")]
     [return: Description("The result of the keyboard operation including success status, characters typed, key pressed, keyboard layout info, and error details if failed.")]
     public async Task<KeyboardControlResult> ExecuteAsync(
         RequestContext<CallToolRequestParams> context,
-        string action,
-        string? text = null,
-        string? key = null,
-        string? modifiers = null,
-        int repeat = 1,
-        string? sequence = null,
-        int? interKeyDelayMs = null,
+        [Description("The keyboard action: type, press, key_down, key_up, combo, sequence, release_all, or get_keyboard_layout")] string action,
+        [Description("Text to type (required for type action)")] string? text = null,
+        [Description("Key name to press (for press, key_down, key_up, combo actions). Examples: enter, tab, escape, f1, a, ctrl, shift, alt, win, copilot")] string? key = null,
+        [Description("Modifier keys: ctrl, shift, alt, win (comma-separated, for press and combo actions)")] string? modifiers = null,
+        [Description("Number of times to repeat key press (default: 1, for press action)")] int repeat = 1,
+        [Description("JSON array of key sequence items, e.g., [{\"key\":\"ctrl\"},{\"key\":\"c\"}] (for sequence action)")] string? sequence = null,
+        [Description("Delay between keys in sequence (milliseconds)")] int? interKeyDelayMs = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
@@ -79,19 +79,20 @@ public sealed partial class MouseControlTool
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the mouse operation including success status, cursor position, and any errors.</returns>
     [McpServerTool(Name = "mouse_control", Title = "Mouse Control", Destructive = true, UseStructuredContent = true)]
+    [Description("Control mouse input on Windows. Supports move, click, double_click, right_click, middle_click, drag, and scroll actions. COORDINATES: All x/y coordinates are relative to the specified monitor (default: monitor 0 = primary). Example: x=100, y=50 clicks 100px from left, 50px from top of the monitor. For secondary monitor, use monitorIndex=1.")]
     [return: Description("The result of the mouse operation including success status, final cursor position, window title at cursor, and error details if failed.")]
     public async Task<MouseControlResult> ExecuteAsync(
         RequestContext<CallToolRequestParams> context,
-        string action,
-        int? x = null,
-        int? y = null,
-        int? endX = null,
-        int? endY = null,
-        string? direction = null,
-        int amount = 1,
-        string? modifiers = null,
-        string? button = null,
-        int monitorIndex = 0,
+        [Description("The mouse action to perform: move, click, double_click, right_click, middle_click, drag, or scroll")] string action,
+        [Description("X-coordinate relative to the monitor's left edge (required for move, optional for clicks).")] int? x = null,
+        [Description("Y-coordinate relative to the monitor's top edge (required for move, optional for clicks).")] int? y = null,
+        [Description("End x-coordinate relative to the monitor (required for drag action).")] int? endX = null,
+        [Description("End y-coordinate relative to the monitor (required for drag action).")] int? endY = null,
+        [Description("Scroll direction: up, down, left, or right (required for scroll action)")] string? direction = null,
+        [Description("Number of scroll clicks (default: 1)")] int amount = 1,
+        [Description("Modifier keys to hold during action: ctrl, shift, alt (comma-separated)")] string? modifiers = null,
+        [Description("Mouse button for drag: left, right, or middle (default: left)")] string? button = null,
+        [Description("Monitor index (0-based, default: 0 = primary monitor). All coordinates are relative to this monitor.")] int monitorIndex = 0,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
@@ -61,24 +61,25 @@ public sealed partial class ScreenshotControlTool
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result containing base64-encoded image data or file path, dimensions, original dimensions (if scaled), file size, and error details if failed.</returns>
     [McpServerTool(Name = "screenshot_control", Title = "Screenshot Capture", ReadOnly = true, UseStructuredContent = true)]
+    [Description("Captures screenshots of screens, monitors, windows, or regions on Windows. Returns base64-encoded image data (JPEG by default, configurable via imageFormat parameter). LLM-optimized defaults: JPEG format at quality 85, auto-scaled to 1568px width. Use action 'list_monitors' to enumerate available monitors. Use target 'all_monitors' to capture all connected monitors as a single composite image. Respects secure desktop (UAC/lock screen) restrictions.")]
     [return: Description("The result of the screenshot operation including success status, base64-encoded image data or file path, monitor list, and error details if failed.")]
     public async Task<ScreenshotControlResult> ExecuteAsync(
         RequestContext<CallToolRequestParams> context,
-        string? action = null,
-        string? target = null,
-        int? monitorIndex = null,
-        long? windowHandle = null,
-        int? regionX = null,
-        int? regionY = null,
-        int? regionWidth = null,
-        int? regionHeight = null,
-        bool includeCursor = false,
-        string? imageFormat = null,
-        int? quality = null,
-        int? maxWidth = null,
-        int? maxHeight = null,
-        string? outputMode = null,
-        string? outputPath = null,
+        [Description("The action to perform. Valid values: 'capture' (take screenshot), 'list_monitors' (enumerate displays). Default: 'capture'")] string? action = null,
+        [Description("Capture target. Valid values: 'primary_screen', 'monitor' (by index), 'window' (by handle), 'region' (by coordinates), 'all_monitors' (composite of all displays). Default: 'primary_screen'")] string? target = null,
+        [Description("Monitor index for 'monitor' target (0-based). Use 'list_monitors' to get available indices.")] int? monitorIndex = null,
+        [Description("Window handle (IntPtr value) for 'window' target. Get from window_management tool.")] long? windowHandle = null,
+        [Description("X coordinate (left) for 'region' target. Can be negative for multi-monitor setups.")] int? regionX = null,
+        [Description("Y coordinate (top) for 'region' target. Can be negative for multi-monitor setups.")] int? regionY = null,
+        [Description("Width in pixels for 'region' target. Must be positive.")] int? regionWidth = null,
+        [Description("Height in pixels for 'region' target. Must be positive.")] int? regionHeight = null,
+        [Description("Include mouse cursor in capture. Default: false")] bool includeCursor = false,
+        [Description("Screenshot format: 'jpeg'/'jpg' or 'png'. Default: 'jpeg' (LLM-optimized).")] string? imageFormat = null,
+        [Description("Image compression quality 1-100. Default: 85. Only affects JPEG format.")] int? quality = null,
+        [Description("Maximum width in pixels. Image scaled down if wider (aspect ratio preserved). Default: 1568 (Claude's high-res native limit). Set to 0 to disable scaling.")] int? maxWidth = null,
+        [Description("Maximum height in pixels. Image scaled down if taller (aspect ratio preserved). Default: 0 (no height constraint).")] int? maxHeight = null,
+        [Description("How to return the screenshot. 'inline' returns base64 data, 'file' saves to disk and returns path. Default: 'inline'.")] string? outputMode = null,
+        [Description("Directory or file path for output when outputMode is 'file'. If directory, auto-generates filename. If null, uses temp directory.")] string? outputPath = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/Sbroenne.WindowsMcp/Tools/WindowManagementTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/WindowManagementTool.cs
@@ -70,21 +70,22 @@ public sealed partial class WindowManagementTool
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the window operation including success status and window information.</returns>
     [McpServerTool(Name = "window_management", Title = "Window Management", Destructive = true, UseStructuredContent = true)]
+    [Description("Manage windows on Windows. Supports list, find, activate, get_foreground, minimize, maximize, restore, close, move, resize, set_bounds, wait_for, and move_to_monitor actions. Use move_to_monitor to move a window to a specific monitor by index without calculating coordinates.")]
     [return: Description("The result of the window operation including success status, window list or single window info, and error details if failed.")]
     public async Task<WindowManagementResult> ExecuteAsync(
         RequestContext<CallToolRequestParams> context,
-        string action,
-        string? handle = null,
-        string? title = null,
-        string? filter = null,
-        bool regex = false,
-        bool includeAllDesktops = false,
-        int? x = null,
-        int? y = null,
-        int? width = null,
-        int? height = null,
-        int? timeoutMs = null,
-        int? monitorIndex = null,
+        [Description("The window action to perform: list, find, activate, get_foreground, minimize, maximize, restore, close, move, resize, set_bounds, wait_for, or move_to_monitor")] string action,
+        [Description("Window handle (required for activate, minimize, maximize, restore, close, move, resize, set_bounds, move_to_monitor)")] string? handle = null,
+        [Description("Window title to search for (required for find and wait_for)")] string? title = null,
+        [Description("Filter windows by title or process name (for list action)")] string? filter = null,
+        [Description("Use regex matching for title/filter (default: false)")] bool regex = false,
+        [Description("Include windows on other virtual desktops (default: false)")] bool includeAllDesktops = false,
+        [Description("X-coordinate for move or set_bounds action")] int? x = null,
+        [Description("Y-coordinate for move or set_bounds action")] int? y = null,
+        [Description("Width for resize or set_bounds action")] int? width = null,
+        [Description("Height for resize or set_bounds action")] int? height = null,
+        [Description("Timeout in milliseconds for wait_for action")] int? timeoutMs = null,
+        [Description("Target monitor index for move_to_monitor action (0-based). Use with action=move_to_monitor to move a window to a specific monitor.")] int? monitorIndex = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(context);


### PR DESCRIPTION
XML documentation generation for tool parameters is not working with
the MCP SDK, so we added back explicit [Description] attributes on
all parameters as a workaround.

This ensures that LLM clients receive proper parameter descriptions
in the tool schema even though the SDK's source generator does not
extract descriptions from XML doc comments.

Affected tools:
- KeyboardControlTool
- MouseControlTool
- ScreenshotControlTool
- WindowManagementTool