### PR TITLE
refactor: standardize tools on CallToolResult + bump ModelContextProtocol SDK to 1.4.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Main application packages -->
-    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="Interop.UIAutomationClient" Version="10.19041.0" />

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIClickTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIClickTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -30,9 +31,9 @@ public static partial class UIClickTool
     /// <param name="foundIndex">Return Nth match (1-based, default: 1).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of the click operation including success status and element information.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload describing the click operation's success status and element information. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_click", Title = "Click UI Element", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         [DefaultValue(null)] string? name,
         [DefaultValue(null)] string? nameContains,
@@ -48,7 +49,7 @@ public static partial class UIClickTool
 
         if (string.IsNullOrWhiteSpace(windowHandle))
         {
-            return WindowsToolsBase.Fail(
+            return WindowsToolsBase.FailResult(
                 "windowHandle is required. Get it from window_management(action='find').");
         }
 
@@ -67,11 +68,11 @@ public static partial class UIClickTool
             };
 
             var result = await WindowsToolsBase.UIAutomationService.FindAndClickAsync(query, cancellationToken);
-            return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+            return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIFileTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIFileTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -26,9 +27,9 @@ public static partial class UIFileTool
     /// <param name="filePath">Full path to save to (e.g., C:/Users/User/doc.txt). REQUIRED for new files. Forward/back slashes both work.</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Success status.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload describing the save operation's success status. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "file_save", Title = "💾 SAVE FILE (handles Save As dialogs)", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         [DefaultValue(null)] string? filePath,
         [DefaultValue(false)] bool includeDiagnostics,
