### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,15 +4,15 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Main application packages -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Interop.UIAutomationClient" Version="10.19041.0" />
     <!-- Test packages -->
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="SharpToken" Version="2.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

Bumps four .NET packages in `Directory.Packages.props` to their latest stable versions:

| Package | From | To |
|---|---|---|
| ModelContextProtocol | 1.3.0 | 1.4.0 |
| Microsoft.Extensions.Hosting | 10.0.8 | 10.0.9 |
| Microsoft.Extensions.Logging | 10.0.8 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.5.1 | 18.7.0 |

All other dependencies were already on their latest stable releases. Prerelease-only updates (MCP 2.0 preview, Extensions 11 preview, NSubstitute 6 RC, WindowsAppSDK experimental) were intentionally skipped.

## Verification

- `dotnet build -c Release` succeeded, 0 warnings / 0 errors
- `dotnet test` (Unit filter) 259 passed, 0 failed

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>