### PR TITLE
ci: remove Azure subscription requirement from LLM workflows

### DIFF
--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -45,7 +45,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Setup Python & uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.12'
 
@@ -54,7 +54,6 @@ jobs:
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         allow-no-subscriptions: true
 
     - name: Build MCP Server

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -132,7 +132,7 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Setup Python & uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.12'
 
@@ -141,7 +141,6 @@ jobs:
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         allow-no-subscriptions: true
 
     - name: Run LLM Integration Tests


### PR DESCRIPTION
## Summary
- upgrade `astral-sh/setup-uv` to `v7`
- remove `subscription-id` from the Azure OIDC login used by the LLM workflows
- keep `allow-no-subscriptions: true` so the release can authenticate without a subscription-backed context

## Validation
- inspected failed release run 23373661298 and confirmed the blocker was the invalid subscription on `azure/login`