@@ -38,18 +39,18 @@ public static partial class UIFileTool
 
         if (string.IsNullOrWhiteSpace(windowHandle))
         {
-            return WindowsToolsBase.Fail(
+            return WindowsToolsBase.FailResult(
                 "windowHandle is required. Get it from window_management(action='find'). Pass the APPLICATION window, not a dialog.");
         }
 
         try
         {
             var result = await WindowsToolsBase.UIAutomationService.SaveAsync(windowHandle, filePath, cancellationToken);
-            return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+            return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -37,9 +38,9 @@ public static partial class UIFindTool
     /// <param name="timeoutMs">Timeout in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result containing list of found elements with their properties and element IDs.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload listing found elements and their properties (including element IDs). <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_find", Title = "Find UI Elements", Destructive = false, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         [DefaultValue(null)] string? name,
         [DefaultValue(null)] string? nameContains,
@@ -61,7 +62,7 @@ public static partial class UIFindTool
 
         if (string.IsNullOrWhiteSpace(windowHandle))
         {
-            return WindowsToolsBase.Fail(
+            return WindowsToolsBase.FailResult(
                 "windowHandle is required. Get it from window_management(action='find').");
         }
 
@@ -86,11 +87,11 @@ public static partial class UIFindTool
             };
 
             var result = await WindowsToolsBase.UIAutomationService.FindElementsAsync(query, cancellationToken);
-            return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+            return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIReadTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIReadTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Native;
 using Sbroenne.WindowsMcp.Tools;
@@ -31,9 +32,9 @@ public static partial class UIReadTool
     /// <param name="language">OCR language code (e.g., 'en-US', 'de-DE'). Uses system default if not specified. Only used if OCR fallback triggers.</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The extracted text content from the element or screen region.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload of the extracted text content from the element or screen region. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_read", Title = "Read Text from Element", Destructive = false, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         [DefaultValue(null)] string? name,
         [DefaultValue(null)] string? nameContains,
@@ -51,7 +52,7 @@ public static partial class UIReadTool
 
         if (string.IsNullOrWhiteSpace(windowHandle))
         {
-            return WindowsToolsBase.Fail(
+            return WindowsToolsBase.FailResult(
                 "windowHandle is required. Get it from window_management(action='find').");
         }
 
@@ -88,7 +89,7 @@ public static partial class UIReadTool
             var result = await automationService.GetTextAsync(elementIdToRead, windowHandle, includeChildren, cancellationToken);
             if (result.Success && !string.IsNullOrWhiteSpace(result.Text))
             {
-                return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+                return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
             }
 
             // Fallback: try OCR on the window region
@@ -96,12 +97,12 @@ public static partial class UIReadTool
             {
                 if (!nint.TryParse(windowHandle, out var hwnd) || hwnd == IntPtr.Zero)
                 {
-                    return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+                    return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
                 }
 
                 if (!NativeMethods.GetWindowRect(hwnd, out var rect))
                 {
-                    return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+                    return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
                 }
 
                 var captureRect = new System.Drawing.Rectangle(rect.Left, rect.Top, rect.Right - rect.Left, rect.Bottom - rect.Top);
@@ -119,7 +120,7 @@ public static partial class UIReadTool
                     {
                         UsageHint = $"Text extracted via OCR (fallback). Engine: {ocrResult.Engine}, Duration: {ocrResult.DurationMs}ms"
                     };
-                    return WindowsToolsBase.SerializeUIResult(ocrSuccessResult, includeDiagnostics);
+                    return WindowsToolsBase.ToCallToolResult(ocrSuccessResult, includeDiagnostics);
                 }
             }
             catch (Exception) when (!cancellationToken.IsCancellationRequested)
@@ -127,11 +128,11 @@ public static partial class UIReadTool
                 // OCR fallback failed - ignore and return original result
             }
 
-            return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+            return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UITypeTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UITypeTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -34,9 +35,9 @@ public static partial class UITypeTool
     /// <param name="clearFirst">Clear existing text before typing (default: false).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of the type operation including success status and element information.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload describing the type operation's success status and element information. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_type", Title = "Type Text into Element", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         string text,
         [DefaultValue(null)] string? name,
@@ -54,13 +55,13 @@ public static partial class UITypeTool
 
         if (string.IsNullOrWhiteSpace(windowHandle))
         {
-            return WindowsToolsBase.Fail(
+            return WindowsToolsBase.FailResult(
                 "windowHandle is required. Get it from window_management(action='find').");
         }
 
         if (string.IsNullOrEmpty(text))
         {
-            return WindowsToolsBase.Fail("text is required.");
+            return WindowsToolsBase.FailResult("text is required.");
         }
 
         try
@@ -78,11 +79,11 @@ public static partial class UITypeTool
             };
 
             var result = await WindowsToolsBase.UIAutomationService.FindAndTypeAsync(query, text, clearFirst, cancellationToken);
-            return WindowsToolsBase.SerializeUIResult(result, includeDiagnostics);
+            return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Tools/AppTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/AppTool.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
 namespace Sbroenne.WindowsMcp.Tools;
@@ -48,9 +49,9 @@ public static partial class AppTool
     /// <param name="waitForWindow">Wait for the application window to appear before returning (default: true). Set to false for background processes.</param>
     /// <param name="timeoutMs">Timeout in milliseconds to wait for the window to appear (default: 5000).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of the launch operation including the window handle for subsequent operations.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload of the launch operation, including the window handle for subsequent operations. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "app", Title = "Launch Application", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string programPath,
         [DefaultValue(null)] string? arguments,
         [DefaultValue(null)] string? workingDirectory,
@@ -63,20 +64,41 @@ public static partial class AppTool
         try
         {
             var result = await HandleLaunchAsync(programPath, arguments, workingDirectory, waitForWindow, timeoutMs, cancellationToken);
-            return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(result);
         }
         catch (OperationCanceledException)
         {
             var errorResult = WindowManagementResult.CreateFailure(
                 WindowManagementErrorCode.Timeout,
                 "Operation was cancelled");
-            return JsonSerializer.Serialize(errorResult, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(errorResult);
         }
         catch (Exception ex)
         {
-            return WindowsToolsBase.SerializeToolError(actionName, ex);
+            return ErrorResult(WindowsToolsBase.SerializeToolError(actionName, ex));
         }
     }
+
+    /// <summary>
+    /// Converts a window management result into an MCP call result. <see cref="CallToolResult.IsError"/>
+    /// mirrors <see cref="WindowManagementResult.Success"/>.
+    /// </summary>
+    private static CallToolResult ToCallToolResult(WindowManagementResult result) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions) }],
+            IsError = !result.Success
+        };
+
+    /// <summary>
+    /// Wraps a pre-serialized JSON error payload in a failed call result.
+    /// </summary>
+    private static CallToolResult ErrorResult(string json) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = json }],
+            IsError = true
+        };
 
     private static async Task<WindowManagementResult> HandleLaunchAsync(
         string? programPath,

--- a/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Native;
 using Sbroenne.WindowsMcp.Serialization;
@@ -32,9 +33,9 @@ public static partial class KeyboardControlTool
     /// <param name="interKeyDelayMs">Delay between keys in sequence (milliseconds).</param>
     /// <param name="clearFirst">For type action only: If true, clears the current field content before typing by sending Ctrl+A (select all) followed by the new text.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result includes success status, operation details, and 'target_window' (handle, title, process_name) showing which window received the input.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload including success status, operation details, and 'target_window' (handle, title, process_name) showing which window received the input. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "keyboard_control", Title = "Keyboard Control", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         string windowHandle,
         KeyboardAction action,
         [DefaultValue(null)] string? text,
@@ -51,21 +52,19 @@ public static partial class KeyboardControlTool
             // Validate windowHandle is provided
             if (string.IsNullOrWhiteSpace(windowHandle))
             {
-                return JsonSerializer.Serialize(
+                return ToCallToolResult(
                     KeyboardControlResult.CreateFailure(
                         KeyboardControlErrorCode.MissingRequiredParameter,
-                        "windowHandle is required. Get it from app() or window_management(action='find')."),
-                    WindowsToolsBase.JsonOptions);
+                        "windowHandle is required. Get it from app() or window_management(action='find')."));
             }
 
             // Parse windowHandle
             if (!long.TryParse(windowHandle, out var handleValue) || handleValue == 0)
             {
-                return JsonSerializer.Serialize(
+                return ToCallToolResult(
                     KeyboardControlResult.CreateFailure(
                         KeyboardControlErrorCode.InvalidAction,
-                        $"Invalid windowHandle '{windowHandle}'. Must be a non-zero decimal number from app() or window_management."),
-                    WindowsToolsBase.JsonOptions);
+                        $"Invalid windowHandle '{windowHandle}'. Must be a non-zero decimal number from app() or window_management."));
             }
 
             var handle = new IntPtr(handleValue);
