### PR TITLE
ci: align VS Code engine with type definitions

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "vscode": "^1.118.0"
+        "vscode": "^1.120.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/sbroenne/mcp-windows",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.118.0"
+    "vscode": "^1.120.0"
   },
   "os": [
     "win32"


### PR DESCRIPTION
## Summary
- Update the VS Code extension engine requirement to match @types/vscode 1.120.0.
- Fix VSIX packaging after the dependency update.

## Validation
- npm run package --prefix vscode-extension