### PR TITLE
ci: align release LLM step with llm workflow

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -146,12 +146,13 @@ jobs:
     - name: Run LLM Integration Tests
       env:
         AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         UV_LINK_MODE: copy
       run: |
         cd tests/Sbroenne.WindowsMcp.LLM.Tests
         dotnet build ../../src/Sbroenne.WindowsMcp -c Release -v:q
         uv sync
-        uv run pytest -v --tb=short --junitxml=TestResults/results.xml -p no:aitest-summary
+        uv run pytest test_notepad_ui.py test_calculator_workflow.py test_window_workflow.py -v --tb=short --junitxml=TestResults/results.xml --aitest-report=TestResults/report.html --no-header -p no:aitest-summary
       shell: pwsh
 
     - name: Upload LLM Test Reports


### PR DESCRIPTION
## Summary
- export GITHUB_TOKEN in the unified release LLM step
- run the same three scenario files as the dedicated llm-tests.yml workflow
- keep the release LLM lane aligned with the known supported CI slice

## Testing
- workflow-only change