@@ -79,11 +78,10 @@ public static partial class KeyboardControlTool
             var activationResult = await WindowsToolsBase.WindowService.ActivateWindowAsync(handle, linkedToken);
             if (!activationResult.Success)
             {
-                return JsonSerializer.Serialize(
+                return ToCallToolResult(
                     KeyboardControlResult.CreateFailure(
                         KeyboardControlErrorCode.WrongTargetWindow,
-                        $"Failed to activate window {windowHandle}: {activationResult.Error}"),
-                    WindowsToolsBase.JsonOptions);
+                        $"Failed to activate window {windowHandle}: {activationResult.Error}"));
             }
 
             // Small delay to let the window settle after activation
@@ -138,21 +136,41 @@ public static partial class KeyboardControlTool
                 operationResult = await AttachTargetWindowInfoAsync(operationResult, linkedToken);
             }
 
-            return JsonSerializer.Serialize(operationResult, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(operationResult);
         }
         catch (OperationCanceledException)
         {
-            return JsonSerializer.Serialize(
+            return ToCallToolResult(
                 KeyboardControlResult.CreateFailure(
                     KeyboardControlErrorCode.OperationTimeout,
-                    $"Operation timed out after {WindowsToolsBase.TimeoutMs}ms"),
-                WindowsToolsBase.JsonOptions);
+                    $"Operation timed out after {WindowsToolsBase.TimeoutMs}ms"));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return WindowsToolsBase.SerializeToolError("keyboard_control", ex);
+            return ErrorResult(WindowsToolsBase.SerializeToolError("keyboard_control", ex));
         }
     }
