### PR TITLE
Fix release LLM skip cache cleanup

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -140,6 +140,9 @@ jobs:
       run: |
         if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
           Write-Warning "COPILOT_GITHUB_TOKEN is not configured; skipping release LLM integration tests."
+          if (-not [string]::IsNullOrWhiteSpace($env:UV_CACHE_DIR)) {
+            New-Item -ItemType Directory -Path $env:UV_CACHE_DIR -Force | Out-Null
+          }
           exit 0
         }
 


### PR DESCRIPTION
## Summary
- create the uv cache directory before intentionally skipping release LLM tests without COPILOT_GITHUB_TOKEN
- prevents setup-uv post-job cleanup from failing the release workflow on the skip path

## Validation
- diagnosed from release run 25168025117