### PR TITLE
feat: ship self-contained x64/arm64 release zips

### DIFF
--- a/.github/workflows/release-mcp-server.yml
+++ b/.github/workflows/release-mcp-server.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       contents: write
 
+    strategy:
+      matrix:
+        rid: [win-x64, win-arm64]
+
     steps:
     - uses: actions/checkout@v4
 
@@ -45,20 +49,38 @@ jobs:
     - name: Restore Dependencies
       run: dotnet restore
 
-    - name: Publish (Portable)
-      run: dotnet publish src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj -c Release -o publish --no-self-contained
+    - name: Publish (Self-contained single-file)
+      run: |
+        $rid = "${{ matrix.rid }}"
+        dotnet publish src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj `
+          -c Release `
+          -r $rid `
+          -o "publish/$rid" `
+          -p:SelfContained=true `
+          -p:PublishSingleFile=true `
+          -p:EnableCompressionInSingleFile=true `
+          -p:IncludeNativeLibrariesForSelfExtract=true `
+          -p:PublishReadyToRun=false
+      shell: pwsh
 
     - name: Create Release Archive
       run: |
         $version = "${{ env.VERSION }}"
+        $rid = "${{ matrix.rid }}"
 
-        Compress-Archive -Path "publish/*" -DestinationPath "windows-mcp-server-$version.zip"
+        $publishDir = "publish/$rid"
+        if (!(Test-Path $publishDir)) {
+          Write-Error "Publish directory not found: $publishDir"
+        }
 
-        Write-Output "Created release archive"
+        $zipName = "windows-mcp-server-$version-$rid.zip"
+        Compress-Archive -Path "$publishDir/*" -DestinationPath $zipName
+
+        Write-Output "Created release archive: $zipName"
         Get-ChildItem *.zip | Format-Table Name, Length
       shell: pwsh
 
-    - name: Create GitHub Release
+    - name: Assemble Release Notes
       run: |
         $tagName = "${{ github.ref_name }}"
         $version = "${{ env.VERSION }}"
@@ -66,13 +88,16 @@ jobs:
         $notes = @"
         ## Windows MCP Server $tagName
 
-        MCP server for Windows automation - UI automation, mouse, keyboard, window management, and screenshots.
+        MCP server for Windows automation — UI automation, mouse, keyboard, window management, and screenshots.
 
-        ### Download
+        ### Downloads (no .NET runtime required)
 
-        | File | Description |
-        |------|-------------|
-        | windows-mcp-server-$version.zip | Requires [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) |
+        | File | Architecture |
+        |------|--------------|
+        | windows-mcp-server-$version-win-x64.zip | x64 |
+        | windows-mcp-server-$version-win-arm64.zip | ARM64 |
+
+        Each zip contains a single, self-contained Sbroenne.WindowsMcp.exe. Pick the RID that matches your machine (x64 for most PCs, ARM64 for Surface/ARM dev kits).
 
         ### Available Tools
 
@@ -84,11 +109,11 @@ jobs:
         | window_management | List, find, activate, minimize, maximize, move, resize, move_to_monitor |
         | screenshot_control | Capture screens, monitors, windows, or regions |
 
-        ### Installation
+        ### Usage
 
-        1. Install [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0)
-        2. Extract the zip to a folder
-        3. Run with ``dotnet Sbroenne.WindowsMcp.dll`` or add to your MCP client config
+        1. Download the zip for your architecture
+        2. Extract the zip (contains Sbroenne.WindowsMcp.exe)
+        3. Run Sbroenne.WindowsMcp.exe or add to your MCP client config
 
         ### MCP Client Configuration
 
