### PR TITLE
ci: move workflows to Node 24-compatible actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,18 @@ on:
       - 'Directory.Packages.props'
       - '.github/workflows/ci.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   build-and-test:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   analyze:
     name: Analyze
@@ -25,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,9 @@ name: 'Dependency Review'
 
 on: [pull_request]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 permissions:
   contents: read
 
@@ -10,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -22,6 +22,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   deploy:
     environment:
@@ -30,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -17,6 +17,9 @@ on:
   # Allow other workflows to call this
   workflow_call:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   # Run each scenario in isolated jobs for clean UI state
   llm-tests:
@@ -34,10 +37,10 @@ jobs:
           - test_window_workflow.py
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.x
 
@@ -131,7 +134,7 @@ jobs:
       shell: pwsh
 
     - name: Upload LLM Test Report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: llm-test-report-${{ matrix.scenario }}
@@ -148,7 +151,7 @@ jobs:
 
     steps:
     - name: Download all test reports
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         pattern: llm-test-report-*
         path: reports

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -38,6 +38,7 @@ on:
 env:
   DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '22'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   # =============================================================================
@@ -52,7 +53,7 @@ jobs:
       version: ${{ steps.calculate_version.outputs.version }}
       tag: ${{ steps.calculate_version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history and tags
 
@@ -123,10 +124,10 @@ jobs:
     if: vars.AZURE_OPENAI_ENDPOINT != ''
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -154,7 +155,7 @@ jobs:
       shell: pwsh
 
     - name: Upload LLM Test Reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: llm-test-reports
@@ -178,10 +179,10 @@ jobs:
         rid: [win-x64, win-arm64]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -239,7 +240,7 @@ jobs:
       shell: pwsh
 
     - name: Upload Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: standalone-${{ matrix.rid }}
         path: windows-mcp-server-*.zip
@@ -258,15 +259,15 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -355,7 +356,7 @@ jobs:
       shell: pwsh
 
     - name: Upload VSIX Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: vscode-extension
         path: vscode-extension/*.vsix
@@ -371,7 +372,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -405,7 +406,7 @@ jobs:
       shell: pwsh
 
     - name: Download VS Code VSIX
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: vscode-extension
         path: vscode-vsix
@@ -430,7 +431,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set Version
       run: |
@@ -439,14 +440,14 @@ jobs:
       shell: pwsh
 
     - name: Download All Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         path: artifacts
         pattern: standalone-*
         merge-multiple: true
 
     - name: Download VSIX Artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         name: vscode-extension
         path: artifacts


### PR DESCRIPTION
## Summary
- force JavaScript actions onto Node 24 across all workflows
- upgrade the repo's core official GitHub actions to Node 24-compatible majors
- remove the Node 20 deprecation warning path from future runs

## Validation
- git diff --check