+
+    /// <summary>
+    /// Converts a keyboard control result into an MCP call result. <see cref="CallToolResult.IsError"/>
+    /// mirrors <see cref="KeyboardControlResult.Success"/>.
+    /// </summary>
+    private static CallToolResult ToCallToolResult(KeyboardControlResult result) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions) }],
+            IsError = !result.Success
+        };
+
+    /// <summary>
+    /// Wraps a pre-serialized JSON error payload in a failed call result.
+    /// </summary>
+    private static CallToolResult ErrorResult(string json) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = json }],
+            IsError = true
+        };
 
     private static async Task<KeyboardControlResult> HandleTypeAsync(string? text, bool clearFirst, CancellationToken cancellationToken)
     {

--- a/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Native;
 
@@ -48,9 +49,9 @@ public static partial class MouseControlTool
     /// <param name="expectedProcessName">Expected process name. If specified, operation fails if foreground window's process doesn't match.</param>
     /// <param name="windowHandle">Window handle for window-relative coordinates. When provided, x/y are relative to the window's top-left corner.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result includes success status, cursor position, monitor context, and 'target_window' for click actions.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload including success status, cursor position, monitor context, and 'target_window' for click actions. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "mouse_control", Title = "Mouse Control", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         MouseAction action,
         [DefaultValue(null)] string? target,
         [DefaultValue(null)] int? x,
@@ -80,7 +81,7 @@ public static partial class MouseControlTool
                 var targetCheckResult = await VerifyTargetWindowAsync(expectedWindowTitle, expectedProcessName, linkedToken);
                 if (!targetCheckResult.Success)
                 {
-                    return JsonSerializer.Serialize(targetCheckResult, WindowsToolsBase.JsonOptions);
+                    return ToCallToolResult(targetCheckResult);
                 }
             }
 
@@ -99,7 +100,7 @@ public static partial class MouseControlTool
                     var result = MouseControlResult.CreateFailure(
                         MouseControlErrorCode.InvalidCoordinates,
                         $"Invalid windowHandle: '{windowHandle}'. Expected decimal string from window_management.");
-                    return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                    return ToCallToolResult(result);
                 }
 
                 // Get window rect
@@ -108,7 +109,7 @@ public static partial class MouseControlTool
                     var result = MouseControlResult.CreateFailure(
                         MouseControlErrorCode.InvalidCoordinates,
                         $"Could not get window position for handle {windowHandle}. The window may no longer exist.");
-                    return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                    return ToCallToolResult(result);
                 }
 
                 windowLeft = windowRect.Left;
@@ -144,7 +145,7 @@ public static partial class MouseControlTool
                     var result = MouseControlResult.CreateFailure(
                         MouseControlErrorCode.InvalidCoordinates,
                         $"Invalid target: '{target}'. Valid values are: 'primary_screen', 'secondary_screen'");
-                    return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                    return ToCallToolResult(result);
                 }
 
                 // Resolve target to monitor index
@@ -163,7 +164,7 @@ public static partial class MouseControlTool
                     var result = MouseControlResult.CreateFailure(
                         MouseControlErrorCode.InvalidCoordinates,
                         errorMessage);
-                    return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                    return ToCallToolResult(result);
                 }
 
                 // Find the index of this monitor
@@ -190,7 +191,7 @@ public static partial class MouseControlTool
                         { "valid_targets", ValidTargets },
                         { "valid_indices", availableIndices }
                     });
-                return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                return ToCallToolResult(result);
             }
 
             // Use resolved monitorIndex, windowBasedMonitorIndex, or default to 0 for coordinate-less actions
@@ -208,7 +209,7 @@ public static partial class MouseControlTool
                         { "valid_indices", availableIndices },
                         { "provided_index", targetMonitorIndex }
                     });
-                return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                return ToCallToolResult(result);
             }
 
             // Translate coordinates to absolute screen coordinates
@@ -219,7 +220,7 @@ public static partial class MouseControlTool
                 var result = MouseControlResult.CreateFailure(
                     MouseControlErrorCode.InvalidCoordinates,
                     $"Invalid monitor index: {monitorIndex}. Available monitors: 0-{WindowsToolsBase.MonitorService.MonitorCount - 1}");
-                return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                return ToCallToolResult(result);
             }
 
             if (isWindowRelativeMode)
@@ -284,7 +285,7 @@ public static partial class MouseControlTool
                                 { "valid_bounds", new { left = monitor.X, top = monitor.Y, right = monitor.X + monitor.Width, bottom = monitor.Y + monitor.Height } },
                                 { "provided_coordinates", new { x = x.Value, y = y.Value } }
                             });