@@ -96,20 +121,27 @@ jobs:
         {
           "mcpServers": {
             "windows-mcp": {
-              "command": "dotnet",
-              "args": ["path/to/Sbroenne.WindowsMcp.dll"]
+              "command": "path/to/Sbroenne.WindowsMcp.exe"
             }
           }
         }
         ```
 
         See [README](https://github.com/sbroenne/mcp-windows/blob/main/README.md) for full documentation.
-        "@
+        @"
 
         $notes | Out-File -FilePath "release_notes.md" -Encoding utf8
+      shell: pwsh
+
+    - name: Create GitHub Release
+      run: |
+        $tagName = "${{ github.ref_name }}"
+        $version = "${{ env.VERSION }}"
+
+        $assets = Get-ChildItem "windows-mcp-server-$version-*.zip" | Select-Object -ExpandProperty FullName
 
         gh release create "$tagName" `
-          "windows-mcp-server-$version.zip" `
+          $assets `
           --title "Windows MCP Server $tagName" `
           --notes-file release_notes.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/screenshots/
 
 # Runtime screenshots generated during test execution (not committed)
 **/bin/**/screenshots/
+nupkg/

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ The extension automatically configures the MCP server and makes it available to 
 
 ### Option 2: Download from Releases
 
-Download pre-built binaries from the [GitHub Releases page](https://github.com/sbroenne/mcp-windows/releases):
+Download pre-built, self-contained executables from the [GitHub Releases page](https://github.com/sbroenne/mcp-windows/releases) — no .NET runtime required:
 
-1. Download the latest `mcp-windows-v*.zip`
-2. Extract to your preferred location
+1. Pick your architecture zip:
+  - `windows-mcp-server-<version>-win-x64.zip` (most PCs)
+  - `windows-mcp-server-<version>-win-arm64.zip` (Surface Pro X, ARM dev kits)
+2. Extract to your preferred location (contains `Sbroenne.WindowsMcp.exe`)
 3. Add to your MCP client configuration (see [MCP Configuration](#mcp-configuration))
 
 ## Usage
@@ -68,15 +70,12 @@ If you downloaded from the releases page, add to your MCP client configuration:
 {
   "servers": {
     "windows": {
-      "command": "dotnet",
-      "args": ["path/to/extracted/Sbroenne.WindowsMcp.dll"],
+      "command": "path/to/extracted/Sbroenne.WindowsMcp.exe",
       "env": {}
     }
   }
 }
 ```
-
-> **Note:** Releases are framework-dependent and require [.NET 10 Runtime](https://dotnet.microsoft.com/download/dotnet/10.0) to be installed.
 
 ## Tools
 

--- a/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
+++ b/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
@@ -19,6 +19,7 @@
     <Description>MCP Server for Windows automation - UI automation, mouse, keyboard, window management, and screenshots</Description>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
 
     <!-- Version properties - updated by release workflow -->
     <Version>1.0.0</Version>
@@ -29,6 +30,9 @@
     <DebugSymbols Condition="'$(Configuration)' == 'Release'">false</DebugSymbols>
     <DebugType Condition="'$(Configuration)' == 'Release'">none</DebugType>
     <PublishDocumentationFile Condition="'$(Configuration)' == 'Release'">false</PublishDocumentationFile>
+
+    <!-- Optimize single-file size when publishing as self-contained -->
+    <EnableCompressionInSingleFile Condition="'$(Configuration)' == 'Release'">true</EnableCompressionInSingleFile>
 
     <!-- WinRT/C#/Win projection trimming for smaller output -->
     <CsWinRTEnableLogging>false</CsWinRTEnableLogging>
@@ -41,9 +45,6 @@
     <PackageReference Include="Interop.UIAutomationClient" />
   </ItemGroup>
 
-  <!-- UI Automation framework references -->
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WPF" />
-  </ItemGroup>
+  <!-- Windows Forms is enabled via UseWindowsForms; no WPF dependency needed -->
 
 </Project>


### PR DESCRIPTION
## Summary
- switch release workflow to self-contained single-file publish for win-x64/win-arm64 and zip per RID with clarified release notes
- drop WPF dependency, enable invariant globalization, and keep single-file compression to shrink binaries
- update README for standalone exe downloads/config and ignore local nupkg outputs

## Testing
- dotnet publish -c Release -r win-x64 -p:SelfContained=true -p:PublishSingleFile=true
- dotnet publish -c Release -r win-arm64 -p:SelfContained=true -p:PublishSingleFile=true