### PR TITLE
ci: allow OIDC login without Azure subscriptions

### DIFF
--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -55,6 +55,7 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        allow-no-subscriptions: true
 
     - name: Build MCP Server
       run: dotnet build src/Sbroenne.WindowsMcp -c Release -v:q

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -142,6 +142,7 @@ jobs:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        allow-no-subscriptions: true
 
     - name: Run LLM Integration Tests
       env:


### PR DESCRIPTION
## Summary
- allow azure/login OIDC auth to succeed even when the service principal has no subscriptions
- unblock the LLM test leg used by the release workflows

## Validation
- inspected failed release run 23373564145 and confirmed the blocker was "No subscriptions found" from azure/login
