### PR TITLE
feat(mouse): require monitorIndex for coordinate-based operations (breaking change)

### DIFF
--- a/specs/012-mouse-position/checklists/requirements.md
+++ b/specs/012-mouse-position/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Mouse Position Awareness for LLM Usability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: December 11, 2025  
+**Updated**: December 11, 2025 (Simplified approach - require monitorIndex)  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- All items passed validation
+- **Simplified approach**: Instead of adding `move_relative`, we require explicit `monitorIndex`
+- Three user stories defined with clear priorities (P1: require monitorIndex, P2: monitor info in responses, P3: get_position)
+- Eight functional requirements (down from 10 in original draft)
+- Key insight: Screenshot coordinates are already monitor-relative, so LLMs just need to specify which monitor they're targeting

--- a/specs/012-mouse-position/contracts/mouse-control.md
+++ b/specs/012-mouse-position/contracts/mouse-control.md
@@ -1,0 +1,413 @@
+# Phase 1 Contracts: Mouse Position Awareness for LLM Usability
+
+**Date**: December 11, 2025  
+**Feature**: 012-mouse-position
+
+## mouse-control-request.schema.json
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MouseControlRequest",
+  "description": "Request to perform a mouse control operation with explicit monitor targeting",
+  "type": "object",
+  "required": ["action"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": [
+        "move",
+        "click",
+        "double_click",
+        "right_click",
+        "middle_click",
+        "drag",
+        "scroll",
+        "get_position"
+      ],
+      "description": "The mouse action to perform"
+    },
+    "x": {
+      "type": "integer",
+      "description": "X-coordinate relative to the specified monitor (required for move, optional for click/double_click/right_click/middle_click/scroll)"
+    },
+    "y": {
+      "type": "integer",
+      "description": "Y-coordinate relative to the specified monitor (required for move, optional for click/double_click/right_click/middle_click/scroll)"
+    },
+    "endX": {
+      "type": "integer",
+      "description": "End X-coordinate for drag operations (required for drag)"
+    },
+    "endY": {
+      "type": "integer",
+      "description": "End Y-coordinate for drag operations (required for drag)"
+    },
+    "monitorIndex": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "REQUIRED when x/y coordinates are provided. The monitor index (0-based) whose coordinate system the x/y values are relative to"
+    },
+    "direction": {
+      "type": "string",
+      "enum": ["up", "down", "left", "right"],
+      "description": "Scroll direction (required for scroll action)"
+    },
+    "amount": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1,
+      "description": "Number of scroll clicks (optional, default 1)"
+    },
+    "modifiers": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["ctrl", "shift", "alt"]
+      },
+      "description": "Modifier keys to hold during click operations (optional)"
+    },
+    "button": {
+      "type": "string",
+      "enum": ["left", "right", "middle"],
+      "default": "left",
+      "description": "Mouse button for drag operations (optional, default left)"
+    }
+  },
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "properties": { "action": { "const": "move" } },
+      "required": ["x", "y", "monitorIndex"]
+    },
+    {
+      "properties": { "action": { "const": "click" } },
+      "allOf": [
+        {
+          "if": { "properties": { "x": { "type": "integer" } }, "required": ["x"] },
+          "then": { "required": ["y", "monitorIndex"] }
+        },
+        {
+          "if": { "properties": { "y": { "type": "integer" } }, "required": ["y"] },
+          "then": { "required": ["x", "monitorIndex"] }
+        }
+      ]
+    },
+    {
+      "properties": { "action": { "const": "double_click" } },
+      "allOf": [
+        {
+          "if": { "properties": { "x": { "type": "integer" } }, "required": ["x"] },
+          "then": { "required": ["y", "monitorIndex"] }
+        },
+        {
+          "if": { "properties": { "y": { "type": "integer" } }, "required": ["y"] },
+          "then": { "required": ["x", "monitorIndex"] }
+        }
+      ]
+    },
+    {
+      "properties": { "action": { "const": "right_click" } },
+      "allOf": [
+        {
+          "if": { "properties": { "x": { "type": "integer" } }, "required": ["x"] },
+          "then": { "required": ["y", "monitorIndex"] }
+        },
+        {
+          "if": { "properties": { "y": { "type": "integer" } }, "required": ["y"] },
+          "then": { "required": ["x", "monitorIndex"] }
+        }
+      ]
+    },
+    {
+      "properties": { "action": { "const": "middle_click" } },
+      "allOf": [
+        {
+          "if": { "properties": { "x": { "type": "integer" } }, "required": ["x"] },
+          "then": { "required": ["y", "monitorIndex"] }
+        },
+        {
+          "if": { "properties": { "y": { "type": "integer" } }, "required": ["y"] },
+          "then": { "required": ["x", "monitorIndex"] }
+        }
+      ]
+    },
+    {
+      "properties": { "action": { "const": "drag" } },
+      "required": ["endX", "endY", "monitorIndex"]
+    },
+    {
+      "properties": { "action": { "const": "scroll" } },
+      "required": ["direction"],
+      "allOf": [
+        {
+          "if": { "properties": { "x": { "type": "integer" } }, "required": ["x"] },
+          "then": { "required": ["y", "monitorIndex"] }
+        },
+        {
+          "if": { "properties": { "y": { "type": "integer" } }, "required": ["y"] },
+          "then": { "required": ["x", "monitorIndex"] }
+        }
+      ]
+    },
+    {
+      "properties": { "action": { "const": "get_position" } }
+    }
+  ]
+}
+```
+
+## mouse-control-response.schema.json
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MouseControlResponse",
+  "description": "Response from a mouse control operation, including monitor context",
+  "type": "object",
+  "required": ["success", "final_position"],
+  "properties": {
+    "success": {
+      "type": "boolean",
+      "description": "Whether the operation completed successfully"
+    },
+    "final_position": {
+      "type": "object",
+      "required": ["x", "y"],
+      "properties": {
+        "x": {
+          "type": "integer",
+          "description": "Final X-coordinate (absolute screen coordinates)"
+        },
+        "y": {
+          "type": "integer",
+          "description": "Final Y-coordinate (absolute screen coordinates)"
+        }
+      }
+    },
+    "monitorIndex": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "The monitor index where the cursor is now located (populated on success)"
+    },
+    "monitorWidth": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Width of the target monitor in physical pixels (populated on success)"
+    },
+    "monitorHeight": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Height of the target monitor in physical pixels (populated on success)"
+    },
+    "window_title": {
+      "type": ["string", "null"],
+      "description": "Title of the window under the cursor after the operation (null if no window)"
+    },
+    "error": {
+      "type": ["string", "null"],
+      "description": "Error message describing the failure (populated on failure)"
+    },
+    "error_code": {
+      "type": ["string", "null"],
+      "enum": [
+        "invalid_action",
+        "invalid_coordinates",
+        "coordinates_out_of_bounds",
+        "missing_required_parameter",
+        "invalid_scroll_direction",
+        "elevated_process_target",
+        "secure_desktop_active",
+        "input_blocked",
+        "send_input_failed",
+        "operation_timeout",
+        "window_lost_during_drag",
+        "unexpected_error"
+      ],
+      "description": "Machine-readable error code (populated on failure)"
+    },
+    "error_details": {
+      "type": ["object", "null"],
+      "description": "Additional error context (e.g., valid_indices, valid_bounds, provided_coordinates)",
+      "properties": {
+        "valid_indices": {
+          "type": "array",
+          "items": { "type": "integer" },
+          "description": "List of valid monitor indices (when error_code is missing_required_parameter or invalid_coordinates)"
+        },
+        "valid_bounds": {
+          "type": "object",
+          "properties": {
+            "left": { "type": "integer" },
+            "top": { "type": "integer" },
+            "right": { "type": "integer" },
+            "bottom": { "type": "integer" }
+          },
+          "description": "Valid coordinate range for the target monitor (when error_code is coordinates_out_of_bounds)"
+        },
+        "provided_coordinates": {
+          "type": "object",
+          "properties": {
+            "x": { "type": "integer" },
+            "y": { "type": "integer" }
+          },
+          "description": "The coordinates provided by the caller (when error_code is coordinates_out_of_bounds)"
+        },
+        "provided_index": {
+          "type": "integer",
+          "description": "The monitorIndex provided by the caller (when error_code is invalid_coordinates)"
+        }
+      }
+    }
+  }
+}
+```
+
+## Example Payloads
+
+### Success: Click with monitorIndex
+
+**Request**:
+```json
+{
+  "action": "click",
+  "x": 500,
+  "y": 300,
+  "monitorIndex": 1
+}
+```
+
+**Response**:
+```json
+{
+  "success": true,
+  "final_position": { "x": 500, "y": 300 },
+  "monitorIndex": 1,
+  "monitorWidth": 2560,
+  "monitorHeight": 1440,
+  "window_title": "Visual Studio Code"
+}
+```
+
+### Failure: Missing monitorIndex with coordinates
+
+**Request**:
+```json
+{
+  "action": "click",
+  "x": 500,
+  "y": 300
+}
+```
+
+**Response**:
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "monitorIndex is required when using x/y coordinates",
+  "error_code": "missing_required_parameter",
+  "error_details": {
+    "valid_indices": [0, 1, 2]
+  }
+}
+```
+
+### Failure: Invalid monitorIndex
+
+**Request**:
+```json
+{
+  "action": "click",
+  "x": 500,
+  "y": 300,
+  "monitorIndex": 5
+}
+```
+
+**Response**:
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "Invalid monitorIndex: 5",
+  "error_code": "invalid_coordinates",
+  "error_details": {
+    "valid_indices": [0, 1, 2],
+    "provided_index": 5
+  }
+}
+```
+
+### Failure: Coordinates out of bounds
+
+**Request**:
+```json
+{
+  "action": "click",
+  "x": 2700,
+  "y": 100,
+  "monitorIndex": 1
+}
+```
+
+**Response**:
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "Coordinates (2700, 100) out of bounds for monitor 1",
+  "error_code": "coordinates_out_of_bounds",
+  "error_details": {
+    "valid_bounds": {
+      "left": 1920,
+      "top": 0,
+      "right": 4480,
+      "bottom": 1440
+    },
+    "provided_coordinates": { "x": 2700, "y": 100 }
+  }
+}
+```
+
+### Success: Click without coordinates (at current cursor)
+
+**Request**:
+```json
+{
+  "action": "click"
+}
+```
+
+**Response**:
+```json
+{
+  "success": true,
+  "final_position": { "x": 500, "y": 300 },
+  "monitorIndex": 0,
+  "monitorWidth": 1920,
+  "monitorHeight": 1080,
+  "window_title": "Notepad"
+}
+```
+
+### Success: Get position
+
+**Request**:
+```json
+{
+  "action": "get_position"
+}
+```
+
+**Response**:
+```json
+{
+  "success": true,
+  "final_position": { "x": 500, "y": 300 },
+  "monitorIndex": 1,
+  "monitorWidth": 2560,
+  "monitorHeight": 1440,
+  "window_title": "Visual Studio Code"
+}
+```

--- a/specs/012-mouse-position/data-model.md
+++ b/specs/012-mouse-position/data-model.md
@@ -1,0 +1,227 @@
+# Phase 1 Data Model: Mouse Position Awareness for LLM Usability
+
+**Date**: December 11, 2025  
+**Feature**: 012-mouse-position  
+**Status**: Complete
+
+## Domain Model
+
+### Entities
+
+#### MouseControlRequest
+Represents a single mouse control operation request.
+
+| Field | Type | Nullable | Validation |
+|-------|------|----------|-----------|
+| action | string (enum) | ✗ | Required; one of: move, click, double_click, right_click, middle_click, drag, scroll, get_position |
+| x | int | ✓ | If provided with y, requires monitorIndex |
+| y | int | ✓ | If provided with x, requires monitorIndex |
+| endX | int | ✓ | Drag only; if provided, requires endY and monitorIndex |
+| endY | int | ✓ | Drag only; if provided, requires endX and monitorIndex |
+| monitorIndex | int | ✓ | **Conditional**: Required if x/y or endX/endY are provided; must be valid (0 <= monitorIndex < monitorCount) |
+| direction | string | ✓ | Scroll only; one of: up, down, left, right |
+| amount | int | ✓ | Scroll only; default 1 |
+| modifiers | string[] | ✓ | Click actions only; array of: ctrl, shift, alt |
+| button | string | ✓ | Drag only; one of: left, right, middle; default left |
+
+**Validation Rules**:
+1. If `action` is "move": x and y REQUIRED, monitorIndex REQUIRED
+2. If `action` is "click", "double_click", "right_click", "middle_click": 
+   - If x and y provided → monitorIndex REQUIRED
+   - If x and y omitted → monitorIndex OPTIONAL (operate at current cursor)
+3. If `action` is "drag": startX, startY, endX, endY REQUIRED, monitorIndex REQUIRED
+4. If `action` is "scroll": direction REQUIRED, monitorIndex OPTIONAL (if x/y provided, monitorIndex REQUIRED)
+5. If `action` is "get_position": no parameters required
+
+#### MouseControlResponse
+Represents the result of a mouse control operation.
+
+| Field | Type | Nullable | Description |
+|-------|------|----------|-------------|
+| success | bool | ✗ | Operation succeeded (true) or failed (false) |
+| final_position | { x: int, y: int } | ✗ | Final cursor position (absolute screen coordinates or monitor-relative depending on context) |
+| monitorIndex | int | ✓ | **NEW**: Monitor where cursor ended up (populated on success) |
+| monitorWidth | int | ✓ | **NEW**: Width of the target monitor (populated on success) |
+| monitorHeight | int | ✓ | **NEW**: Height of the target monitor (populated on success) |
+| window_title | string | ✓ | Title of window under cursor at end of operation |
+| error | string | ✓ | Error message (populated on failure) |
+| error_code | string | ✓ | Machine-readable error code (populated on failure) |
+| error_details | object | ✓ | Additional error context (e.g., valid_bounds, valid_indices) |
+
+**Success Example**:
+```json
+{
+  "success": true,
+  "final_position": { "x": 500, "y": 300 },
+  "monitorIndex": 1,
+  "monitorWidth": 2560,
+  "monitorHeight": 1440,
+  "window_title": "Visual Studio Code"
+}
+```
+
+**Failure Example** (missing monitorIndex):
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "monitorIndex is required when using x/y coordinates",
+  "error_code": "missing_required_parameter",
+  "error_details": {
+    "valid_indices": [0, 1]
+  }
+}
+```
+
+**Failure Example** (invalid monitorIndex):
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "Invalid monitorIndex: 5",
+  "error_code": "invalid_coordinates",
+  "error_details": {
+    "valid_indices": [0, 1, 2],
+    "provided_index": 5
+  }
+}
+```
+
+**Failure Example** (coordinates out of bounds):
+```json
+{
+  "success": false,
+  "final_position": { "x": 100, "y": 100 },
+  "error": "Coordinates (2700, 100) out of bounds for monitor 1",
+  "error_code": "coordinates_out_of_bounds",
+  "error_details": {
+    "valid_bounds": {
+      "left": 1920,
+      "top": 0,
+      "right": 1920 + 2560,
+      "bottom": 1440
+    },
+    "provided_coordinates": { "x": 2700, "y": 100 }
+  }
+}
+```
+
+### Key Types & Enumerations
+
+#### MouseAction
+Enum of valid actions:
+- `move` — Move cursor to coordinates
+- `click` — Left-click
+- `double_click` — Double left-click
+- `right_click` — Right-click
+- `middle_click` — Middle-click
+- `drag` — Drag from start to end coordinates
+- `scroll` — Scroll in specified direction
+- `get_position` — Query current cursor position (P3 priority)
+
+#### ScrollDirection
+Enum of scroll directions:
+- `up`
+- `down`
+- `left`
+- `right`
+
+#### MouseButton
+Enum for drag operations:
+- `left` (default)
+- `right`
+- `middle`
+
+#### ModifierKey
+Set of modifier keys:
+- `ctrl`
+- `shift`
+- `alt`
+
+#### MouseControlErrorCode
+Machine-readable error codes:
+- `invalid_action` — Unknown action
+- `invalid_coordinates` — Coordinates validation failed
+- `coordinates_out_of_bounds` — Coordinates outside all monitor bounds
+- `missing_required_parameter` — monitorIndex required but not provided
+- `invalid_scroll_direction` — Unknown scroll direction
+- `elevated_process_target` — Target is elevated (admin) process
+- `secure_desktop_active` — UAC or lock screen active
+- `input_blocked` — Input blocked by system
+- `send_input_failed` — Windows SendInput API failed
+- `operation_timeout` — Operation exceeded timeout
+- `window_lost_during_drag` — Window closed during drag
+- `unexpected_error` — Unexpected error (details in error message)
+
+### Relationships
+
+```
+MouseControlRequest
+  ├─ action: MouseAction
+  ├─ coordinates: { x, y } → requires monitorIndex
+  ├─ monitorIndex → validates against Monitor registry
+  └─ [optional] modifiers: ModifierKey[]
+
+Monitor (from system registry)
+  ├─ index: int (0-based)
+  ├─ bounds: { left, top, width, height }
+  ├─ x, y, width, height
+  └─ dpiScale: float (for future use)
+
+MouseControlResponse
+  ├─ success: bool
+  ├─ final_position: { x, y } (monitor-relative or absolute, depending on context)
+  ├─ monitorIndex: int (where cursor is now)
+  ├─ error: string (if success=false)
+  └─ error_details: object (validation context)
+```
+
+### State Transitions
+
+```
+LLM sends MouseControlRequest
+  ↓
+[Validation Phase]
+  ├─ Is action valid? → No: return invalid_action error
+  ├─ Does action require coordinates? 
+  │   ├─ Yes: Are x/y provided?
+  │   │   ├─ No: return missing_required_parameter error
+  │   │   └─ Yes: Is monitorIndex provided?
+  │   │       ├─ No: return missing_required_parameter error
+  │   │       └─ Yes: proceed to coordinate validation
+  │   └─ No: proceed to operation
+  └─ Are coordinates within monitor bounds?
+      ├─ No: return coordinates_out_of_bounds error
+      └─ Yes: proceed to operation
+  ↓
+[Execution Phase]
+  ├─ Move cursor (if needed)
+  ├─ Perform action (click, drag, scroll, etc.)
+  └─ Query final position + monitor
+  ↓
+[Response Phase]
+  ├─ Success: return final_position + monitorIndex + monitorWidth/Height
+  └─ Failure: return error code + error_details
+
+```
+
+### Validation Rules
+
+#### monitorIndex Validation
+- Must be integer
+- Must be >= 0 and < (number of monitors in system)
+- Must be accompanied by coordinates (if x/y provided, monitorIndex REQUIRED)
+- Error response includes list of valid indices
+
+#### Coordinate Validation
+- Must be integers
+- If monitorIndex is provided, coordinates must be within that monitor's bounds
+- Bounds: `monitorIndex.left <= x < monitorIndex.right` and `monitorIndex.top <= y < monitorIndex.bottom`
+- Error response includes valid bounds and provided coordinates
+
+#### Action-Specific Validation
+- `move`: x, y, monitorIndex required
+- `click`/`double_click`/`right_click`/`middle_click`: x, y optional (if provided, monitorIndex required)
+- `drag`: startX, startY, endX, endY, monitorIndex required
+- `scroll`: direction required, x/y optional (if provided, monitorIndex required)
+- `get_position`: no parameters required

--- a/specs/012-mouse-position/plan.md
+++ b/specs/012-mouse-position/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Mouse Position Awareness for LLM Usability
+
+**Branch**: `012-mouse-position` | **Date**: December 11, 2025 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-mouse-position/spec.md`
+
+## Summary
+
+**Primary Requirement**: Make `monitorIndex` a required parameter when x/y coordinates are provided to the `mouse_control` tool, eliminating silent failures where LLMs click on the wrong monitor.
+
+**Technical Approach**: 
+- Modify `MouseControlTool.ExecuteAsync()` to enforce `monitorIndex` validation rules:
+  - If x/y coordinates are provided → `monitorIndex` MUST be present, else return error with list of valid indices
+  - If no coordinates → allow actions at current cursor position without `monitorIndex`
+- Extend response payload (via `MouseControlResult`) to include `monitorIndex`, `monitorWidth`, `monitorHeight`, `error_code`, `error_details`
+- Add `get_position` action (P3 priority) to return current cursor position and monitor context
+- All success responses include monitor dimensions for LLM awareness and validation
+- All error responses include machine-readable error_code and contextual error_details
+
+**Phase 1 Deliverables**: ✅ COMPLETE
+- ✅ [research.md](research.md) — Decision rationale, validation logic, implementation approach
+- ✅ [data-model.md](data-model.md) — Request/response entities, validation rules, state transitions
+- ✅ [quickstart.md](quickstart.md) — Developer walkthrough with code examples and test patterns
+- ✅ [contracts/mouse-control.md](contracts/mouse-control.md) — JSON schemas and example payloads
+
+## Technical Context
+
+**Language/Version**: C# 12+, .NET 8.0 LTS
+**Primary Dependencies**: MCP C# SDK, System.Windows.Automation (existing)
+**Storage**: N/A (stateless tool)
+**Testing**: xUnit 2.6+ with integration tests on Windows 11 desktop
+**Target Platform**: Windows 11 (architecture-independent, .NET 8.0 runtime required)
+**Project Type**: Single C# service (standalone + VS Code extension, shared core)
+**Performance Goals**: Tool calls complete within 5 seconds (configurable timeout via `MCP_MOUSE_TIMEOUT_MS` / VS Code setting)
+**Constraints**: 
+- Coordinate validation must happen before any input is sent (fail-fast)
+- Monitor index validation must list valid indices in error messages for LLM clarity
+- Responses always include monitor context (index + dimensions) on success
+**Scale/Scope**: 
+- Modifies existing `MouseControlTool` in `src/Sbroenne.WindowsMcp/Tools/`
+- Extends response model `MouseControlResult` in `src/Sbroenne.WindowsMcp/Models/`
+- Adds input validation and monitor querying logic
+- Impacts all mouse action handlers (move, click, double_click, right_click, middle_click, drag, scroll)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+✅ **All Constitution Principles Satisfied:**
+
+| Principle | Check | Notes |
+|-----------|-------|-------|
+| I. Test-First Development | ✅ PASS | Integration tests on Windows 11 desktop required for all handlers; xUnit fixtures for multi-monitor setup |
+| II. Latest Libraries Policy | ✅ PASS | Modifies existing tool; uses System.Automation (built-in), no new external dependencies |
+| III. MCP Protocol Compliance | ✅ PASS | Extends `[Description]` attributes on parameters, uses structured output in response model, tool is semantic actuator |
+| IV. Windows 11 Target Platform | ✅ PASS | Uses `System.Windows.Automation`, `GetSystemMetrics` for monitor detection; no COM/deprecated APIs |
+| V. Dual Packaging Architecture | ✅ PASS | Changes to core `MouseControlTool` shared by both standalone and VS Code extension |
+| VI. Augmentation, Not Duplication | ✅ PASS | Tool is a "dumb actuator"—validates and reports monitor context; LLM decides what to click |
+| VII. Windows API Documentation-First | ✅ PASS | Uses `GetSystemMetrics` (SM_XVIRTUALSCREEN, etc.) documented in Microsoft Docs |
+| VIII. Security Best Practices | ✅ PASS | Input validation on `monitorIndex`; inherits elevated process detection from 001 |
+| IX. Resilient Error Handling | ✅ PASS | Returns actionable errors: missing `monitorIndex`, invalid index (lists valid ones), out-of-bounds coordinates |
+| X. Thread-Safe Windows Interaction | ✅ PASS | Uses existing STA automation thread infrastructure; no new threading |
+| XI. Observability & Diagnostics | ✅ PASS | Logs tool invocation with correlation ID and outcome (existing structured logging) |
+| XII. Graceful Lifecycle Management | ✅ PASS | Stateless tool; no new lifecycle concerns |
+| XIII. Modern .NET & C# Best Practices | ✅ PASS | Uses latest C# 12 patterns, nullable reference types, async/await, constructor injection |
+| XIV. xUnit Testing Best Practices | ✅ PASS | Integration tests with multi-monitor fixtures; coordinate generation via `TestMonitorHelper` |
+| XV. Input Simulation Best Practices | ✅ PASS | No new input simulation; modifies validation layer only |
+| XVI. Timing & Synchronization | ✅ PASS | No new timing changes; uses existing 5-second tool timeout |
+| XVII. Coordinate Systems & DPI Awareness | ✅ PASS | Enforces monitor-relative coordinates; leverages existing `CoordinateNormalizer` |
+| XVIII. Elevated Process Handling | ✅ PASS | Inherits elevated process detection from 001; validates *before* sending input |
+| XIX. Accessibility & Inclusive Design | ✅ PASS | No UI automation tree changes; respects existing accessibility handling |
+| XX. Window Activation & Focus Management | ✅ PASS | No changes to focus; tool operates at cursor position |
+| XXI. Modern .NET CLI Application Architecture | ✅ PASS | No CLI changes; modifies tool handler logic only |
+| XXII. Open Source Dependencies Only | ✅ PASS | No new dependencies; uses only System.* and MCP SDK |
+
+**Gate Status**: ✅ **PASS** — No principle violations; feature is safe to proceed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── Sbroenne.WindowsMcp/
+│   ├── Tools/
+│   │   └── MouseControlTool.cs          # [MODIFIED] Enforce monitorIndex validation
+│   ├── Models/
+│   │   ├── MouseControlResult.cs        # [MODIFIED] Add monitorIndex, monitorWidth, monitorHeight
+│   │   ├── MouseControlErrorCode.cs     # [UNCHANGED] Inherits from 001
+│   │   └── [other existing models]
+│   ├── Input/
+│   │   └── MouseInputService.cs         # [UNCHANGED] Coordinate handling still works
+│   └── [other existing services]
+
+tests/
+├── Sbroenne.WindowsMcp.Tests/
+│   ├── Tools/
+│   │   └── MouseControlToolTests.cs     # [MODIFIED] Add monitorIndex validation tests
+│   ├── Fixtures/
+│   │   └── MultiMonitorFixture.cs       # [NEW] Provides test monitor setup
+│   └── [other existing tests]
+```
+
+**Structure Decision**: Single project modification. The existing `MouseControlTool` and `MouseInputService` handle all coordinate and monitor logic; this feature adds validation rules and response enrichment without restructuring.
+
+## Complexity Tracking
+
+No Constitution violations; no complexity justifications needed.

--- a/specs/012-mouse-position/quickstart.md
+++ b/specs/012-mouse-position/quickstart.md
@@ -1,0 +1,393 @@
+# Quickstart: Implementing Mouse Position Awareness
+
+**Feature**: 012-mouse-position  
+**Date**: December 11, 2025  
+**Audience**: Development team implementing breaking changes to MouseControlTool
+
+## Overview
+
+This quickstart guides you through the changes required to implement monitor-explicit mouse control. The feature makes `monitorIndex` **required** when coordinates (x/y) are provided, enabling LLMs to target specific monitors reliably.
+
+## Key Changes at a Glance
+
+| Area | Change | Breaking? | Impact |
+|------|--------|-----------|--------|
+| **MouseControlTool validation** | Require `monitorIndex` when x/y provided | YES | Coordinate-based calls must specify monitor |
+| **MouseControlResult** | Add monitor dimension fields | NO | Response data enriched (backward compatible in JSON) |
+| **Error handling** | New error codes and detailed context | NO | Better error messages with valid monitor indices |
+| **Tests** | Multi-monitor integration tests | — | Validates behavior on multi-monitor systems |
+
+## Implementation Path
+
+### Phase 1: Update Response Model (MouseControlResult.cs)
+
+Add three new fields to enrich responses with monitor context:
+
+```csharp
+public class MouseControlResult
+{
+    // Existing fields
+    public bool Success { get; set; }
+    public Position FinalPosition { get; set; }
+    public string WindowTitle { get; set; }
+    public string Error { get; set; }
+    
+    // NEW FIELDS
+    [JsonPropertyName("monitorIndex")]
+    public int? MonitorIndex { get; set; }
+    
+    [JsonPropertyName("monitorWidth")]
+    public int? MonitorWidth { get; set; }
+    
+    [JsonPropertyName("monitorHeight")]
+    public int? MonitorHeight { get; set; }
+    
+    [JsonPropertyName("error_code")]
+    public string ErrorCode { get; set; }
+    
+    [JsonPropertyName("error_details")]
+    public Dictionary<string, object> ErrorDetails { get; set; }
+}
+```
+
+**Rationale**: Monitor dimensions tell the LLM the coordinate bounds for future calls. Error codes enable LLMs to distinguish between "missing parameter" vs. "out of bounds" vs. "invalid index".
+
+### Phase 2: Update Validation in MouseControlTool.cs
+
+In `ExecuteAsync()`, add conditional-required validation **before** operation execution:
+
+```csharp
+public async Task<MouseControlResult> ExecuteAsync(MouseControlRequest request)
+{
+    try
+    {
+        // NEW: Validate monitorIndex requirement
+        if (HasCoordinates(request) && !request.MonitorIndex.HasValue)
+        {
+            var monitors = _screenService.GetMonitorIndices();
+            return new MouseControlResult
+            {
+                Success = false,
+                Error = "monitorIndex is required when using x/y coordinates",
+                ErrorCode = "missing_required_parameter",
+                ErrorDetails = new Dictionary<string, object>
+                {
+                    { "valid_indices", monitors }
+                }
+            };
+        }
+        
+        // NEW: Validate monitorIndex is in valid range
+        if (request.MonitorIndex.HasValue)
+        {
+            if (!_screenService.IsValidMonitorIndex(request.MonitorIndex.Value))
+            {
+                var monitors = _screenService.GetMonitorIndices();
+                return new MouseControlResult
+                {
+                    Success = false,
+                    Error = $"Invalid monitorIndex: {request.MonitorIndex}",
+                    ErrorCode = "invalid_coordinates",
+                    ErrorDetails = new Dictionary<string, object>
+                    {
+                        { "valid_indices", monitors },
+                        { "provided_index", request.MonitorIndex }
+                    }
+                };
+            }
+        }
+        
+        // NEW: Validate coordinates are within monitor bounds (if both provided)
+        if (request.MonitorIndex.HasValue && request.X.HasValue && request.Y.HasValue)
+        {
+            var monitor = _screenService.GetMonitor(request.MonitorIndex.Value);
+            if (!monitor.Contains(request.X.Value, request.Y.Value))
+            {
+                return new MouseControlResult
+                {
+                    Success = false,
+                    Error = $"Coordinates ({request.X}, {request.Y}) out of bounds for monitor {request.MonitorIndex}",
+                    ErrorCode = "coordinates_out_of_bounds",
+                    ErrorDetails = new Dictionary<string, object>
+                    {
+                        { "valid_bounds", new { 
+                            left = monitor.Left, 
+                            top = monitor.Top, 
+                            right = monitor.Right, 
+                            bottom = monitor.Bottom 
+                        }},
+                        { "provided_coordinates", new { x = request.X, y = request.Y } }
+                    }
+                };
+            }
+        }
+        
+        // Existing operation execution follows...
+        var result = await PerformMouseOperation(request);
+        
+        // NEW: Enrich successful response with monitor context
+        if (result.Success)
+        {
+            var finalMonitor = _screenService.FindMonitorAtPosition(result.FinalPosition.X, result.FinalPosition.Y);
+            result.MonitorIndex = finalMonitor.Index;
+            result.MonitorWidth = finalMonitor.Width;
+            result.MonitorHeight = finalMonitor.Height;
+        }
+        
+        return result;
+    }
+    catch (Exception ex)
+    {
+        return new MouseControlResult
+        {
+            Success = false,
+            Error = ex.Message,
+            ErrorCode = "unexpected_error"
+        };
+    }
+}
+
+private bool HasCoordinates(MouseControlRequest request)
+{
+    // Coordinates present if x/y both provided, or for drag endX/endY
+    return (request.X.HasValue && request.Y.HasValue) || 
+           (request.EndX.HasValue && request.EndY.HasValue) ||
+           request.Action == "drag";
+}
+```
+
+**Rationale**: Fail fast with actionable errors. Give LLMs the list of valid monitors so they can recover without re-querying.
+
+### Phase 3: Test Multi-Monitor Behavior (Integration Tests)
+
+Create `MultiMonitorFixture.cs` for reusable test setup:
+
+```csharp
+public class MultiMonitorFixture : IAsyncLifetime
+{
+    private readonly IScreen _screenService;
+    private List<int> _availableMonitors;
+    
+    public async Task InitializeAsync()
+    {
+        // Detect available monitors
+        _availableMonitors = _screenService.GetMonitorIndices();
+        
+        // Ensure at least 2 monitors detected, or log requirement
+        if (_availableMonitors.Count < 2)
+        {
+            throw new InvalidOperationException(
+                "Multi-monitor tests require at least 2 connected monitors. " +
+                "Found: " + string.Join(", ", _availableMonitors));
+        }
+    }
+    
+    public async Task DisposeAsync()
+    {
+        // Restore cursor to primary monitor
+        var primary = _screenService.GetMonitor(0);
+        await _screenService.MoveMouseAsync(primary.Center.X, primary.Center.Y);
+    }
+    
+    public int GetSecondaryMonitor() => _availableMonitors[1];
+    public List<int> GetAllMonitors() => _availableMonitors;
+}
+```
+
+**Example Test: Click on Secondary Monitor Requires monitorIndex**:
+
+```csharp
+public class MouseControlToolTests : IAsyncLifetime
+{
+    private readonly MouseControlTool _tool;
+    private MultiMonitorFixture _fixture;
+    
+    [Fact]
+    public async Task Click_WithCoordinates_RequiresMonitorIndex()
+    {
+        // Arrange
+        var request = new MouseControlRequest
+        {
+            Action = "click",
+            X = 500,
+            Y = 300
+            // NOTE: No MonitorIndex - this should fail
+        };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("missing_required_parameter", result.ErrorCode);
+        Assert.NotNull(result.ErrorDetails["valid_indices"]);
+    }
+    
+    [Fact]
+    public async Task Click_WithValidMonitorIndex_Succeeds()
+    {
+        // Arrange
+        var secondaryMonitor = _fixture.GetSecondaryMonitor();
+        var monitor = _screenService.GetMonitor(secondaryMonitor);
+        
+        var request = new MouseControlRequest
+        {
+            Action = "click",
+            X = monitor.Width / 2,
+            Y = monitor.Height / 2,
+            MonitorIndex = secondaryMonitor
+        };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(secondaryMonitor, result.MonitorIndex);
+        Assert.Equal(monitor.Width, result.MonitorWidth);
+        Assert.Equal(monitor.Height, result.MonitorHeight);
+    }
+    
+    [Fact]
+    public async Task Click_WithInvalidMonitorIndex_ReturnsError()
+    {
+        // Arrange
+        var request = new MouseControlRequest
+        {
+            Action = "click",
+            X = 500,
+            Y = 300,
+            MonitorIndex = 99  // Invalid
+        };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("invalid_coordinates", result.ErrorCode);
+        Assert.NotNull(result.ErrorDetails["valid_indices"]);
+    }
+    
+    [Fact]
+    public async Task Click_CoordinatesOutOfBounds_ReturnsDetailedError()
+    {
+        // Arrange
+        var secondaryMonitor = _fixture.GetSecondaryMonitor();
+        
+        var request = new MouseControlRequest
+        {
+            Action = "click",
+            X = 5000,  // Way out of bounds
+            Y = 5000,
+            MonitorIndex = secondaryMonitor
+        };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.False(result.Success);
+        Assert.Equal("coordinates_out_of_bounds", result.ErrorCode);
+        Assert.NotNull(result.ErrorDetails["valid_bounds"]);
+        Assert.NotNull(result.ErrorDetails["provided_coordinates"]);
+    }
+    
+    [Fact]
+    public async Task Click_WithoutCoordinates_DoesNotRequireMonitorIndex()
+    {
+        // Arrange - cursor at some position
+        var request = new MouseControlRequest
+        {
+            Action = "click"
+            // No X, Y, MonitorIndex
+        };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.True(result.Success);
+        // But response should indicate which monitor the click happened on
+        Assert.NotNull(result.MonitorIndex);
+    }
+    
+    [Fact]
+    public async Task GetPosition_ReturnsCurrentMonitorContext()
+    {
+        // Arrange
+        var request = new MouseControlRequest { Action = "get_position" };
+        
+        // Act
+        var result = await _tool.ExecuteAsync(request);
+        
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotNull(result.MonitorIndex);
+        Assert.True(result.MonitorWidth > 0);
+        Assert.True(result.MonitorHeight > 0);
+    }
+}
+```
+
+## Breaking Change Communication
+
+### For API Users
+
+**Before (v1.x)**:
+```csharp
+// monitorIndex is optional; defaults to 0
+await mouseControl.Click(x: 500, y: 300);  // Clicks on monitor 0, silently wrong if target is monitor 1
+```
+
+**After (v2.0)**:
+```csharp
+// monitorIndex is REQUIRED with coordinates
+await mouseControl.Click(x: 500, y: 300, monitorIndex: 1);  // Clear intent; error if index invalid
+```
+
+### For LLM Callers
+
+**Error Message** (when monitorIndex missing):
+```
+monitorIndex is required when using x/y coordinates
+
+Valid monitor indices: [0, 1, 2]
+```
+
+**Example Recovery Flow**:
+1. LLM calls `screenshot(monitorIndex: 1)` → Gets image
+2. LLM analyzes image → Finds button at coordinates (500, 300)
+3. LLM calls `click(x: 500, y: 300, monitorIndex: 1)` → Click succeeds
+
+## Testing Checklist
+
+- [ ] Single monitor: All existing tests pass without modification
+- [ ] Multi-monitor required: Add 2+ monitors; run new integration tests
+- [ ] Error paths: Verify error_code and error_details populated
+- [ ] Response enrichment: Verify monitorIndex, monitorWidth, monitorHeight in success responses
+- [ ] Coordinate-less actions: Verify click() without x/y doesn't require monitorIndex
+- [ ] Edge cases: Negative coordinates (multi-monitor setups), fractional scaling
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/Sbroenne.WindowsMcp/Models/MouseControlResult.cs` | Add MonitorIndex, MonitorWidth, MonitorHeight, ErrorCode, ErrorDetails |
+| `src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs` | Add validation for monitorIndex requirement; enrich responses |
+| `tests/Sbroenne.WindowsMcp.Tests/MultiMonitorFixture.cs` | NEW: Fixture for multi-monitor test setup |
+| `tests/Sbroenne.WindowsMcp.Tests/MouseControlToolTests.cs` | Add multi-monitor integration tests |
+
+## Next Steps
+
+1. **Code Review**: Review validation logic against multi-monitor test results
+2. **Manual Testing**: Test on actual multi-monitor Windows 11 system (required by Constitution XIV)
+3. **Documentation**: Update tool documentation with monitorIndex requirement
+4. **Release**: Publish as v2.0 (breaking change) with migration guide
+
+## Links
+
+- **Specification**: [spec.md](../spec.md)
+- **Data Model**: [data-model.md](../data-model.md)
+- **API Contracts**: [contracts/](../contracts/)
+- **Research**: [research.md](../research.md)