-                        return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                        return ToCallToolResult(result);
                     }
                 }
 
@@ -300,7 +301,7 @@ public static partial class MouseControlTool
                                 { "valid_bounds", new { left = monitor.X, top = monitor.Y, right = monitor.X + monitor.Width, bottom = monitor.Y + monitor.Height } },
                                 { "provided_coordinates", new { x = endX.Value, y = endY.Value } }
                             });
-                        return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+                        return ToCallToolResult(result);
                     }
                 }
             }
@@ -377,20 +378,41 @@ public static partial class MouseControlTool
                 }
             }
 
-            return JsonSerializer.Serialize(operationResult, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(operationResult);
         }
         catch (OperationCanceledException)
         {
             var errorResult = MouseControlResult.CreateFailure(
                 MouseControlErrorCode.OperationTimeout,
                 $"Operation timed out after {WindowsToolsBase.TimeoutMs}ms");
-            return JsonSerializer.Serialize(errorResult, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(errorResult);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return WindowsToolsBase.SerializeToolError("mouse_control", ex);
+            return ErrorResult(WindowsToolsBase.SerializeToolError("mouse_control", ex));
         }
     }
+
+    /// <summary>
+    /// Converts a mouse control result into an MCP call result. <see cref="CallToolResult.IsError"/>
+    /// mirrors <see cref="MouseControlResult.Success"/>.
+    /// </summary>
+    private static CallToolResult ToCallToolResult(MouseControlResult result) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions) }],
+            IsError = !result.Success
+        };
+
+    /// <summary>
+    /// Wraps a pre-serialized JSON error payload in a failed call result.
+    /// </summary>
+    private static CallToolResult ErrorResult(string json) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = json }],
+            IsError = true
+        };
 
     private static async Task<MouseControlResult> HandleMoveAsync(int? x, int? y, CancellationToken cancellationToken)
     {

--- a/src/Sbroenne.WindowsMcp/Tools/WindowManagementTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/WindowManagementTool.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using Sbroenne.WindowsMcp.Native;
 
@@ -51,9 +52,9 @@ public static partial class WindowManagementTool
     /// <param name="excludeTitle">Window title to exclude from list results (for list action).</param>
     /// <param name="discardChanges">For close action: if true, automatically dismisses 'Save?' dialogs by clicking 'Don't Save'. Only works on English Windows. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The result of the window operation including success status and window information.</returns>
+    /// <returns>A call result containing a text content block with the JSON payload of the window operation, including success status and window information. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "window_management", Title = "Window Management", Destructive = true, OpenWorld = false)]
-    public static async partial Task<string> ExecuteAsync(
+    public static async partial Task<CallToolResult> ExecuteAsync(
         WindowAction action,
         [DefaultValue(null)] string? handle,
         [DefaultValue(null)] string? title,
@@ -153,27 +154,47 @@ public static partial class WindowManagementTool
                     break;
             }
 
-            return JsonSerializer.Serialize(operationResult, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(operationResult);
         }
         catch (OperationCanceledException)
         {
-            return JsonSerializer.Serialize(
+            return ToCallToolResult(
                 WindowManagementResult.CreateFailure(
                     WindowManagementErrorCode.Timeout,
-                    "Operation was cancelled"),
-                WindowsToolsBase.JsonOptions);
+                    "Operation was cancelled"));
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            return WindowsToolsBase.SerializeToolError("window_management", ex);
+            return ErrorResult(WindowsToolsBase.SerializeToolError("window_management", ex));
         }
     }
+
+    /// <summary>
+    /// Converts a window management result into an MCP call result. <see cref="CallToolResult.IsError"/>
+    /// mirrors <see cref="WindowManagementResult.Success"/>.
+    /// </summary>
+    private static CallToolResult ToCallToolResult(WindowManagementResult result) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions) }],
+            IsError = !result.Success
+        };
+
+    /// <summary>
+    /// Wraps a pre-serialized JSON error payload in a failed call result.
+    /// </summary>
+    private static CallToolResult ErrorResult(string json) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = json }],
+            IsError = true
+        };
 
     /// <summary>
     /// Handles the list action, returning a slim JSON response with only
     /// handle, title, and process name per window to minimize token usage.
     /// </summary>
