### PR TITLE
fix: disable screenshot scaling by default for accurate mouse positioning

### DIFF
--- a/src/Sbroenne.WindowsMcp/Configuration/ScreenshotConfiguration.cs
+++ b/src/Sbroenne.WindowsMcp/Configuration/ScreenshotConfiguration.cs
@@ -38,10 +38,10 @@ public sealed class ScreenshotConfiguration
     public const int DefaultQuality = 85;
 
     /// <summary>
-    /// Default maximum width for auto-scaling. 1568 is Claude's high-res native limit.
-    /// Set to 0 to disable scaling.
+    /// Default maximum width for auto-scaling. 0 means no scaling (coordinates match screen).
+    /// Set to 1568 for LLM-optimized size (Claude's high-res native limit).
     /// </summary>
-    public const int DefaultMaxWidth = 1568;
+    public const int DefaultMaxWidth = 0;
 
     /// <summary>
     /// Default maximum height for auto-scaling. 0 means no height constraint.

--- a/src/Sbroenne.WindowsMcp/Models/ScreenshotControlRequest.cs
+++ b/src/Sbroenne.WindowsMcp/Models/ScreenshotControlRequest.cs
@@ -58,7 +58,7 @@ public sealed record ScreenshotControlRequest
 
     /// <summary>
     /// Gets the maximum width in pixels. Image scaled down if wider (aspect ratio preserved).
-    /// Default is 1568 (Claude's high-res native limit). Set to 0 to disable scaling.
+    /// Default is 0 (no scaling, coordinates match screen). Set to 1568 for LLM-optimized size.
     /// </summary>
     [JsonPropertyName("max_width")]
     public int MaxWidth { get; init; } = ScreenshotConfiguration.DefaultMaxWidth;

