### PR TITLE
test: migrate LLM suite to pytest-skill-engineering

### DIFF
--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/README.md
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/README.md
@@ -1,6 +1,6 @@
 # Windows MCP Server - LLM Integration Tests
 
-This project contains integration tests for the Windows MCP Server using [pytest-aitest](https://github.com/sbroenne/pytest-aitest) — a pytest plugin for testing AI agents with MCP tools.
+This project contains integration tests for the Windows MCP Server using [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering) — the successor to `pytest-aitest` for testing AI agents with MCP tools.
 
 ## Test Applications
 
@@ -115,11 +115,11 @@ Tool-level tests that verify individual MCP tool functionality. Run with `gpt-4.
 
 ## Writing Tests
 
-Tests use pytest-aitest's `aitest_run` fixture:
+Tests use `pytest-skill-engineering` via the local `aitest_run` compatibility fixture, which currently delegates to the package's `eval_run` fixture:
 
 ```python
 import pytest
-from pytest_aitest import Agent, MCPServer, Provider
+from pytest_skill_engineering import Eval as Agent, MCPServer, Provider
 
 async def test_example(aitest_run):
     result = await aitest_run(
@@ -166,8 +166,8 @@ assert not result.asked_for_clarification
 
 ## Test Reports
 
-HTML reports are generated when using `--aitest-report`:
+HTML reports are generated when using `--aitest-html` together with an AI summary model:
 
 ```powershell
-uv run pytest test_notepad_ui.py -v --aitest-report=TestResults/report.html
+uv run pytest test_notepad_ui.py -v --aitest-summary-model=azure/gpt-5.2-chat --aitest-html=TestResults/report.html
 ```

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/conftest.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/conftest.py
@@ -12,7 +12,12 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from pytest_aitest import Agent, ClarificationDetection, MCPServer, Provider
+from pytest_skill_engineering import (
+    Eval as Agent,
+    ClarificationDetection,
+    MCPServer,
+    Provider,
+)
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -67,6 +72,12 @@ def _build_mcp_server():
 def windows_mcp_server():
     """The Windows MCP Server under test."""
     return MCPServer(command=SERVER_COMMAND)
+
+
+@pytest.fixture
+def aitest_run(eval_run):
+    """Temporary compatibility alias while migrating to pytest-skill-engineering."""
+    return eval_run
 
 
 @pytest.fixture(scope="session")

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/eval/test_4sysops_cursortouch.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/eval/test_4sysops_cursortouch.py
@@ -11,7 +11,7 @@ Key Differences:
 """
 
 import pytest
-from pytest_aitest import Agent, ClarificationDetection, MCPServer, Provider
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection, MCPServer, Provider
 
 from conftest import (
     SYSTEM_PROMPT,

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_app_tool_uwp.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_app_tool_uwp.py
@@ -14,7 +14,7 @@ from conftest import (
     assert_quality,
     assert_tool_called,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_file_dialog.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_file_dialog.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_quality,
     assert_tool_called,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_keyboard_mouse.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_keyboard_mouse.py
@@ -18,7 +18,7 @@ from conftest import (
     assert_tool_param_equals,
     assert_tool_param_matches,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_paint_ui.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_paint_ui.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_tool_called,
     assert_tool_param_equals,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_run_dialog.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_run_dialog.py
@@ -14,7 +14,7 @@ from conftest import (
     assert_quality,
     assert_tool_called,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_screenshot.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_screenshot.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_tool_called,
     assert_tool_param_equals,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_window_activate.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_window_activate.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_quality,
     assert_tool_param_matches,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_window_management.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/integration/test_window_management.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_tool_called,
     assert_tool_param_equals,
 )
-from pytest_aitest import Agent, ClarificationDetection
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection
 
 
 def _agent(windows_mcp_server, gpt41_provider):

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
@@ -1,13 +1,17 @@
 [project]
 name = "mcp-windows-llm-tests"
 version = "0.1.0"
-description = "LLM integration tests for Windows MCP Server using pytest-aitest"
+description = "LLM integration tests for Windows MCP Server using pytest-skill-engineering"
 requires-python = ">=3.12"
 dependencies = [
-    "pytest-aitest",
+    "pytest-skill-engineering",
     "anyio",
     "pytest-asyncio",
+    "trio",
 ]
+
+[tool.uv.sources]
+pytest-skill-engineering = { git = "https://github.com/sbroenne/pytest-skill-engineering", rev = "373ddaea012af61808e0ae5715607c34b865bd34" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/test_notepad_ui.py
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/test_notepad_ui.py
@@ -15,7 +15,7 @@ from conftest import (
     assert_tool_param_matches,
     make_agents,
 )
-from pytest_aitest import Agent, ClarificationDetection, MCPServer, Provider
+from pytest_skill_engineering import Eval as Agent, ClarificationDetection, MCPServer, Provider
 
 
 def _agents(windows_mcp_server, gpt41_provider, gpt52_provider):


### PR DESCRIPTION
Summary:
- switch the LLM test project from pytest-aitest to pytest-skill-engineering
- add a temporary aitest_run compatibility fixture to minimize churn
- pin the dependency to the GitHub successor repo so CI uses the current 0.5.7 code instead of the stale package-index release

Testing:
- python -m py_compile on migrated test modules
- branch CI run is in progress