-    private static async Task<string> HandleListSerializedAsync(
+    private static async Task<CallToolResult> HandleListSerializedAsync(
         string? filter,
         bool useRegex,
         bool includeAllDesktops,
@@ -184,7 +205,7 @@ public static partial class WindowManagementTool
 
         if (!result.Success)
         {
-            return JsonSerializer.Serialize(result, WindowsToolsBase.JsonOptions);
+            return ToCallToolResult(result);
         }
 
         var windows = result.Windows ?? [];
@@ -203,7 +224,11 @@ public static partial class WindowManagementTool
             count = windows.Count
         };
 
-        return JsonSerializer.Serialize(slimResult, WindowsToolsBase.JsonOptions);
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(slimResult, WindowsToolsBase.JsonOptions) }],
+            IsError = false
+        };
     }
 
     private static async Task<WindowManagementResult> HandleFindAsync(

--- a/src/Sbroenne.WindowsMcp/Tools/WindowsToolsBase.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/WindowsToolsBase.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
 using Sbroenne.WindowsMcp.Automation;
 using Sbroenne.WindowsMcp.Capture;
 using Sbroenne.WindowsMcp.Input;
@@ -222,6 +223,53 @@ public static class WindowsToolsBase
         }
 
         return JsonSerializer.Serialize(result, JsonOptions);
+    }
+
+    /// <summary>
+    /// Converts a UI automation result into an MCP call result, stripping diagnostics unless
+    /// explicitly requested. <see cref="CallToolResult.IsError"/> mirrors <see cref="UIAutomationResult.Success"/>.
+    /// </summary>
+    /// <param name="result">The UI automation result.</param>
+    /// <param name="includeDiagnostics">Whether to include diagnostics in the response.</param>
+    /// <returns>A call result carrying the serialized JSON payload.</returns>
+    public static CallToolResult ToCallToolResult(UIAutomationResult result, bool includeDiagnostics)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = SerializeUIResult(result, includeDiagnostics) }],
+            IsError = !result.Success
+        };
+    }
+
+    /// <summary>
+    /// Wraps a failure message in a failed MCP call result.
+    /// </summary>
+    /// <param name="error">Error message.</param>
+    /// <returns>A failed call result carrying the serialized JSON error payload.</returns>
+    public static CallToolResult FailResult(string error)
+    {
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = Fail(error) }],
+            IsError = true
+        };
+    }
+
+    /// <summary>
+    /// Wraps a tool exception into a failed MCP call result with consistent structure.
+    /// </summary>
+    /// <param name="actionName">Action that failed.</param>
+    /// <param name="ex">Exception that occurred.</param>
+    /// <returns>A failed call result carrying the serialized JSON error payload.</returns>
+    public static CallToolResult ErrorCallToolResult(string actionName, Exception ex)
+    {
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = SerializeToolError(actionName, ex) }],
+            IsError = true
+        };
     }
 
     private static int GetTimeoutFromEnvironment()

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/AppLaunchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/AppLaunchTests.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -24,9 +25,10 @@ public class AppLaunchTests : IClassFixture<WindowTestFixture>
         _fixture = fixture;
     }
 
-    private static WindowManagementResult DeserializeResult(string json)
+    private static WindowManagementResult DeserializeResult(CallToolResult callResult)
     {
-        return JsonSerializer.Deserialize<WindowManagementResult>(json, WindowsToolsBase.JsonOptions)!;
+        var text = Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
+        return JsonSerializer.Deserialize<WindowManagementResult>(text, WindowsToolsBase.JsonOptions)!;
     }
 
     [Fact]

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WindowCloseActionTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WindowCloseActionTests.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -23,9 +24,15 @@ public sealed class WindowCloseActionTests : IAsyncLifetime, IDisposable
 
     private const string SacrificialWindowTitle = "MCP Close Test Window";
 