--- a/specs/012-mouse-position/research.md
+++ b/specs/012-mouse-position/research.md
@@ -1,0 +1,223 @@
+# Phase 0 Research: Mouse Position Awareness for LLM Usability
+
+**Date**: December 11, 2025  
+**Feature**: 012-mouse-position  
+**Status**: Complete
+
+## Overview
+
+This research documents the API design patterns, implementation approach, and validation strategies for requiring explicit `monitorIndex` in the `mouse_control` tool.
+
+---
+
+## Decision: monitorIndex as Required Parameter
+
+**Decision**: Make `monitorIndex` required when x/y coordinates are provided; allow omission for coordinate-less actions (click at current cursor position).
+
+**Rationale**:
+- Screenshot coordinates are **inherently monitor-relative** (0,0 = top-left of captured monitor's image).
+- When an LLM uses `screenshot_control(monitorIndex: Z)`, it receives coordinates in that monitor's frame.
+- If the LLM forgets to pass the matching `monitorIndex` to `mouse_control`, it silently clicks on **monitor 0 instead**, causing failures.
+- Requiring explicit `monitorIndex` with coordinates **forces correctness by design**—the contract is unambiguous.
+
+**Alternatives Considered & Rejected**:
+1. **Add `move_relative` action** (original spec):
+   - ❌ Unnecessary complexity; LLM can calculate absolute coordinates from screenshot.
+   - ❌ Doesn't solve the root problem: forgetting which monitor was captured.
+2. **Deprecation period for missing `monitorIndex`**:
+   - ❌ Defers clarity; LLMs benefit from immediate, strict contracts.
+   - ✅ We chose immediate enforcement (hardbreak).
+3. **Optional with smart defaults** (e.g., detect monitor from screenshot metadata):
+   - ❌ Requires passing screenshot object to mouse tool (breaks tool independence).
+   - ❌ Adds coupling between tools; violates "dumb actuator" principle.
+
+**Chosen Approach**: Immediate hard requirement.
+
+---
+
+## API Contract Changes
+
+### Current Behavior (001-mouse-control)
+
+```
+mouse_control(action="click", x=500, y=300)
+↓
+Uses default monitorIndex=0 (silent failure if user meant monitor 1!)
+```
+
+### New Behavior (012-mouse-position)
+
+```
+mouse_control(action="click", x=500, y=300)
+↓
+Returns ERROR: "monitorIndex is required when using x/y coordinates. Specify monitorIndex."
+
+mouse_control(action="click", x=500, y=300, monitorIndex=1)
+↓
+Clicks at (500, 300) on monitor 1 ✓
+
+mouse_control(action="click")
+↓
+Clicks at current cursor position (monitorIndex not needed) ✓
+```
+
+---
+
+## Validation Logic
+
+### When monitorIndex is Required
+
+✅ **Coordinates provided** → monitorIndex REQUIRED:
+- `move(x=?, y=?, monitorIndex=?)`
+- `click(x=?, y=?, monitorIndex=?)`
+- `double_click(x=?, y=?, monitorIndex=?)`
+- `right_click(x=?, y=?, monitorIndex=?)`
+- `middle_click(x=?, y=?, monitorIndex=?)`
+- `drag(startX=?, startY=?, endX=?, endY=?, monitorIndex=?)`
+- `scroll(x=?, y=?, direction=?, monitorIndex=?)`
+
+### When monitorIndex is Optional (Not Needed)
+
+✅ **No coordinates provided** → monitorIndex OPTIONAL (ignored):
+- `click()` → click at current cursor position
+- `scroll(direction=down)` → scroll at current cursor position
+- `get_position()` → return current position (monitorIndex is output, not input)
+
+### Error Messages
+
+| Scenario | Error Code | Message | Error Details |
+|----------|------------|---------|----------------|
+| x/y provided, monitorIndex missing | `missing_required_parameter` | "monitorIndex is required when using x/y coordinates" | Valid indices: [0, 1, 2] |
+| Invalid monitorIndex | `invalid_coordinates` | "Invalid monitorIndex: 5" | Valid indices: [0, 1, 2] |
+| Coordinates out of monitor bounds | `coordinates_out_of_bounds` | "Coordinates (2000, 300) out of bounds for monitor 1" | Monitor 1 bounds: { left: 1920, top: 0, width: 2560, height: 1440 } |
+
+---
+
+## Response Enrichment
+
+### What Gets Added to All Success Responses
+
+Every successful `mouse_control` response includes:
+- `monitorIndex` (where cursor ended up)
+- `monitorWidth`, `monitorHeight` (dimensions of that monitor)
+
+**Example**:
+```json
+{
+  "success": true,
+  "final_position": { "x": 500, "y": 300 },
+  "monitorIndex": 1,
+  "monitorWidth": 2560,
+  "monitorHeight": 1440,
+  "window_title": "Visual Studio Code"
+}
+```
+
+**Why**: Provides feedback to LLM; allows validation ("I clicked on monitor 1 ✓" vs. "I ended up on monitor 0 ✗").
+
+---
+
+## Implementation Approach
+
+### Files to Modify
+
+1. **MouseControlTool.cs** (`src/Sbroenne.WindowsMcp/Tools/`)
+   - Add `monitorIndex` parameter to method signature (currently optional, needs to become conditional-required)
+   - Add validation logic: if x/y provided, require monitorIndex
+   - Pass monitorIndex to all action handlers
+   - Enrich responses with monitor dimensions
+
+2. **MouseControlResult.cs** (`src/Sbroenne.WindowsMcp/Models/`)
+   - Add `monitorIndex` field
+   - Add `monitorWidth` field
+   - Add `monitorHeight` field
+   - Update JSON serialization
+
+3. **MouseControlTool.cs** handlers (HandleMoveAsync, HandleClickAsync, etc.)
+   - Use provided monitorIndex instead of defaulting to 0
+   - Validate monitorIndex early in each handler
+
+### Files to Create (Tests)
+
+4. **MouseControlToolTests.cs** additions or new test class
+   - Test: monitorIndex required when x/y provided
+   - Test: monitorIndex not required when x/y omitted
+   - Test: invalid monitorIndex returns clear error
+   - Test: coordinates clamped to monitor bounds
+   - Test: response includes monitor dimensions
+   - Multi-monitor fixtures: use secondary monitor for test clicks (if available)
+
+---
+
+## Coordinate System & Monitor Layout
+
+### Key Facts
+
+- **Monitor 0** is primary (typically top-left origin: 0,0)
+- **Secondary monitors** can have negative coordinates (e.g., monitor to the left of primary)
+- **Coordinate system** is always monitor-relative: (0,0) is top-left of specified monitor
+- **Existing normalization** (0-65535 range for SendInput) already handles multi-monitor geometry correctly; no changes needed there
+
+### Validation Example
+
+On a 2-monitor setup (monitor 0: 1920×1080, monitor 1: 2560×1440):
+
+```
+LLM: "Click at (2200, 300, monitorIndex=1)"
+→ Check: 2200 < 2560? ✓ | 300 < 1440? ✓
+→ Send to SendInput (with coordinate translation)
+→ ✓ Click succeeds on monitor 1
+```
+
+---
+
+## Breaking Change & Rollout
+
+**Status**: Immediate hard break (Option A).
+
+**Impact**:
+- Existing code that calls `mouse_control(x=500, y=300)` without monitorIndex will fail immediately.
+- **Mitigation**: Update all call sites to include `monitorIndex`. For single-monitor setups, use `monitorIndex=0`. For multi-monitor, require caller to specify.
+
+**Affected Integrations**:
+- Any MCP client using `mouse_control` with coordinates (LLMs, automation scripts, etc.)
+- VS Code extension bundled with this server
+- Standalone server users
+
+**Messaging**:
+- Clear error messages in responses: "monitorIndex is required when using x/y coordinates."
+- Release notes: "Breaking change: monitorIndex now required for coordinate-based mouse actions."
+
+---
+
+## Testing Strategy
+
+### Integration Tests
+
+- **Single Monitor Setup**: Test all actions with `monitorIndex=0`
+- **Multi-Monitor Setup** (if available):
+  - Test clicks on secondary monitor
+  - Test validation with invalid indices
+  - Test coordinates outside monitor bounds
+  - Prefer **secondary monitor for test clicks** to avoid interfering with developer's VS Code session
+
+### Test Fixtures
+
+- `MultiMonitorFixture`: Provides monitor enumeration, detects secondary monitor, supplies test coordinates
+- Pattern: Tests use `TestMonitorHelper.GetTestMonitorIndex()` to target secondary monitor if available, else primary
+
+### Unit Tests (if applicable)
+
+- Validation logic: missing monitorIndex, invalid index, out-of-bounds coordinates
+
+---
+
+## Implementation Checklist
+
+- [ ] Modify `MouseControlTool` to enforce monitorIndex validation
+- [ ] Update `MouseControlResult` with monitor fields
+- [ ] Add parameter descriptions to enforce LLM clarity
+- [ ] Write integration tests on Windows 11 (multi-monitor preferred)
+- [ ] Update VS Code extension to pass monitorIndex
+- [ ] Update standalone server documentation
+- [ ] Release notes: breaking change notice

--- a/specs/012-mouse-position/spec.md
+++ b/specs/012-mouse-position/spec.md
@@ -1,0 +1,185 @@
+# Feature Specification: Mouse Position Awareness for LLM Usability
+
+**Feature Branch**: `012-mouse-position`  
+**Created**: December 11, 2025  
+**Status**: Draft  
+**Input**: User description: "Improve mouse control for LLM usability by adding get_position action and monitor awareness"  
+**Extends**: [001-mouse-control](../001-mouse-control/spec.md)
+
+## Problem Statement
+
+LLMs using the `mouse_control` MCP tool struggle to position the mouse accurately because the `monitorIndex` parameter is optional (defaults to 0). This creates a mismatch:
+
+1. LLM takes a screenshot of monitor 1
+2. LLM finds a button at coordinates (500, 300) in that image
+3. LLM calls `mouse_control(action: click, x: 500, y: 300)` — **forgetting monitorIndex**
+4. Click happens on monitor 0 at (500, 300) — **wrong monitor!**
+
+The fix is simple: **make `monitorIndex` a required parameter** so the LLM must be explicit about which monitor it's targeting.
+
+## Evolution from 001-mouse-control
+
+The original [001-mouse-control spec](../001-mouse-control/spec.md) was designed from a **human developer's perspective**—assuming the caller would "just know" where to click. It focused on:
+
+| 001 Spec Focus | Assumption |
+|----------------|------------|
+| Accurate cursor positioning | Caller knows the target coordinates |
+| Multi-monitor support | Caller understands monitor layout |
+| DPI awareness | Caller handles scaling calculations |
+| Click/drag/scroll operations | Caller will position cursor first |
+
+**What 001 got right:**
+- Robust Windows API usage (`SendInput`, not deprecated `mouse_event`)
+- Proper multi-monitor coordinate handling with normalization
+- Excellent error handling for elevated processes, secure desktop, UIPI
+- Modifier key management without stuck keys
+- Comprehensive action support (move, click, double_click, right_click, middle_click, drag, scroll)
+- **Monitor-relative coordinates already work correctly!**
+
+**What 001 didn't anticipate:**
+The optional `monitorIndex` with a default of 0 is a footgun for LLMs:
+
+| Human Developer | LLM Caller |
+|-----------------|------------|
+| Remembers which monitor they're working on | May forget to specify monitorIndex |
+| Mentally tracks context | Each tool call is stateless |
+| Catches mistakes by seeing cursor move | Cannot see the screen |
+
+**The simple fix:**
+Instead of adding new actions like `get_position` and `move_relative`, we simply **require the LLM to be explicit** about which monitor it's targeting. The coordinate translation already works correctly.
+
+## Simplified LLM Workflow
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    LLM UI Automation Flow                     │
+├──────────────────────────────────────────────────────────────┤
+│  1. screenshot_control(target: monitor, monitorIndex: 1)     │
+│     → Get image of monitor 1                                  │
+│                                                               │
+│  2. Analyze image, find button at (500, 300)                 │
+│     → Coordinates are already monitor-relative!               │
+│                                                               │
+│  3. mouse_control(action: click, x: 500, y: 300,             │
+│                   monitorIndex: 1)  ← REQUIRED                │
+│     → Click at correct position on correct monitor            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+This is much simpler than adding `get_position` or `move_relative` because:
+- Screenshot coordinates **are already monitor-relative** (0,0 is top-left of image)
+- The coordinate translation **already works** in the existing implementation
+- We just need to **force explicit monitor targeting**
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Explicit Monitor Targeting (Priority: P1)
+
+As an LLM performing UI automation, I need to explicitly specify which monitor I'm targeting so that coordinates from my screenshot analysis map correctly to mouse positions.
+
+**Why this priority**: This is the core fix - eliminating the silent failure mode where the LLM clicks on the wrong monitor.
+
+**Independent Test**: Can be tested by calling any mouse action with coordinates but without monitorIndex and verifying an error is returned, and by calling actions without coordinates to confirm they still work at the current cursor position.
+
+**Acceptance Scenarios**:
+
+1. **Given** an LLM calls mouse_control with action "click" and x=500, y=300, **When** monitorIndex is not provided, **Then** the tool returns an error indicating monitorIndex is required.
+
+2. **Given** an LLM takes a screenshot of monitor 1 and finds a button at (500, 300), **When** it calls mouse_control with x=500, y=300, monitorIndex=1, **Then** the click occurs at the correct position on monitor 1.
+
+3. **Given** a single-monitor setup, **When** an LLM calls mouse_control with action "click" and x=500, y=300 and monitorIndex=0, **Then** the operation succeeds.
+
+4. **Given** an LLM specifies an invalid monitorIndex (e.g., 5 on a 2-monitor system), **When** the tool is called with coordinates, **Then** a clear error is returned listing valid monitor indices.
+
+5. **Given** an LLM calls mouse_control with action "click" and no coordinates (x,y omitted), **When** monitorIndex is also omitted, **Then** the click occurs at the current cursor position without error.
+
+---
+
+### User Story 2 - Monitor Information in Responses (Priority: P2)
+
+As an LLM performing UI automation, I need confirmation of which monitor the cursor ended up on so I can verify my operation succeeded.
+
+**Why this priority**: Provides feedback for the LLM to confirm actions worked as expected.
+
+**Independent Test**: Can be tested by performing any mouse action and verifying the response includes the target monitor index and dimensions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mouse_control action completes successfully, **When** the response is returned, **Then** it includes the monitorIndex where the cursor is now located.
+
+2. **Given** a successful mouse action on monitor 1, **When** the response is returned, **Then** it includes the monitor's dimensions (width and height).
+
+3. **Given** a user with a 1920×1080 monitor at index 0, **When** an LLM clicks at (100, 100, monitorIndex=0), **Then** the response includes monitorIndex=0, monitorWidth=1920, monitorHeight=1080.
+
+---
+
+### User Story 3 - Query Current Position (Priority: P3)
+
+As an LLM performing UI automation, I may need to know where the cursor currently is before deciding where to move it.
+
+**Why this priority**: Nice-to-have for advanced scenarios, but not critical since the primary workflow uses screenshot→click.
+
+**Independent Test**: Can be tested by calling get_position and verifying valid coordinates and monitor index are returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** the cursor is at any position, **When** an LLM calls mouse_control with action "get_position", **Then** the response includes x, y coordinates relative to the current monitor and the monitorIndex.
+
+2. **Given** the cursor is on monitor 1 at position (500, 300), **When** get_position is called, **Then** the response shows x=500, y=300, monitorIndex=1.
+
+---
+
+### Edge Cases
+
+- What happens when an LLM specifies coordinates outside the target monitor's bounds?
+  - Return error with valid coordinate range for that monitor.
+- What happens if a monitor is disconnected between screenshot and click?
+  - Return error indicating the monitor index is no longer valid.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The `monitorIndex` parameter MUST be required for all mouse_control actions that use coordinates (move, click, double_click, right_click, middle_click, drag start/end, scroll with position).
+- **FR-002**: When coordinates are provided and `monitorIndex` is not provided, the tool MUST return a clear error message indicating that monitorIndex is required when using x/y coordinates.
+- **FR-003**: When an invalid `monitorIndex` is provided together with coordinates, the tool MUST return an error listing valid monitor indices (e.g., "Invalid monitorIndex: 5. Valid indices: 0, 1, 2").
+- **FR-004**: When no coordinates are provided, actions MUST operate at the current cursor position and MUST NOT require `monitorIndex`.
+- **FR-005**: All successful mouse_control responses MUST include the `monitorIndex` where the cursor ended up.
+- **FR-006**: All successful mouse_control responses MUST include the target monitor's dimensions (`monitorWidth`, `monitorHeight`).
+- **FR-007**: System MUST support a new "get_position" action that returns current cursor position (x, y relative to monitor, plus monitorIndex).
+- **FR-008**: The get_position action MUST NOT require monitorIndex as input (it reports where the cursor already is).
+- **FR-009**: Coordinates MUST continue to be interpreted as relative to the specified monitor's origin (0,0 = top-left of that monitor).
+
+### Key Entities
+
+- **Monitor Index**: Required identifier (0-based) specifying which monitor coordinates are relative to.
+- **Monitor Dimensions**: Width and height of a monitor, returned in responses for LLM awareness.
+- **Cursor Position**: Current x,y coordinates relative to a specific monitor.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of mouse operations with coordinates require explicit monitorIndex specification.
+- **SC-002**: LLMs successfully click on the correct monitor when using screenshot coordinates + matching monitorIndex.
+- **SC-003**: Clear error messages are returned when monitorIndex is missing or invalid.
+- **SC-004**: All responses include monitor dimensions for LLM awareness.
+- **SC-005**: Existing screenshot→click workflow works correctly when LLM specifies matching monitor indices.
+
+## Assumptions
+
+- LLMs will use `screenshot_control` with a specific monitorIndex before attempting mouse operations.
+- Coordinates from screenshot analysis (0,0 at top-left of image) directly map to monitor-relative coordinates.
+- This feature introduces a **breaking change**: all existing calls that provide x/y coordinates without `monitorIndex` will fail with an error. No deprecation period or warning phase—the requirement is enforced immediately.
+
+## Out of Scope
+
+- `move_relative` action (unnecessary if LLM uses screenshot coordinates)
+- OCR or visual element detection (LLMs use screenshot tool for that)
+- Automatic coordinate calculation from UI element names
+
+## Clarifications
+
+### Session 2025-12-11
+
+- Q: Should the breaking change (requiring `monitorIndex` when x/y coordinates are used) be rolled out immediately or phased with deprecation warnings? → A: Immediate hard break. The requirement is enforced immediately with no transition period.

--- a/specs/012-mouse-position/tasks.md
+++ b/specs/012-mouse-position/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Mouse Position Awareness for LLM Usability
+
+**Input**: Design documents from `/specs/012-mouse-position/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm scope and artifacts before code changes
+
+- [ ] T001 Validate feature scope against plan and spec in specs/012-mouse-position/plan.md and specs/012-mouse-position/spec.md
+- [ ] T002 [P] Confirm supporting design artifacts are present (research.md, data-model.md, contracts/) in specs/012-mouse-position/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared test scaffolding for all user stories
+
+- [ ] T003 Create multi-monitor test fixture in tests/Sbroenne.WindowsMcp.Tests/Fixtures/MultiMonitorFixture.cs
+
+**Checkpoint**: Foundation ready - user story implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Explicit Monitor Targeting (Priority: P1) 🎯 MVP
+
+**Goal**: Require monitorIndex when coordinates are provided; allow coordinate-less actions without monitorIndex
+
+**Independent Test**: Coordinate-based calls without monitorIndex fail with actionable error; coordinate-less calls still succeed at current cursor
+
+### Tests for User Story 1
+
+- [ ] T004 [P] [US1] Add failing test for missing monitorIndex with coordinates in tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolTests.cs
+- [ ] T005 [P] [US1] Add failing test for invalid monitorIndex listing valid indices in tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolTests.cs
+- [ ] T006 [P] [US1] Add failing test for coordinates out of bounds returning valid_bounds in tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolTests.cs
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Enforce monitorIndex requirement when coordinates are present in src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+- [ ] T008 [US1] Validate monitorIndex range and coordinate bounds per monitor in src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+- [ ] T009 [US1] Preserve coordinate-less actions (click/scroll without x/y) without requiring monitorIndex in src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+
+**Checkpoint**: User Story 1 independently testable
+
+---
+
+## Phase 4: User Story 2 - Monitor Info in Responses (Priority: P2)
+
+**Goal**: Include monitor index and dimensions in all success responses; provide error_code/error_details on failures
+
+**Independent Test**: Successful actions return monitorIndex/monitorWidth/monitorHeight; errors return structured error_code and details
+
+### Tests for User Story 2
+
+- [ ] T010 [P] [US2] Add test asserting success responses include monitorIndex and dimensions in tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolTests.cs
+
+### Implementation for User Story 2
+
+- [ ] T011 [US2] Extend response model with monitorIndex, monitorWidth, monitorHeight, error_code, error_details in src/Sbroenne.WindowsMcp/Models/MouseControlResult.cs
+- [ ] T012 [US2] Populate monitor context on success and structured error details on failure in src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+
+**Checkpoint**: User Story 2 independently testable
+
+---
+
+## Phase 5: User Story 3 - Query Current Position (Priority: P3)
+
+**Goal**: Provide get_position action returning cursor coordinates and monitor context
+
+**Independent Test**: get_position returns current cursor x/y and monitorIndex with dimensions
+
+### Tests for User Story 3
+
+- [ ] T013 [P] [US3] Add test for get_position returning monitorIndex and dimensions in tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolTests.cs
+
+### Implementation for User Story 3
+
+- [ ] T014 [US3] Implement get_position action in src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+- [ ] T015 [US3] Update contracts to document get_position response fields in specs/012-mouse-position/contracts/mouse-control.md
+
+**Checkpoint**: User Story 3 independently testable
+
+---
+
+## Phase N: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final docs and consistency sweep
+
+- [ ] T016 [P] Refresh quickstart examples to match implemented behavior in specs/012-mouse-position/quickstart.md
+- [ ] T017 [P] Ensure data-model and plan reflect final API fields in specs/012-mouse-position/data-model.md and specs/012-mouse-position/plan.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Setup (Phase 1) → Foundational (Phase 2) → User Stories (Phases 3-5) → Polish (Final)
+
+### User Story Completion Order (by priority)
+
+- US1 (P1) → US2 (P2) → US3 (P3)
+
+### Parallel Opportunities
+
+- [P] tasks within each phase can run concurrently (e.g., T002, T004-T006, T010, T013, T016-T017)
+- After Phase 2, separate contributors can work on different user stories in parallel
+
+## Implementation Strategy
+
+- MVP = Complete User Story 1 (coordinate validation) after foundational fixture, then validate
+- Incremental: Ship US1 → add monitor context (US2) → add get_position (US3)
+- Tests-first per story: add failing tests before implementation tasks

--- a/src/Sbroenne.WindowsMcp/Capture/ScreenshotService.cs
+++ b/src/Sbroenne.WindowsMcp/Capture/ScreenshotService.cs
@@ -593,13 +593,26 @@ public sealed class ScreenshotService : IScreenshotService
                 var cursorX = cursorInfo.PtScreenPos.X - regionX;
                 var cursorY = cursorInfo.PtScreenPos.Y - regionY;
 
-                NativeMethods.DrawIcon(
-                    graphics.GetHdc(),
-                    cursorX,
-                    cursorY,
-                    cursorInfo.HCursor);
-
-                graphics.ReleaseHdc();
+                // Use DrawIconEx with explicit HDC and ensure the DC is always released.
+                var hdc = graphics.GetHdc();
+                try
+                {
+                    // DI_NORMAL draws the icon using its mask and image.
+                    NativeMethods.DrawIconEx(
+                        hdc,
+                        cursorX,
+                        cursorY,
+                        cursorInfo.HCursor,
+                        0,
+                        0,
+                        0,
+                        IntPtr.Zero,
+                        NativeConstants.DI_NORMAL);
+                }
+                finally
+                {
+                    graphics.ReleaseHdc(hdc);
+                }
             }
         }
         catch

--- a/src/Sbroenne.WindowsMcp/Models/MouseAction.cs
+++ b/src/Sbroenne.WindowsMcp/Models/MouseAction.cs
@@ -24,5 +24,8 @@ public enum MouseAction
     Drag,
 
     /// <summary>Mouse wheel scroll.</summary>
-    Scroll
+    Scroll,
+
+    /// <summary>Get current cursor position with monitor context.</summary>
+    GetPosition
 }

--- a/src/Sbroenne.WindowsMcp/Models/MouseControlResult.cs
+++ b/src/Sbroenne.WindowsMcp/Models/MouseControlResult.cs
@@ -30,6 +30,30 @@ public sealed record MouseControlResult
     public string? WindowTitle { get; init; }
 
     /// <summary>
+    /// Gets the monitor index where the operation occurred (0-based).
+    /// Only populated for operations with explicit coordinates.
+    /// </summary>
+    [JsonPropertyName("monitor_index")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MonitorIndex { get; init; }
+
+    /// <summary>
+    /// Gets the width of the monitor where the operation occurred.
+    /// Only populated for operations with explicit coordinates.
+    /// </summary>
+    [JsonPropertyName("monitor_width")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MonitorWidth { get; init; }
+
+    /// <summary>
+    /// Gets the height of the monitor where the operation occurred.
+    /// Only populated for operations with explicit coordinates.
+    /// </summary>
+    [JsonPropertyName("monitor_height")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? MonitorHeight { get; init; }
+
+    /// <summary>
     /// Gets the error message if the operation failed.
     /// </summary>
     [JsonPropertyName("error")]
@@ -74,14 +98,26 @@ public sealed record MouseControlResult
     /// <param name="coordinates">The final cursor coordinates.</param>
     /// <param name="screenBounds">The current screen bounds.</param>
     /// <param name="windowTitle">Optional window title under the cursor.</param>
+    /// <param name="monitorIndex">Optional monitor index where the operation occurred.</param>
+    /// <param name="monitorWidth">Optional width of the monitor where the operation occurred.</param>
+    /// <param name="monitorHeight">Optional height of the monitor where the operation occurred.</param>
     /// <returns>A successful result.</returns>
-    public static MouseControlResult CreateSuccess(Coordinates coordinates, ScreenBounds? screenBounds = null, string? windowTitle = null)
+    public static MouseControlResult CreateSuccess(
+        Coordinates coordinates,
+        ScreenBounds? screenBounds = null,
+        string? windowTitle = null,
+        int? monitorIndex = null,
+        int? monitorWidth = null,
+        int? monitorHeight = null)
     {
         return new MouseControlResult
         {
             Success = true,
             FinalPosition = new FinalPosition(coordinates.X, coordinates.Y),
             WindowTitle = windowTitle,
+            MonitorIndex = monitorIndex,
+            MonitorWidth = monitorWidth,
+            MonitorHeight = monitorHeight,
             ScreenBounds = screenBounds,
             ErrorCode = MouseControlErrorCode.Success,
         };

--- a/src/Sbroenne.WindowsMcp/Native/NativeConstants.cs
+++ b/src/Sbroenne.WindowsMcp/Native/NativeConstants.cs
@@ -678,4 +678,17 @@ internal static class NativeConstants
     public const uint DESKTOP_WRITEOBJECTS = 0x0080;
 
     #endregion
+
+    #region DrawIconEx Flags (DI_*)
+
+    /// <summary>Draws the icon using its mask (DI_MASK | DI_IMAGE).</summary>
+    public const uint DI_NORMAL = 0x0003;
+
+    /// <summary>Draws the icon using the image.</summary>
+    public const uint DI_IMAGE = 0x0002;
+
+    /// <summary>Draws the icon using the mask.</summary>
+    public const uint DI_MASK = 0x0001;
+
+    #endregion
 }

--- a/src/Sbroenne.WindowsMcp/Native/NativeMethods.cs
+++ b/src/Sbroenne.WindowsMcp/Native/NativeMethods.cs
@@ -405,6 +405,29 @@ internal static partial class NativeMethods
     internal delegate bool MonitorEnumProc(nint hMonitor, nint hdcMonitor, ref RECT lprcMonitor, nint dwData);
 
     /// <summary>
+    /// Retrieves the DPI for a display monitor.
+    /// </summary>
+    /// <param name="hMonitor">Handle to the monitor.</param>
+    /// <param name="dpiType">The type of DPI being queried (MDT_EFFECTIVE_DPI = 0, MDT_ANGULAR_DPI = 1, MDT_RAW_DPI = 2).</param>
+    /// <param name="dpiX">Receives the horizontal DPI.</param>
+    /// <param name="dpiY">Receives the vertical DPI.</param>
+    /// <returns>S_OK if successful, or an error code.</returns>
+    [LibraryImport("shcore.dll")]
+    internal static partial int GetDpiForMonitor(nint hMonitor, int dpiType, out uint dpiX, out uint dpiY);
+
+    /// <summary>
+    /// Retrieves information about one of the graphics modes for a display device.
+    /// With ENUM_CURRENT_SETTINGS (-1), retrieves the current physical resolution.
+    /// </summary>
+    /// <param name="lpszDeviceName">Display device name (e.g., \\.\DISPLAY1). Can be null for primary.</param>
+    /// <param name="iModeNum">Mode number or ENUM_CURRENT_SETTINGS (-1).</param>
+    /// <param name="lpDevMode">Pointer to DEVMODE structure to receive settings.</param>
+    /// <returns>True if successful, false otherwise.</returns>
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool EnumDisplaySettingsW(string? lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);
+
+    /// <summary>
     /// Retrieves the identifier of the thread that created the specified window.
     /// </summary>
     /// <returns>Thread identifier of the calling thread.</returns>
@@ -475,6 +498,23 @@ internal static partial class NativeMethods
     [LibraryImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool DrawIcon(nint hDC, int X, int Y, nint hIcon);
+
+    /// <summary>
+    /// Draws an icon or cursor into the specified device context, performing the specified raster operations.
+    /// </summary>
+    /// <param name="hdc">Handle to the device context.</param>
+    /// <param name="xLeft">X-coordinate of the upper-left corner of the icon.</param>
+    /// <param name="yTop">Y-coordinate of the upper-left corner of the icon.</param>
+    /// <param name="hIcon">Handle to the icon to be drawn.</param>
+    /// <param name="cxWidth">Width of the icon. If 0, uses the system metric SM_CXICON.</param>
+    /// <param name="cyWidth">Height of the icon. If 0, uses the system metric SM_CYICON.</param>
+    /// <param name="istepIfAniCur">Index of the frame if animated cursor. Ignored if not animated.</param>
+    /// <param name="hbrFlickerFreeDraw">Handle to a brush for flicker-free drawing. Can be IntPtr.Zero.</param>
+    /// <param name="diFlags">Drawing flags (DI_NORMAL, DI_IMAGE, DI_MASK, DI_COMPAT, DI_DEFAULTSIZE).</param>
+    /// <returns>True if successful, false otherwise.</returns>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool DrawIconEx(nint hdc, int xLeft, int yTop, nint hIcon, int cxWidth, int cyWidth, uint istepIfAniCur, nint hbrFlickerFreeDraw, uint diFlags);
 
     /// <summary>
     /// Determines whether the specified window handle identifies an existing window.

--- a/src/Sbroenne.WindowsMcp/Native/NativeStructs.cs
+++ b/src/Sbroenne.WindowsMcp/Native/NativeStructs.cs
@@ -285,3 +285,122 @@ internal struct CURSORINFO
     /// </summary>
     public readonly bool IsVisible => (Flags & CURSOR_SHOWING) != 0;
 }
+
+/// <summary>
+/// Contains information about the initialization and environment of a display device.
+/// This simplified version contains only the fields needed for display mode enumeration.
+/// </summary>
+[StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+internal struct DEVMODE
+{
+    private const int CCHDEVICENAME = 32;
+    private const int CCHFORMNAME = 32;
+
+    /// <summary>Device name (up to 32 characters).</summary>
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
+    public string dmDeviceName;
+
+    /// <summary>Version number of the initialization data specification.</summary>
+    public ushort dmSpecVersion;
+
+    /// <summary>Driver version.</summary>
+    public ushort dmDriverVersion;
+
+    /// <summary>Size of the DEVMODE structure (not including private driver data).</summary>
+    public ushort dmSize;
+
+    /// <summary>Size of optional private driver data following this structure.</summary>
+    public ushort dmDriverExtra;
+
+    /// <summary>Specifies which members have been initialized.</summary>
+    public uint dmFields;
+
+    // Position union - we use separate X and Y fields
+    /// <summary>X position of the device.</summary>
+    public int dmPositionX;
+
+    /// <summary>Y position of the device.</summary>
+    public int dmPositionY;
+
+    /// <summary>Display orientation.</summary>
+    public uint dmDisplayOrientation;
+
+    /// <summary>Fixed output mode.</summary>
+    public uint dmDisplayFixedOutput;
+
+    /// <summary>Color resolution in bits per pixel.</summary>
+    public short dmColor;
+
+    /// <summary>Duplex mode.</summary>
+    public short dmDuplex;
+
+    /// <summary>Y resolution.</summary>
+    public short dmYResolution;
+
+    /// <summary>TrueType option.</summary>
+    public short dmTTOption;
+
+    /// <summary>Collation option.</summary>
+    public short dmCollate;
+
+    /// <summary>Form name (up to 32 characters).</summary>
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHFORMNAME)]
+    public string dmFormName;
+
+    /// <summary>Logical pixels per inch (DPI).</summary>
+    public ushort dmLogPixels;
+
+    /// <summary>Bits per pixel (color depth).</summary>
+    public uint dmBitsPerPel;
+
+    /// <summary>Width in pixels.</summary>
+    public uint dmPelsWidth;
+
+    /// <summary>Height in pixels.</summary>
+    public uint dmPelsHeight;
+
+    /// <summary>Display flags or NUP (pages per sheet).</summary>
+    public uint dmDisplayFlags;
+
+    /// <summary>Display frequency (refresh rate in Hz).</summary>
+    public uint dmDisplayFrequency;
+
+    // Additional fields for printers (not used for display)
+    /// <summary>ICM method.</summary>
+    public uint dmICMMethod;
+
+    /// <summary>ICM intent.</summary>
+    public uint dmICMIntent;
+
+    /// <summary>Media type.</summary>
+    public uint dmMediaType;
+
+    /// <summary>Dither type.</summary>
+    public uint dmDitherType;
+
+    /// <summary>Reserved field 1.</summary>
+    public uint dmReserved1;
+
+    /// <summary>Reserved field 2.</summary>
+    public uint dmReserved2;
+
+    /// <summary>Panning width.</summary>
+    public uint dmPanningWidth;
+
+    /// <summary>Panning height.</summary>
+    public uint dmPanningHeight;
+
+    /// <summary>
+    /// Creates a new DEVMODE structure with the dmSize field initialized.
+    /// </summary>
+    /// <returns>An initialized DEVMODE structure.</returns>
+    public static DEVMODE Create()
+    {
+        return new DEVMODE
+        {
+            dmSize = (ushort)Marshal.SizeOf<DEVMODE>(),
+            dmDeviceName = string.Empty,
+            dmFormName = string.Empty
+        };
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Fixtures/MultiMonitorFixture.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Fixtures/MultiMonitorFixture.cs
@@ -1,0 +1,153 @@
+using Sbroenne.WindowsMcp.Capture;
+using Sbroenne.WindowsMcp.Models;
+
+namespace Sbroenne.WindowsMcp.Tests.Fixtures;
+
+/// <summary>
+/// Provides shared setup for multi-monitor integration tests.
+/// Detects available monitors and provides utility methods for coordinate generation.
+/// </summary>
+public sealed class MultiMonitorFixture : IAsyncLifetime
+{
+    private readonly MonitorService _monitorService;
+    private IReadOnlyList<MonitorInfo> _availableMonitors = Array.Empty<MonitorInfo>();
+
+    public MultiMonitorFixture()
+    {
+        _monitorService = new MonitorService();
+    }
+
+    /// <summary>
+    /// Gets the list of available monitor indices.
+    /// </summary>
+    public IReadOnlyList<int> AvailableMonitorIndices =>
+        _availableMonitors.Select(m => m.Index).ToList();
+
+    /// <summary>
+    /// Gets the count of available monitors.
+    /// </summary>
+    public int MonitorCount => _availableMonitors.Count;
+
+    /// <summary>
+    /// Gets whether multi-monitor setup is available (2+ monitors).
+    /// </summary>
+    public bool IsMultiMonitorSetup => _availableMonitors.Count >= 2;
+
+    /// <summary>
+    /// Gets the primary monitor.
+    /// </summary>
+    public MonitorInfo PrimaryMonitor =>
+        _availableMonitors.First(m => m.IsPrimary);
+
+    /// <summary>
+    /// Gets a secondary monitor (if available).
+    /// </summary>
+    /// <returns>The second monitor, or null if only one monitor available.</returns>
+    public MonitorInfo? GetSecondaryMonitor()
+    {
+        return _availableMonitors.Count >= 2 ? _availableMonitors[1] : null;
+    }
+
+    /// <summary>
+    /// Gets a monitor by index.
+    /// </summary>
+    /// <param name="index">The monitor index.</param>
+    /// <returns>The monitor info, or null if index invalid.</returns>
+    public MonitorInfo? GetMonitor(int index)
+    {
+        return _monitorService.GetMonitor(index);
+    }
+
+    /// <summary>
+    /// Gets center coordinates for a specific monitor.
+    /// </summary>
+    /// <param name="monitorIndex">The monitor index.</param>
+    /// <returns>Center point (x, y) relative to the monitor's origin.</returns>
+    public (int X, int Y) GetMonitorCenter(int monitorIndex)
+    {
+        var monitor = _monitorService.GetMonitor(monitorIndex);
+        if (monitor == null)
+        {
+            throw new ArgumentException($"Monitor {monitorIndex} not found", nameof(monitorIndex));
+        }
+
+        return (monitor.Width / 2, monitor.Height / 2);
+    }
+
+    /// <summary>
+    /// Gets safe coordinates within a monitor's bounds (10% padding from edges).
+    /// </summary>
+    /// <param name="monitorIndex">The monitor index.</param>
+    /// <returns>Safe point (x, y) relative to the monitor's origin.</returns>
+    public (int X, int Y) GetSafeCoordinates(int monitorIndex)
+    {
+        var monitor = _monitorService.GetMonitor(monitorIndex);
+        if (monitor == null)
+        {
+            throw new ArgumentException($"Monitor {monitorIndex} not found", nameof(monitorIndex));
+        }
+
+        // Use 10% padding from edges
+        var xOffset = (int)(monitor.Width * 0.1);
+        var yOffset = (int)(monitor.Height * 0.1);
+
+        return (xOffset, yOffset);
+    }
+
+    /// <summary>
+    /// Checks if coordinates are within a monitor's bounds.
+    /// </summary>
+    /// <param name="monitorIndex">The monitor index.</param>
+    /// <param name="x">X-coordinate (monitor-relative).</param>
+    /// <param name="y">Y-coordinate (monitor-relative).</param>
+    /// <returns>True if within bounds, false otherwise.</returns>
+    public bool AreCoordinatesInBounds(int monitorIndex, int x, int y)
+    {
+        var monitor = _monitorService.GetMonitor(monitorIndex);
+        if (monitor == null)
+        {
+            return false;
+        }
+
+        return x >= 0 && x < monitor.Width && y >= 0 && y < monitor.Height;
+    }
+
+    /// <summary>
+    /// Gets coordinates that are out of bounds for a monitor.
+    /// </summary>
+    /// <param name="monitorIndex">The monitor index.</param>
+    /// <returns>Out-of-bounds point (x, y).</returns>
+    public (int X, int Y) GetOutOfBoundsCoordinates(int monitorIndex)
+    {
+        var monitor = _monitorService.GetMonitor(monitorIndex);
+        if (monitor == null)
+        {
+            throw new ArgumentException($"Monitor {monitorIndex} not found", nameof(monitorIndex));
+        }
+
+        // Return coordinates well beyond monitor bounds
+        return (monitor.Width + 1000, monitor.Height + 1000);
+    }
+
+    /// <inheritdoc />
+    public Task InitializeAsync()
+    {
+        // Detect available monitors
+        _availableMonitors = _monitorService.GetMonitors();
+
+        if (_availableMonitors.Count == 0)
+        {
+            throw new InvalidOperationException(
+                "No monitors detected. Integration tests require at least one monitor.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DisposeAsync()
+    {
+        // No cleanup needed - we don't move the cursor or modify state
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/AllMonitorsCaptureTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/AllMonitorsCaptureTests.cs
@@ -234,8 +234,6 @@ public sealed class AllMonitorsCaptureTests
             Target = CaptureTarget.AllMonitors
         };
 
-        var virtualScreen = System.Windows.Forms.SystemInformation.VirtualScreen;
-
         // Act
         var result = await _screenshotService.ExecuteAsync(request);
 
@@ -249,11 +247,11 @@ public sealed class AllMonitorsCaptureTests
             Assert.True(region.X >= 0, $"X should be >= 0, was {region.X}");
             Assert.True(region.Y >= 0, $"Y should be >= 0, was {region.Y}");
 
-            // Image coordinates + dimensions should be within virtual screen bounds
-            Assert.True(region.X + region.Width <= virtualScreen.Width,
-                $"Region extends beyond virtual screen width");
-            Assert.True(region.Y + region.Height <= virtualScreen.Height,
-                $"Region extends beyond virtual screen height");
+            // NOTE: With DPI scaling, physical monitor dimensions may exceed virtual screen
+            // logical dimensions. Virtual screen uses logical coordinates while monitors
+            // report physical pixels. We validate dimensions are positive instead.
+            Assert.True(region.Width > 0, $"Monitor {region.Index} width should be positive");
+            Assert.True(region.Height > 0, $"Monitor {region.Index} height should be positive");
         }
     }
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ScreenshotAllMonitorsTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ScreenshotAllMonitorsTests.cs
@@ -335,13 +335,23 @@ public sealed class ScreenshotAllMonitorsTests
         Assert.NotNull(result.VirtualScreen);
         Assert.NotNull(result.Monitors);
 
-        // Virtual screen should be at least as large as any individual monitor
+        // NOTE: Virtual screen is in logical coordinates, monitor dimensions are physical.
+        // With DPI scaling, physical monitor dimensions may exceed virtual screen dimensions.
+        // We verify that monitor positions (which are logical) fall within the virtual screen bounds.
         foreach (var monitor in result.Monitors)
         {
-            Assert.True(result.VirtualScreen.Width >= monitor.Width,
-                $"Virtual screen width ({result.VirtualScreen.Width}) should be >= monitor {monitor.Index} width ({monitor.Width})");
-            Assert.True(result.VirtualScreen.Height >= monitor.Height,
-                $"Virtual screen height ({result.VirtualScreen.Height}) should be >= monitor {monitor.Index} height ({monitor.Height})");
+            Assert.True(monitor.X >= result.VirtualScreen.X,
+                $"Monitor {monitor.Index} X ({monitor.X}) should be >= virtual screen X ({result.VirtualScreen.X})");
+            Assert.True(monitor.Y >= result.VirtualScreen.Y,
+                $"Monitor {monitor.Index} Y ({monitor.Y}) should be >= virtual screen Y ({result.VirtualScreen.Y})");
+
+            // Monitor dimensions should be positive
+            Assert.True(monitor.Width > 0, $"Monitor {monitor.Index} width should be positive");
+            Assert.True(monitor.Height > 0, $"Monitor {monitor.Index} height should be positive");
         }
+
+        // Virtual screen dimensions should be positive
+        Assert.True(result.VirtualScreen.Width > 0, "Virtual screen width should be positive");
+        Assert.True(result.VirtualScreen.Height > 0, "Virtual screen height should be positive");
     }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
@@ -1,0 +1,330 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Capture;
+using Sbroenne.WindowsMcp.Configuration;
+using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Logging;
+using Sbroenne.WindowsMcp.Tests.Fixtures;
+using Sbroenne.WindowsMcp.Tools;
+
+namespace Sbroenne.WindowsMcp.Tests.Tools;
+
+/// <summary>
+/// Integration tests for MouseControlTool monitorIndex validation and monitor context features.
+/// Tests User Story 1 (Explicit Monitor Targeting), User Story 2 (Monitor Info in Responses),
+/// and User Story 3 (Query Current Position) using real services without mocking.
+/// </summary>
+public sealed class MouseControlToolMonitorIndexTests : IClassFixture<MultiMonitorFixture>
+{
+    private readonly MultiMonitorFixture _fixture;
+    private readonly MouseControlTool _tool;
+
+    public MouseControlToolMonitorIndexTests(MultiMonitorFixture fixture)
+    {
+        _fixture = fixture;
+
+        // Create real services for integration testing
+        var mouseService = new MouseInputService();
+        var monitorService = new MonitorService();
+        var elevationDetector = new ElevationDetector();
+        var secureDesktopDetector = new SecureDesktopDetector();
+        var logger = new MouseOperationLogger(NullLogger<MouseOperationLogger>.Instance);
+        var config = MouseConfiguration.FromEnvironment();
+
+        _tool = new MouseControlTool(
+            mouseService,
+            monitorService,
+            elevationDetector,
+            secureDesktopDetector,
+            logger,
+            config);
+    }
+
+    /// <summary>
+    /// Helper to create a RequestContext for testing.
+    /// Uses unsafe FormatterServices to bypass constructor and set required fields.
+    /// </summary>
+#pragma warning disable SYSLIB0050 // FormatterServices.GetUninitializedObject is obsolete but necessary for struct instantiation without constructor
+    private static RequestContext<CallToolRequestParams> CreateMockContext()
+    {
+        // RequestContext is a struct with required Server property
+        // For unit testing validation logic that doesn't need the context internals,
+        // we use FormatterServices to create an instance without calling constructor
+        var contextType = typeof(RequestContext<CallToolRequestParams>);
+        var context = (RequestContext<CallToolRequestParams>)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(contextType);
+
+        // Set the Server property to satisfy ArgumentNullException.ThrowIfNull
+        // Find and set the backing field
+        var serverProp = contextType.GetProperty("Server");
+        if (serverProp != null)
+        {
+            var backingField = contextType.GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .FirstOrDefault(f => f.Name.Contains("Server"));
+
+            if (backingField != null)
+            {
+                var mockServer = new object(); // Minimal non-null object to pass ThrowIfNull check
+                var boxed = (object)context;
+                backingField.SetValue(boxed, mockServer);
+                context = (RequestContext<CallToolRequestParams>)boxed;
+            }
+        }
+
+        return context;
+    }
+#pragma warning restore SYSLIB0050
+
+    [Fact]
+    public async Task ExecuteAsync_ClickWithCoordinatesNoMonitorIndex_ReturnsMissingParameterError()
+    {
+        // Arrange
+        var (x, y) = _fixture.GetMonitorCenter(0);
+
+        // Act - monitorIndex parameter defaults to 0, but we're testing the new validation
+        // Note: The current implementation has monitorIndex with default=0, so this test
+        // will initially PASS (wrong behavior). After T007 implementation, behavior depends
+        // on whether we can make monitorIndex nullable or detect if it was explicitly provided.
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click",
+            x: x,
+            y: y);
+
+        // Assert - Validation should fail because monitorIndex is required with coordinates
+        Assert.False(result.Success);
+        Assert.Equal("missing_required_parameter", result.ErrorCodeString);
+        Assert.Contains("monitorIndex", result.Error!);
+        Assert.NotNull(result.ErrorDetails);
+        Assert.True(result.ErrorDetails!.ContainsKey("valid_indices"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClickWithInvalidMonitorIndex_ReturnsInvalidCoordinatesError()
+    {
+        // Arrange
+        var (x, y) = _fixture.GetMonitorCenter(0);
+        var invalidIndex = _fixture.MonitorCount + 10; // Way beyond valid range
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click",
+            x: x,
+            y: y,
+            monitorIndex: invalidIndex);
+
+        // Assert - Validation should fail because monitorIndex is out of range
+        Assert.False(result.Success);
+        Assert.Equal("invalid_coordinates", result.ErrorCodeString);
+        Assert.Contains($"Invalid monitorIndex: {invalidIndex}", result.Error!);
+        Assert.NotNull(result.ErrorDetails);
+        Assert.True(result.ErrorDetails!.ContainsKey("valid_indices"));
+        Assert.True(result.ErrorDetails!.ContainsKey("provided_index"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClickWithOutOfBoundsCoordinates_ReturnsOutOfBoundsError()
+    {
+        // Arrange
+        var monitorIndex = 0;
+        var (x, y) = _fixture.GetOutOfBoundsCoordinates(monitorIndex);
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click",
+            x: x,
+            y: y,
+            monitorIndex: monitorIndex);
+
+        // Assert - Validation should fail because coordinates are out of bounds
+        Assert.False(result.Success);
+        Assert.Equal("coordinates_out_of_bounds", result.ErrorCodeString);
+        Assert.Contains($"Coordinates ({x}, {y}) out of bounds", result.Error!);
+        Assert.NotNull(result.ErrorDetails);
+        Assert.True(result.ErrorDetails!.ContainsKey("valid_bounds"));
+        Assert.True(result.ErrorDetails!.ContainsKey("provided_coordinates"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ClickWithoutCoordinates_DoesNotRequireMonitorIndex()
+    {
+        // Arrange - click at current cursor position (no x/y provided)
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click");
+        // Note: monitorIndex parameter omitted - should use default (0)
+
+        // Assert - coordinate-less actions should work without explicit monitorIndex
+        Assert.True(result.Success);
+        Assert.NotNull(result.FinalPosition);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MoveWithCoordinatesAndValidMonitorIndex_Succeeds()
+    {
+        // Arrange
+        var monitorIndex = 0;
+        var monitor = _fixture.GetMonitor(monitorIndex)!;
+        var (x, y) = _fixture.GetSafeCoordinates(monitorIndex);
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "move",
+            x: x,
+            y: y,
+            monitorIndex: monitorIndex);
+
+        // Assert - Real integration test, cursor actually moved
+        Assert.True(result.Success);
+        Assert.NotNull(result.FinalPosition);
+        Assert.Equal(monitor.Width, result.MonitorWidth);
+        Assert.Equal(monitor.Height, result.MonitorHeight);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DragWithCoordinatesNoMonitorIndex_ReturnsMissingParameterError()
+    {
+        // Arrange
+        var (startX, startY) = _fixture.GetSafeCoordinates(0);
+        var (endX, endY) = _fixture.GetMonitorCenter(0);
+
+        // Act - Attempt drag without monitorIndex (should fail validation)
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "drag",
+            x: startX,  // Note: drag uses x/y for start position
+            y: startY,
+            endX: endX,
+            endY: endY);
+        // monitorIndex omitted - defaults to 0
+
+        // Assert - Validation should fail because monitorIndex is required with coordinates
+        Assert.False(result.Success);
+        Assert.Equal("missing_required_parameter", result.ErrorCodeString);
+        Assert.Contains("monitorIndex", result.Error!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuccessfulMove_IncludesMonitorInfo()
+    {
+        // Arrange
+        var monitorIndex = 0;
+        var (x, y) = _fixture.GetSafeCoordinates(monitorIndex);
+        var monitor = _fixture.GetMonitor(monitorIndex)!;
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "move",
+            x: x,
+            y: y,
+            monitorIndex: monitorIndex);
+
+        // Assert - Success response should include monitor context
+        Assert.True(result.Success);
+        Assert.NotNull(result.MonitorIndex);
+        Assert.Equal(monitorIndex, result.MonitorIndex);
+        Assert.NotNull(result.MonitorWidth);
+        Assert.Equal(monitor.Width, result.MonitorWidth);
+        Assert.NotNull(result.MonitorHeight);
+        Assert.Equal(monitor.Height, result.MonitorHeight);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SuccessfulClick_IncludesMonitorInfo()
+    {
+        // Arrange
+        var monitorIndex = 0;
+        var (x, y) = _fixture.GetSafeCoordinates(monitorIndex);
+        var monitor = _fixture.GetMonitor(monitorIndex)!;
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click",
+            x: x,
+            y: y,
+            monitorIndex: monitorIndex);
+
+        // Assert - Success response should include monitor context
+        Assert.True(result.Success);
+        Assert.NotNull(result.MonitorIndex);
+        Assert.Equal(monitorIndex, result.MonitorIndex);
+        Assert.NotNull(result.MonitorWidth);
+        Assert.Equal(monitor.Width, result.MonitorWidth);
+        Assert.NotNull(result.MonitorHeight);
+        Assert.Equal(monitor.Height, result.MonitorHeight);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CoordinatelessClick_DoesNotIncludeMonitorInfo()
+    {
+        // Arrange - click at current position (no coordinates, no monitorIndex)
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "click");
+
+        // Assert - Coordinate-less operations don't have explicit monitor context
+        Assert.True(result.Success);
+        Assert.Null(result.MonitorIndex);
+        Assert.Null(result.MonitorWidth);
+        Assert.Null(result.MonitorHeight);
+    }
+
+    // =========================
+    // US3: Query Current Position Tests
+    // =========================
+
+    [Fact]
+    public async Task ExecuteAsync_GetPosition_ReturnsCurrentPositionWithMonitorInfo()
+    {
+        // Arrange - get_position should return current cursor position with monitor context
+        var monitor = _fixture.GetMonitor(0);
+
+        // Act
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "get_position");
+
+        // Assert - Should return success with coordinates and monitor context
+        Assert.True(result.Success, $"get_position should succeed. Error: {result.Error}");
+        Assert.NotNull(result.FinalPosition);
+        Assert.NotNull(result.MonitorIndex);
+        Assert.InRange(result.MonitorIndex.Value, 0, _fixture.MonitorCount - 1);
+        Assert.NotNull(result.MonitorWidth);
+        Assert.True(result.MonitorWidth.Value > 0);
+        Assert.NotNull(result.MonitorHeight);
+        Assert.True(result.MonitorHeight.Value > 0);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GetPosition_DeterminesCorrectMonitor()
+    {
+        // Act - get_position should determine which monitor contains the cursor
+        var result = await _tool.ExecuteAsync(
+            context: CreateMockContext(),
+            action: "get_position");
+
+        // Assert - Should identify a valid monitor and return its dimensions
+        Assert.True(result.Success);
+        Assert.NotNull(result.MonitorIndex);
+        Assert.InRange(result.MonitorIndex.Value, 0, _fixture.MonitorCount - 1);
+
+        // Verify the returned dimensions match the identified monitor
+        var identifiedMonitor = _fixture.GetMonitor(result.MonitorIndex.Value)!;
+        Assert.Equal(identifiedMonitor.Width, result.MonitorWidth);
+        Assert.Equal(identifiedMonitor.Height, result.MonitorHeight);
+
+        // Verify coordinates are within monitor bounds
+        Assert.InRange(result.FinalPosition.X, 0, identifiedMonitor.Width - 1);
+        Assert.InRange(result.FinalPosition.Y, 0, identifiedMonitor.Height - 1);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements feature 012-mouse-position, making \monitorIndex\ a **required** parameter when x/y coordinates are provided to \mouse_control\. This is a breaking change that prevents silent failures where LLMs click on the wrong monitor.

Closes #15

## Breaking Change

**Before:** LLMs could call \mouse_control(action: click, x: 500, y: 300)\ without specifying \monitorIndex\, which silently clicked on monitor 0 even if the coordinates came from a screenshot of monitor 1.

**After:** The tool returns an error with valid monitor indices if \monitorIndex\ is omitted when coordinates are provided.

## Changes

### Mouse Control Enhancements
- **New \get_position\ action** - Query current cursor position with monitor context
- **Require \monitorIndex\** when x/y or endX/endY coordinates are provided
- **Error responses** include \alid_indices\ and \alid_bounds\ for LLM recovery
- **Success responses** include \monitor_index\, \monitor_width\, \monitor_height\
- Coordinate-less actions (click at current position) still work without \monitorIndex\

### Screenshot DPI Fix
- Fix screenshot capture on DPI-scaled monitors returning incomplete images
- Use \EnumDisplaySettingsW\ to get true physical resolution from display driver
- \MonitorService\ now reports physical dimensions instead of logical (DPI-scaled)

### Cursor Rendering Fix
- Switch from \DrawIcon\ to \DrawIconEx\ with \DI_NORMAL\ flag
- Ensure HDC is always released in finally block

### Test Infrastructure
- Add \MultiMonitorFixture\ for multi-monitor integration tests
- Add \MouseControlToolMonitorIndexTests\ for validation testing
- Update DPI-related test assertions

### Documentation
- Full spec documentation in \specs/012-mouse-position/\

## Test Results

✅ **650 tests pass** (excluding 3 pre-existing LlmOptimization failures unrelated to this change)

## API Contract

See [contracts/mouse-control.md](specs/012-mouse-position/contracts/mouse-control.md) for JSON schemas and examples.