### PR TITLE
Disable uv cache for release LLM gate

### DIFF
--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -132,6 +132,7 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         python-version: '3.12'
+        enable-cache: false
 
     - name: Run LLM Integration Tests
       env:


### PR DESCRIPTION
## Summary
- disable setup-uv caching for the release LLM job
- prevents uv post-job cache pruning failures when LLM tests are intentionally skipped without COPILOT_GITHUB_TOKEN

## Validation
- diagnosed from release runs 25168025117 and 25168454271