--- a/src/Sbroenne.WindowsMcp/Models/ScreenshotControlResult.cs
+++ b/src/Sbroenne.WindowsMcp/Models/ScreenshotControlResult.cs
@@ -124,6 +124,7 @@ public sealed record ScreenshotControlResult
         string? filePath = null)
     {
         ArgumentNullException.ThrowIfNull(processed);
+        var wasScaled = processed.OriginalWidth != processed.Width;
         return new()
         {
             Success = true,
@@ -132,8 +133,8 @@ public sealed record ScreenshotControlResult
             ImageData = filePath is null ? Convert.ToBase64String(processed.Data) : null,
             Width = processed.Width,
             Height = processed.Height,
-            OriginalWidth = processed.OriginalWidth != processed.Width ? processed.OriginalWidth : null,
-            OriginalHeight = processed.OriginalHeight != processed.Height ? processed.OriginalHeight : null,
+            OriginalWidth = wasScaled ? processed.OriginalWidth : null,
+            OriginalHeight = wasScaled ? processed.OriginalHeight : null,
             Format = processed.Format,
             FileSizeBytes = processed.Data.Length,
             FilePath = filePath
@@ -171,6 +172,7 @@ public sealed record ScreenshotControlResult
     {
         ArgumentNullException.ThrowIfNull(processed);
         ArgumentNullException.ThrowIfNull(metadata);
+        var wasScaled = processed.OriginalWidth != processed.Width;
         return new()
         {
             Success = true,
@@ -179,8 +181,8 @@ public sealed record ScreenshotControlResult
             ImageData = filePath is null ? Convert.ToBase64String(processed.Data) : null,
             Width = processed.Width,
             Height = processed.Height,
-            OriginalWidth = processed.OriginalWidth != processed.Width ? processed.OriginalWidth : null,
-            OriginalHeight = processed.OriginalHeight != processed.Height ? processed.OriginalHeight : null,
+            OriginalWidth = wasScaled ? processed.OriginalWidth : null,
+            OriginalHeight = wasScaled ? processed.OriginalHeight : null,
             Format = processed.Format,
             FileSizeBytes = processed.Data.Length,
             FilePath = filePath,

--- a/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
@@ -37,7 +37,8 @@ public sealed partial class ScreenshotControlTool
     /// </summary>
     /// <remarks>
     /// Returns base64-encoded image data (JPEG by default, configurable via imageFormat parameter).
-    /// LLM-optimized defaults: JPEG format at quality 85, auto-scaled to 1568px width.
+    /// Default: JPEG format at quality 85, no scaling (coordinates match screen for accurate mouse clicks).
+    /// Set maxWidth=1568 for LLM-optimized smaller images.
     /// Use action 'list_monitors' to enumerate available monitors.
     /// Use target 'all_monitors' to capture all connected monitors as a single composite image.
     /// Respects secure desktop (UAC/lock screen) restrictions.
@@ -54,14 +55,14 @@ public sealed partial class ScreenshotControlTool
     /// <param name="includeCursor">Include mouse cursor in capture. Default: false.</param>
     /// <param name="imageFormat">Screenshot format: 'jpeg'/'jpg' or 'png'. Default: 'jpeg' (LLM-optimized).</param>
     /// <param name="quality">Image compression quality 1-100. Default: 85. Only affects JPEG format.</param>
-    /// <param name="maxWidth">Maximum width in pixels. Image scaled down if wider (aspect ratio preserved). Default: 1568 (Claude's high-res native limit). Set to 0 to disable scaling.</param>
+    /// <param name="maxWidth">Maximum width in pixels. Image scaled down if wider (aspect ratio preserved). Default: 0 (no scaling, coordinates match screen). Set to 1568 for LLM-optimized size.</param>
     /// <param name="maxHeight">Maximum height in pixels. Image scaled down if taller (aspect ratio preserved). Default: 0 (no height constraint).</param>
     /// <param name="outputMode">How to return the screenshot. 'inline' returns base64 data, 'file' saves to disk and returns path. Default: 'inline'.</param>
     /// <param name="outputPath">Directory or file path for output when outputMode is 'file'. If directory, auto-generates filename. If null, uses temp directory.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result containing base64-encoded image data or file path, dimensions, original dimensions (if scaled), file size, and error details if failed.</returns>
     [McpServerTool(Name = "screenshot_control", Title = "Screenshot Capture", ReadOnly = true, UseStructuredContent = true)]
-    [Description("Captures screenshots of screens, monitors, windows, or regions on Windows. Returns base64-encoded image data (JPEG by default, configurable via imageFormat parameter). LLM-optimized defaults: JPEG format at quality 85, auto-scaled to 1568px width. Use action 'list_monitors' to enumerate available monitors. Use target 'all_monitors' to capture all connected monitors as a single composite image. Respects secure desktop (UAC/lock screen) restrictions.")]
+    [Description("Captures screenshots of screens, monitors, windows, or regions on Windows. Returns base64-encoded image data (JPEG by default, configurable via imageFormat parameter). Default: JPEG format at quality 85, no scaling (coordinates match screen for accurate mouse clicks). Set maxWidth=1568 for LLM-optimized smaller images. Use action 'list_monitors' to enumerate available monitors. Use target 'all_monitors' to capture all connected monitors as a single composite image. Respects secure desktop (UAC/lock screen) restrictions.")]
     [return: Description("The result of the screenshot operation including success status, base64-encoded image data or file path, monitor list, and error details if failed.")]
     public async Task<ScreenshotControlResult> ExecuteAsync(
         RequestContext<CallToolRequestParams> context,
@@ -76,7 +77,7 @@ public sealed partial class ScreenshotControlTool
         [Description("Include mouse cursor in capture. Default: false")] bool includeCursor = false,
         [Description("Screenshot format: 'jpeg'/'jpg' or 'png'. Default: 'jpeg' (LLM-optimized).")] string? imageFormat = null,
         [Description("Image compression quality 1-100. Default: 85. Only affects JPEG format.")] int? quality = null,
-        [Description("Maximum width in pixels. Image scaled down if wider (aspect ratio preserved). Default: 1568 (Claude's high-res native limit). Set to 0 to disable scaling.")] int? maxWidth = null,
+        [Description("Maximum width in pixels. Image scaled down if wider (aspect ratio preserved). Default: 0 (no scaling, coordinates match screen). Set to 1568 for LLM-optimized size.")] int? maxWidth = null,
         [Description("Maximum height in pixels. Image scaled down if taller (aspect ratio preserved). Default: 0 (no height constraint).")] int? maxHeight = null,
         [Description("How to return the screenshot. 'inline' returns base64 data, 'file' saves to disk and returns path. Default: 'inline'.")] string? outputMode = null,
         [Description("Directory or file path for output when outputMode is 'file'. If directory, auto-generates filename. If null, uses temp directory.")] string? outputPath = null,


### PR DESCRIPTION
Fixes #12

## Summary

Previously, screenshots were scaled to \maxWidth=1568\ by default (Claude's high-res limit), but LLMs would pass the scaled image coordinates directly to \mouse_control\, causing clicks to miss their targets.

## Changes

- Change \DefaultMaxWidth\ from 1568 to 0 (no scaling)
- Update all tool descriptions to reflect new default
- Screenshots now return coordinates that match screen coordinates 1:1
- Users can still opt-in to scaling with \maxWidth=1568\ parameter

## Testing

1. Take a screenshot with default settings
2. Verify the returned dimensions match the actual screen resolution
3. Use coordinates from screenshot analysis with \mouse_control\
4. Verify clicks land at the correct positions

## Impact

This is a **breaking change** for users who relied on the automatic scaling behavior. However, it's necessary for accurate mouse automation based on screenshot analysis.