### PR TITLE
ci: pin release workflow action refs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v5
+        uses: actions/dependency-review-action@v5.0.0
         with:
           fail-on-severity: high
           comment-summary-in-pr: always

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -44,7 +44,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Setup Python & uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: '3.12'
 

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -129,7 +129,7 @@ jobs:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
     - name: Setup Python & uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: '3.12'
         enable-cache: false


### PR DESCRIPTION
## Summary
- Pin action refs that do not publish moving major tags.
- Restore release workflow resolution after the dependency update.

## Validation
- actionlint
- Confirmed exact action tags resolve via GitHub API.