-    private static WindowManagementResult DeserializeResult(string json)
+    private static WindowManagementResult DeserializeResult(CallToolResult callResult)
     {
-        return JsonSerializer.Deserialize<WindowManagementResult>(json, WindowsToolsBase.JsonOptions)!;
+        var text = Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
+        return JsonSerializer.Deserialize<WindowManagementResult>(text, WindowsToolsBase.JsonOptions)!;
+    }
+
+    private static string GetResultText(CallToolResult callResult)
+    {
+        return Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
     }
 
     /// <inheritdoc/>
@@ -246,7 +253,7 @@ public sealed class WindowCloseActionTests : IAsyncLifetime, IDisposable
             discardChanges: false,
             cancellationToken: CancellationToken.None);
 
-        using var listDoc = JsonDocument.Parse(listResultJson);
+        using var listDoc = JsonDocument.Parse(GetResultText(listResultJson));
         var root = listDoc.RootElement;
 
         Assert.True(root.GetProperty("success").GetBoolean());

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WindowCloseDiscardChangesTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WindowCloseDiscardChangesTests.cs
@@ -3,6 +3,7 @@
 
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tools;
 
@@ -24,9 +25,15 @@ public sealed class WindowCloseDiscardChangesTests : IAsyncLifetime, IDisposable
 
     private const string TestWindowTitle = "MCP DiscardChanges Test Window";
 
-    private static WindowManagementResult DeserializeResult(string json)
+    private static WindowManagementResult DeserializeResult(CallToolResult callResult)
     {
-        return JsonSerializer.Deserialize<WindowManagementResult>(json, WindowsToolsBase.JsonOptions)!;
+        var text = Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
+        return JsonSerializer.Deserialize<WindowManagementResult>(text, WindowsToolsBase.JsonOptions)!;
+    }
+
+    private static string GetResultText(CallToolResult callResult)
+    {
+        return Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
     }
 
     /// <inheritdoc/>
@@ -268,7 +275,7 @@ public sealed class WindowCloseDiscardChangesTests : IAsyncLifetime, IDisposable
             discardChanges: false,
             cancellationToken: CancellationToken.None);
 
