### PR TITLE
ci: fix release LLM test discovery

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -151,7 +151,7 @@ jobs:
         cd tests/Sbroenne.WindowsMcp.LLM.Tests
         dotnet build ../../src/Sbroenne.WindowsMcp -c Release -v:q
         uv sync
-        uv run pytest test_*.py -v --tb=short --junitxml=TestResults/results.xml -p no:aitest-summary
+        uv run pytest -v --tb=short --junitxml=TestResults/results.xml -p no:aitest-summary
       shell: pwsh
 
     - name: Upload LLM Test Reports


### PR DESCRIPTION
## Summary
- use default pytest discovery in the unified release workflow
- avoid the broken `test_*.py` argument that matched no files on the runner
- unblock the release after Azure login succeeds

## Validation
- inspected failed release run 23373721487 and confirmed pytest exited with "file or directory not found: test_*.py"
