### PR TITLE
fix: emit boolean JSON-schema type for screenshot includeImage parameter

### DIFF
--- a/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/ScreenshotControlTool.cs
@@ -77,7 +77,7 @@ public static partial class ScreenshotControlTool
         [DefaultValue(null)] int? quality,
         [DefaultValue(null)] string? outputMode,
         [DefaultValue(null)] string? outputPath,
-        [DefaultValue(null)] bool? includeImage,
+        [DefaultValue(false)] bool includeImage,
         CancellationToken cancellationToken)
     {
         try
@@ -172,7 +172,7 @@ public static partial class ScreenshotControlTool
             {
                 // Default: don't include image for annotated screenshots (element metadata is sufficient)
                 // This saves ~100K+ tokens per screenshot
-                var shouldIncludeImage = includeImage ?? false;
+                var shouldIncludeImage = includeImage;
                 return await CaptureAnnotatedAsync(windowHandle, parsedImageFormat, parsedQuality, parsedOutputMode, outputPath, shouldIncludeImage, cancellationToken);
             }
 


### PR DESCRIPTION
## Problem

`screenshot_control` fails instantly with `An error occurred invoking 'screenshot_control'` whenever `includeImage` is set to `true`. Capturing to a file (`outputMode=file`, without `includeImage`) works fine, which made it look image- or size-related — it is not.

## Root cause

`includeImage` was declared as a nullable `bool?`:

```csharp
[DefaultValue(null)] bool? includeImage,
```

The MCP SDK schema generator does **not** emit a `"type"` for a nullable bool. Compare the generated `tools/list` schema:

- `includeCursor` (`bool`): `{"type":"boolean","default":false}`
- `includeImage` (`bool?`): `{"description":"...","default":null}`  ← no `type`

With no declared type, the client serializes the argument as the string `"true"`. The server's nullable-bool argument binder cannot convert a JSON string to `bool?` and throws, before any screenshot work happens. (The `int?` binder coerces strings, which is why `quality` and other nullable params were unaffected.)

## Fix

Make the parameter a non-nullable `bool` with a `false` default (matching `includeCursor`):

```csharp
[DefaultValue(false)] bool includeImage,
...
var shouldIncludeImage = includeImage;
```

Behavior is unchanged — `null` was already collapsed to `false` via `includeImage ?? false`. The schema now advertises `"type":"boolean"`, so clients send a real boolean and binding succeeds.

## Verification

- Build: clean (0 warnings / 0 errors).
- `tools/list` now reports `"includeImage":{...,"type":"boolean","default":false}`.
- End-to-end against a live client: `screenshot_control(annotate=true, includeImage=true)` and `list_monitors` + `includeImage=true` both succeed; previously both returned the invocation error.