### PR TITLE
ci: remove unsupported aitest report flag

### DIFF
--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -86,7 +86,7 @@ jobs:
         }
 
         Write-Output "Running scenario: $matrixScenario"
-        uv run pytest $matrixScenario -v --tb=short --junitxml=TestResults/results.xml --aitest-report=TestResults/report.html --no-header -p no:aitest-summary 2>&1 | Tee-Object -Variable testOutput
+        uv run pytest $matrixScenario -v --tb=short --junitxml=TestResults/results.xml --no-header -p no:aitest-summary 2>&1 | Tee-Object -Variable testOutput
         $testOutput | ForEach-Object { Write-Output $_ }
       shell: pwsh
 

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -152,7 +152,7 @@ jobs:
         cd tests/Sbroenne.WindowsMcp.LLM.Tests
         dotnet build ../../src/Sbroenne.WindowsMcp -c Release -v:q
         uv sync
-        uv run pytest test_notepad_ui.py test_calculator_workflow.py test_window_workflow.py -v --tb=short --junitxml=TestResults/results.xml --aitest-report=TestResults/report.html --no-header -p no:aitest-summary
+        uv run pytest test_notepad_ui.py test_calculator_workflow.py test_window_workflow.py -v --tb=short --junitxml=TestResults/results.xml --no-header -p no:aitest-summary
       shell: pwsh
 
     - name: Upload LLM Test Reports


### PR DESCRIPTION
## Summary
- remove the unsupported --aitest-report argument from llm-tests.yml`n- remove the same unsupported argument from elease-unified.yml`n- keep junit output and existing summary/report upload behavior intact

## Testing
- workflow-only change