-        using var listDoc = JsonDocument.Parse(listResultJson);
+        using var listDoc = JsonDocument.Parse(GetResultText(listResultJson));
         Assert.True(listDoc.RootElement.GetProperty("success").GetBoolean());
 
         // Window may still appear in list (behind dialog) or dialog may be the active window

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Stefan Brenner. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.Versioning;
+using ModelContextProtocol.Protocol;
+using Sbroenne.WindowsMcp.Automation.Tools;
+using Sbroenne.WindowsMcp.Models;
+using Sbroenne.WindowsMcp.Tools;
+
+namespace Sbroenne.WindowsMcp.Tests.Tools;
+
+/// <summary>
+/// Smoke tests verifying the <see cref="CallToolResult"/> shape returned by tools migrated
+/// from <see cref="Task{String}"/> to <see cref="Task{CallToolResult}"/> as part of issue #133,
+/// covering a service-backed tool (<see cref="WindowManagementTool"/>) and a UI-automation tool
+/// (<see cref="UIFindTool"/>).
+/// </summary>
+[SupportedOSPlatform("windows")]
+public sealed class CallToolResultMigrationSmokeTests
+{
+    [Fact]
+    public async Task WindowManagementTool_List_ReturnsSuccessCallToolResult()
+    {
+        // Act
+        var result = await WindowManagementTool.ExecuteAsync(
+            action: WindowAction.List,
+            handle: null,
+            title: null,
+            processName: null,
+            filter: "___no_such_window_should_match___",
+            regex: false,
+            includeAllDesktops: false,
+            x: null,
+            y: null,
+            width: null,
+            height: null,
+            timeoutMs: null,
+            target: null,
+            monitorIndex: null,
+            state: null,
+            excludeTitle: null,
+            discardChanges: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.False(result.IsError, "list action should succeed even with zero matches");
+        Assert.NotNull(result.Content);
+        var textBlock = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Contains("\"success\":true", textBlock.Text);
+    }
+
+    [Fact]
+    public async Task UIFindTool_MissingWindowHandle_ReturnsIsErrorTrue()
+    {
+        // Act
+        var result = await UIFindTool.ExecuteAsync(
+            windowHandle: null!,
+            name: null,
+            nameContains: null,
+            namePattern: null,
+            controlType: null,
+            automationId: null,
+            className: null,
+            exactDepth: null,
+            foundIndex: 1,
+            includeChildren: false,
+            sortByProminence: false,
+            inRegion: null,
+            nearElement: null,
+            timeoutMs: 5000,
+            includeDiagnostics: false,
+            cancellationToken: CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsError, "Missing windowHandle should surface as an MCP-level error");
+        Assert.NotNull(result.Content);
+        var textBlock = Assert.Single(result.Content.OfType<TextContentBlock>());
+        Assert.Contains("windowHandle", textBlock.Text, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.Versioning;
 using System.Text.Json;
+using ModelContextProtocol.Protocol;
 using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tests.Fixtures;
 using Sbroenne.WindowsMcp.Tools;
@@ -21,9 +22,10 @@ public sealed class MouseControlToolMonitorIndexTests : IClassFixture<MultiMonit
         _fixture = fixture;
     }
 
-    private static MouseControlResult DeserializeResult(string json)
+    private static MouseControlResult DeserializeResult(CallToolResult callResult)
     {
-        return JsonSerializer.Deserialize<MouseControlResult>(json, WindowsToolsBase.JsonOptions)!;
+        var text = Assert.Single(callResult.Content.OfType<TextContentBlock>()).Text;
+        return JsonSerializer.Deserialize<MouseControlResult>(text, WindowsToolsBase.JsonOptions)!;
     }
 
     [Fact]


### PR DESCRIPTION
Closes #133.

## SDK bump
- `ModelContextProtocol` 1.4.0 -> 1.4.1 in `Directory.Packages.props`. No functional changes expected: 1.4.0/1.4.1 changes are HTTP/SSE transport, auth (Identity Assertion Grant), and stdio-client env-var logging related. This repo only uses `StdioServerTransport` (`Program.cs`), so none of that surface is exercised.

## CallToolResult migration (issue #133)
Migrated the remaining 9 tools from `Task<string>` to `Task<CallToolResult>`, matching the pattern established for `ScreenshotControlTool` in PR #130/#134:
- `AppTool`, `MouseControlTool`, `KeyboardControlTool`, `WindowManagementTool`
- `UIClickTool`, `UIFileTool`, `UIFindTool`, `UIReadTool`, `UITypeTool`

Each tool's `CallToolResult.IsError` now mirrors its operation's `Success` flag, giving protocol-level error signaling that MCP clients can act on (retries, error styling, etc.) instead of only encoding failure in the JSON body.

### Implementation notes
- Added `ToCallToolResult`/`FailResult`/`ErrorCallToolResult` helpers to `WindowsToolsBase` for the 5 UI-automation tools that already funnel through `SerializeUIResult`/`Fail`/`SerializeToolError` -- existing string-returning helpers are kept unchanged (still used internally).
- Added small per-tool wrapper helpers for `AppTool`, `MouseControlTool`, `KeyboardControlTool`, `WindowManagementTool`, which serialize their own result records directly.
- No business logic, validation logic, or JSON field shapes changed -- only the outer return type/wrapping.
- No image content blocks added to these tools (none return binary/image data); this is purely an `IsError`/consistency migration, matching what issue #133 proposed. Only `ScreenshotControlTool` retains image content blocks.
- `ScreenshotControlTool.cs` itself was not touched.

### Tests
- Updated existing tests that asserted on raw JSON strings returned from these tools' `ExecuteAsync` to extract the payload from `CallToolResult.Content` (`TextContentBlock.Text`) and assert on `IsError`.
- Added `CallToolResultMigrationSmokeTests` covering a service-backed tool (`WindowManagementTool` `list`) and a UI-automation tool (`UIFindTool` with a missing `windowHandle`) to confirm the new `CallToolResult` shape end-to-end.

## Verification
- `dotnet build` (whole solution, `TreatWarningsAsErrors`): 0 warnings / 0 errors.
- `dotnet test --filter "FullyQualifiedName!~LLM"`: passes; no regressions from the migration (pre-existing environment gaps around Electron/Chrome not being installed in the build sandbox, and one known-flaky parallel test, are unrelated to this change).
