### PR TITLE
Optimize browser/UI automation runtime and Chromium test harness

### DIFF
--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -98,6 +98,14 @@ public static class ElementIdGenerator
                 element = FindByTreePath(parts.WindowHandle, parts.TreePath);
             }
 
+            // Last-resort: Locator-style re-resolution by name + control type. Chromium/Electron churn
+            // runtime IDs and tree indices on re-render, so re-find the element by its stable semantic
+            // selector when both the runtime ID and tree path have gone stale.
+            if (element == null && !string.IsNullOrEmpty(parts.Name))
+            {
+                element = FindBySelector(parts.WindowHandle, parts.ControlType, parts.Name!);
+            }
+
             return element;
         }
         catch
@@ -143,7 +151,7 @@ public static class ElementIdGenerator
             // Calculate tree path from root
             var treePath = CalculateTreePath(element, rootElement);
 
-            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:{treePath}";
+            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:{treePath}{BuildSelectorSegment(element, cached: false)}";
         }
         catch
         {
@@ -192,7 +200,7 @@ public static class ElementIdGenerator
                 : "0";
 
             // Simplified format - no tree path (expensive to calculate)
-            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:cached";
+            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:cached{BuildSelectorSegment(element, cached: true)}";
         }
         catch
         {
@@ -223,7 +231,7 @@ public static class ElementIdGenerator
                 : "0";
 
             // Simplified format - no tree path
-            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:fast";
+            return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:fast{BuildSelectorSegment(element, cached: false)}";
         }
         catch
         {
@@ -276,26 +284,104 @@ public static class ElementIdGenerator
         return path.Count > 0 ? string.Join(".", path) : "0";
     }
 
+    /// <summary>
+    /// Builds the optional selector segment ("|sel:{controlType}~{name}") used as a Locator-style
+    /// re-resolution fallback. Returns an empty string when the element has no usable name.
+    /// </summary>
+    private static string BuildSelectorSegment(UIA.IUIAutomationElement element, bool cached)
+    {
+        try
+        {
+            var name = cached ? element.GetCachedName() : element.GetName();
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return string.Empty;
+            }
+
+            var controlType = cached ? element.GetCachedControlTypeName() : element.GetControlTypeName();
+
+            // '|' and '~' are our delimiters and newlines break the single-line id; strip them.
+            // Cap length to keep ids compact — the name only needs to be specific enough to re-find.
+            var sanitizedName = name
+                .Replace('|', ' ')
+                .Replace('~', ' ')
+                .Replace('\r', ' ')
+                .Replace('\n', ' ')
+                .Trim();
+            if (sanitizedName.Length > 120)
+            {
+                sanitizedName = sanitizedName[..120];
+            }
+
+            var sanitizedType = (controlType ?? string.Empty).Replace('|', ' ').Replace('~', ' ').Trim();
+
+            return $"|sel:{sanitizedType}~{sanitizedName}";
+        }
+        catch
+        {
+            return string.Empty;
+        }
+    }
+
     private static ElementIdParts? ParseElementId(string elementId)
     {
         try
         {
             var parts = elementId.Split('|');
-            if (parts.Length != 3)
+            if (parts.Length < 3)
             {
                 return null;
             }
 
-            var windowPart = parts[0].Replace("window:", "");
-            var runtimePart = parts[1].Replace("runtime:", "");
-            var pathPart = parts[2].Replace("path:", "");
+            string? windowPart = null;
+            string? runtimePart = null;
+            string? pathPart = null;
+            string? controlType = null;
+            string? name = null;
+
+            foreach (var part in parts)
+            {
+                if (part.StartsWith("window:", StringComparison.Ordinal))
+                {
+                    windowPart = part["window:".Length..];
+                }
+                else if (part.StartsWith("runtime:", StringComparison.Ordinal))
+                {
+                    runtimePart = part["runtime:".Length..];
+                }
+                else if (part.StartsWith("path:", StringComparison.Ordinal))
+                {
+                    pathPart = part["path:".Length..];
+                }
+                else if (part.StartsWith("sel:", StringComparison.Ordinal))
+                {
+                    var sel = part["sel:".Length..];
+                    var tilde = sel.IndexOf('~');
+                    if (tilde >= 0)
+                    {
+                        controlType = sel[..tilde];
+                        name = sel[(tilde + 1)..];
+                    }
+                    else
+                    {
+                        name = sel;
+                    }
+                }
+            }
+
+            // Require the original three segments so malformed ids (e.g., "window:0|runtime:0")
+            // still fail closed.
+            if (windowPart == null || runtimePart == null || pathPart == null)
+            {
+                return null;
+            }
 
             if (!nint.TryParse(windowPart, out var windowHandle))
             {
                 return null;
             }
 
-            return new ElementIdParts(windowHandle, runtimePart, pathPart);
+            return new ElementIdParts(windowHandle, runtimePart, pathPart, controlType, name);
         }
         catch
         {
@@ -374,7 +460,73 @@ public static class ElementIdGenerator
         }
     }
 
-    private sealed record ElementIdParts(nint WindowHandle, string RuntimeId, string TreePath);
+    /// <summary>
+    /// Locator-style fallback: re-finds an element by exact name, preferring a control-type match and
+    /// an on-screen element. Used only when runtime-id and tree-path resolution have both failed.
+    /// </summary>
+    private static UIA.IUIAutomationElement? FindBySelector(nint windowHandle, string? controlType, string name)
+    {
+        try
+        {
+            var uia = UIA3Automation.Instance;
+            var root = windowHandle != 0
+                ? uia.ElementFromHandle(windowHandle)
+                : uia.RootElement;
+
+            if (root == null)
+            {
+                return null;
+            }
+
+            var condition = uia.CreatePropertyCondition(UIA3PropertyIds.Name, name);
+            var candidates = root.FindAll(UIA.TreeScope.TreeScope_Descendants, condition);
+            if (candidates == null || candidates.Length == 0)
+            {
+                return null;
+            }
+
+            UIA.IUIAutomationElement? typeMatch = null;
+            UIA.IUIAutomationElement? firstAny = null;
+
+            for (var i = 0; i < candidates.Length; i++)
+            {
+                var candidate = candidates.GetElement(i);
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                firstAny ??= candidate;
+
+                if (string.IsNullOrEmpty(controlType) ||
+                    string.Equals(candidate.GetControlTypeName(), controlType, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Prefer an on-screen element of the right type; keep searching for a visible one.
+                    try
+                    {
+                        if (candidate.CurrentIsOffscreen == 0)
+                        {
+                            return candidate;
+                        }
+                    }
+                    catch
+                    {
+                        return candidate;
+                    }
+
+                    typeMatch ??= candidate;
+                }
+            }
+
+            return typeMatch ?? firstAny;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private sealed record ElementIdParts(nint WindowHandle, string RuntimeId, string TreePath, string? ControlType, string? Name);
 
     /// <summary>
     /// Registers a full element ID and returns a short ID.

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
@@ -35,6 +35,7 @@ public static partial class UIFindTool
     /// <param name="sortByProminence">Sort results by size (largest first). Useful for disambiguation.</param>
     /// <param name="inRegion">Filter to region: 'x,y,width,height' in screen coordinates.</param>
     /// <param name="nearElement">Find elements near this elementId (results sorted by distance).</param>
+    /// <param name="visibleOnly">Exclude off-screen elements. Default (unset): excluded for Chromium/Edge/Electron (which expose many hidden nodes), included elsewhere. Set false to include hidden nodes.</param>
     /// <param name="timeoutMs">Timeout in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -54,6 +55,7 @@ public static partial class UIFindTool
         [DefaultValue(false)] bool sortByProminence,
         [DefaultValue(null)] string? inRegion,
         [DefaultValue(null)] string? nearElement,
+        [DefaultValue(null)] bool? visibleOnly,
         [DefaultValue(5000)] int timeoutMs,
         [DefaultValue(false)] bool includeDiagnostics,
         CancellationToken cancellationToken)
@@ -83,6 +85,7 @@ public static partial class UIFindTool
                 SortByProminence = sortByProminence,
                 InRegion = inRegion,
                 NearElement = nearElement,
+                VisibleOnly = visibleOnly,
                 TimeoutMs = Math.Clamp(timeoutMs, 0, 60000)
             };
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -109,6 +109,18 @@ public sealed partial class UIAutomationService
             // Ensure window is activated before clicking
             TryActivateWindowForElement(element, activationHandle);
 
+            // Actionability gate: a disabled control cannot be clicked. Fail fast with a clear,
+            // actionable error instead of invoking a pattern that silently no-ops.
+            if (!element.IsEnabled())
+            {
+                return UIAutomationResult.CreateFailure(
+                    "click",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Element with ID '{elementId}' is disabled and cannot be clicked. " +
+                    "Wait for it to become enabled (e.g., after filling required fields) or target a different element.",
+                    CreateDiagnostics(stopwatch));
+            }
+
             var rootElement = GetRootElementForScroll(element);
             var controlType = element.GetControlTypeId();
 
@@ -341,6 +353,17 @@ public sealed partial class UIAutomationService
 
             // Ensure window is activated before typing
             TryActivateWindowForElement(element, activationHandle);
+
+            // Actionability gate: a disabled field cannot receive text. Fail fast with guidance.
+            if (!element.IsEnabled())
+            {
+                return (Success: false, Result: UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Element with ID '{elementId}' is disabled and cannot receive text. " +
+                    "Wait for it to become enabled or target a different field.",
+                    CreateDiagnostics(stopwatch)), ValuePatternSucceeded: false, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+            }
 
             // Try to set focus
             element.TrySetFocus();

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -96,19 +96,39 @@ public sealed partial class UIAutomationService
                 // Detect framework and get optimal search strategy
                 var strategy = GetFrameworkStrategy(rootElement);
 
+                // Resolve visibility filtering: explicit caller value wins; otherwise exclude
+                // off-screen nodes for Chromium/Electron (huge hidden/virtualized trees), include elsewhere.
+                var visibleOnly = query.VisibleOnly ?? strategy.UsePostHocFiltering;
+
                 // Use framework-aware depth: if caller used default (null or 20), use framework recommendation
                 // Otherwise respect explicit caller value
                 var effectiveMaxDepth = !query.MaxDepth.HasValue || query.MaxDepth.Value == 20
                     ? strategy.RecommendedMaxDepth
                     : query.MaxDepth.Value;
 
+                // Route to the cheapest correct strategy:
+                // - No advanced criteria: single FindAllBuildCache (fastest).
+                // - Advanced criteria without ExactDepth: cached bulk fetch + in-process filter.
+                //   This avoids the per-node COM storm of the raw TreeWalker, which is the dominant
+                //   cost for Chromium/Electron where nameContains/namePattern is the recommended path.
+                // - ExactDepth requires depth-aware traversal, so keep the TreeWalker.
                 if (!hasAdvancedCriteria)
                 {
                     FindElementsWithFindAll(rootElement, condition, query, elementInfos, ref elementsScanned, maxResults);
                 }
+                else if (!query.ExactDepth.HasValue)
+                {
+                    FindElementsWithCachedFilter(rootElement, condition, query, elementInfos, ref elementsScanned, ref matchCount, maxResults);
+                }
                 else
                 {
                     FindElementsWithTreeWalker(rootElement, rootElement, condition, query, effectiveMaxDepth, 0, elementInfos, ref elementsScanned, ref matchCount, maxResults, query.IncludeChildren);
+                }
+
+                // Exclude off-screen elements when visibility filtering is in effect.
+                if (visibleOnly && elementInfos.Count > 0)
+                {
+                    elementInfos.RemoveAll(e => e.IsOffscreen);
                 }
 
                 stopwatch.Stop();
@@ -127,7 +147,12 @@ public sealed partial class UIAutomationService
                     elementsScanned = 0;
                     matchCount = 0;
 
-                    FindElementsWithTreeWalker(rootElement, rootElement, relaxedCondition, relaxedQuery, effectiveMaxDepth, 0, elementInfos, ref elementsScanned, ref matchCount, maxResults, query.IncludeChildren);
+                    FindElementsWithCachedFilter(rootElement, relaxedCondition, relaxedQuery, elementInfos, ref elementsScanned, ref matchCount, maxResults);
+
+                    if (visibleOnly && elementInfos.Count > 0)
+                    {
+                        elementInfos.RemoveAll(e => e.IsOffscreen);
+                    }
 
                     if (elementInfos.Count > 0)
                     {
@@ -255,6 +280,125 @@ public sealed partial class UIAutomationService
         catch
         {
             // Element disappeared during search
+        }
+    }
+
+    /// <summary>
+    /// Advanced-criteria finding using a single FindAllBuildCache pass plus in-process filtering.
+    /// Pushes Name(exact)/AutomationId/ControlType down as native conditions, then filters
+    /// nameContains/namePattern/className against cached properties. This avoids the per-node
+    /// cross-process COM round-trips of the raw TreeWalker, which is the dominant cost for
+    /// Chromium/Electron content where nameContains/namePattern is the recommended query path.
+    /// </summary>
+    private void FindElementsWithCachedFilter(
+        UIA.IUIAutomationElement rootElement,
+        UIA.IUIAutomationCondition condition,
+        ElementQuery query,
+        List<UIElementInfo> results,
+        ref int elementsScanned,
+        ref int matchCount,
+        int maxResults)
+    {
+        try
+        {
+            // Single COM call fetches every element matching the native condition with all
+            // properties cached; substring/regex/className are then evaluated in-process.
+            var cacheRequest = Uia.CreateElementCacheRequest(UIA.TreeScope.TreeScope_Element);
+            var elements = rootElement.FindAllBuildCache(UIA.TreeScope.TreeScope_Descendants, condition, cacheRequest);
+            if (elements == null)
+            {
+                return;
+            }
+
+            // Bound in-process work with the same budget the tree path uses.
+            var count = Math.Min(elements.Length, MaxElementsToScan);
+            for (var i = 0; i < count && results.Count < maxResults; i++)
+            {
+                elementsScanned++;
+
+                var element = elements.GetElement(i);
+                if (element == null)
+                {
+                    continue;
+                }
+
+                if (!MatchesAdvancedCriteriaCached(element, query))
+                {
+                    continue;
+                }
+
+                matchCount++;
+                if (matchCount < query.FoundIndex)
+                {
+                    continue;
+                }
+
+                var children = query.IncludeChildren ? GetChildren(element, rootElement) : null;
+                var elementInfo = ConvertToElementInfo(element, rootElement, _coordinateConverter, children, fromCachedElement: true);
+                if (elementInfo != null)
+                {
+                    results.Add(elementInfo);
+                }
+            }
+        }
+        catch
+        {
+            // Element tree changed during search - return whatever was collected.
+        }
+    }
+
+    /// <summary>
+    /// Evaluates nameContains/namePattern/className against an element's cached properties.
+    /// </summary>
+    private static bool MatchesAdvancedCriteriaCached(UIA.IUIAutomationElement element, ElementQuery query)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(query.NameContains))
+            {
+                var name = element.GetCachedName();
+                if (string.IsNullOrEmpty(name) ||
+                    !name.Contains(query.NameContains, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(query.NamePattern))
+            {
+                var name = element.GetCachedName();
+                if (string.IsNullOrEmpty(name))
+                {
+                    return false;
+                }
+
+                try
+                {
+                    if (!Regex.IsMatch(name, query.NamePattern, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100)))
+                    {
+                        return false;
+                    }
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(query.ClassName))
+            {
+                var className = element.GetCachedClassName();
+                if (!string.Equals(className, query.ClassName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch
+        {
+            return false;
         }
     }
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -82,7 +82,21 @@ public sealed partial class UIAutomationService
                         CreateDiagnosticsWithContext(stopwatch, rootElement, null, elementsScanned, windowTitle, windowHandle));
                 }
 
-                return UIAutomationResult.CreateSuccessCompactTree("get_tree", [tree], CreateDiagnosticsWithContext(stopwatch, rootElement, null, elementsScanned, windowTitle, windowHandle));
+                var diagnostics = CreateDiagnosticsWithContext(stopwatch, rootElement, null, elementsScanned, windowTitle, windowHandle);
+                if (wasTruncated)
+                {
+                    diagnostics = diagnostics with
+                    {
+                        Warnings =
+                        [
+                            $"Tree truncated at {MaxElementsToScan} elements (scanned {elementsScanned}). " +
+                            "Results are incomplete — scope to a smaller parentElementId/windowHandle, add a controlTypeFilter, " +
+                            "or scroll content into view and retry."
+                        ]
+                    };
+                }
+
+                return UIAutomationResult.CreateSuccessCompactTree("get_tree", [tree], diagnostics);
             }, cancellationToken);
         }
         catch (COMException ex)

--- a/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
+++ b/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
@@ -148,4 +148,11 @@ public sealed record ElementQuery
     /// The element ID of the reference element. Results will be sorted by distance from this element's center.
     /// </summary>
     public string? NearElement { get; init; }
+
+    /// <summary>
+    /// When set, controls whether off-screen (IsOffscreen) elements are excluded from results.
+    /// When null, the framework strategy decides: excluded for Chromium/Electron (which expose many
+    /// hidden/virtualized nodes), included otherwise. Set explicitly to override.
+    /// </summary>
+    public bool? VisibleOnly { get; init; }
 }

--- a/src/Sbroenne.WindowsMcp/Prompts/WindowsAutomationPrompts.cs
+++ b/src/Sbroenne.WindowsMcp/Prompts/WindowsAutomationPrompts.cs
@@ -172,6 +172,8 @@ public sealed class WindowsAutomationPrompts
             new(ChatRole.System,
                 "Use the standard semantic workflow for Chromium browsers (Edge, Chrome). " +
                 "Page content — links, buttons, form fields, and text — is reliably discoverable via ui_* tools using ARIA labels and visible text. " +
+                "When you launch a Chromium browser via app(), renderer accessibility is enabled automatically so the full page tree is exposed; " +
+                "a browser that was already open by other means may expose a reduced tree until it is interacted with. " +
                 "Browser chrome (address bar, tab bar, toolbar) is best-effort: prefer keyboard shortcuts for those. " +
                 "For authenticated or SSO-only sites, check whether a signed-in browser window is already open before launching a new instance — " +
                 "Chromium launcher helpers often exit immediately when an existing session picks up the request, so that is not a failure."),

--- a/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
+++ b/src/Sbroenne.WindowsMcp/Sbroenne.WindowsMcp.csproj
@@ -47,6 +47,10 @@
     <PackageReference Include="Interop.UIAutomationClient" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sbroenne.WindowsMcp.Tests" />
+  </ItemGroup>
+
   <!-- Windows Forms is enabled via UseWindowsForms; no WPF dependency needed -->
 
 </Project>

--- a/src/Sbroenne.WindowsMcp/Tools/AppTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/AppTool.cs
@@ -117,6 +117,11 @@ public static partial class AppTool
 
         try
         {
+            // Chromium browsers only expose a complete accessibility tree when an assistive-technology
+            // client requests it. Force renderer accessibility on launch so ui_find/ui_read/ui_click see
+            // full page content (links, buttons, form fields) instead of a reduced/empty tree.
+            arguments = AugmentChromiumArguments(programPath, arguments);
+
             var startInfo = new ProcessStartInfo
             {
                 FileName = programPath,
@@ -267,6 +272,37 @@ public static partial class AppTool
                 WindowManagementErrorCode.SystemError,
                 $"Failed to launch '{programPath}': {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Known Chromium-based browser executables (without extension) that expose their page
+    /// accessibility tree lazily and benefit from --force-renderer-accessibility on launch.
+    /// </summary>
+    private static readonly string[] ChromiumExecutables =
+        ["msedge", "chrome", "brave", "vivaldi", "opera", "chromium"];
+
+    /// <summary>
+    /// Appends --force-renderer-accessibility when launching a Chromium browser so its page
+    /// accessibility tree is fully populated for UIA-based automation. No-op for other programs
+    /// or when the flag is already present.
+    /// </summary>
+    internal static string? AugmentChromiumArguments(string programPath, string? arguments)
+    {
+        var name = Path.GetFileNameWithoutExtension(programPath);
+        if (string.IsNullOrEmpty(name) ||
+            !ChromiumExecutables.Contains(name, StringComparer.OrdinalIgnoreCase))
+        {
+            return arguments;
+        }
+
+        if (arguments != null &&
+            arguments.Contains("force-renderer-accessibility", StringComparison.OrdinalIgnoreCase))
+        {
+            return arguments;
+        }
+
+        const string a11yFlag = "--force-renderer-accessibility";
+        return string.IsNullOrWhiteSpace(arguments) ? a11yFlag : $"{a11yFlag} {arguments}";
     }
 
     /// <summary>

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSession.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSession.cs
@@ -58,6 +58,16 @@ internal sealed class ChromiumBrowserSession : IDisposable
     public static void SkipUnlessSupported(ChromiumBrowserKind browser = ChromiumBrowserKind.Edge)
     {
         Skip.If(FindBrowserExecutable(browser) is null, $"Chromium browser smoke tests require {GetBrowserDisplayName(browser)} to be installed.");
+
+        // R9: Chrome is opt-in for the default local run to halve launch cost. Edge is the always-on
+        // baseline; enable Chrome coverage by setting MCP_TEST_CHROME=1 (e.g., in CI browser matrices).
+        if (browser == ChromiumBrowserKind.Chrome)
+        {
+            var optIn = Environment.GetEnvironmentVariable("MCP_TEST_CHROME");
+            var enabled = string.Equals(optIn, "1", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(optIn, "true", StringComparison.OrdinalIgnoreCase);
+            Skip.IfNot(enabled, "Chrome coverage is opt-in. Set MCP_TEST_CHROME=1 to run Chrome smoke tests.");
+        }
     }
 
     public static ChromiumBrowserSession LaunchLocalPage(ChromiumBrowserKind browser = ChromiumBrowserKind.Edge)
@@ -99,8 +109,8 @@ internal sealed class ChromiumBrowserSession : IDisposable
     {
         var browserExecutable = FindBrowserExecutable(browser)
             ?? throw new InvalidOperationException($"{GetBrowserDisplayName(browser)} executable was not found.");
-        var userDataDirectory = CreateUserDataDirectory();
         var browserDescriptor = GetBrowserDescriptor(browser);
+        var userDataDirectory = PrepareUserDataDirectory(browserExecutable, browserDescriptor);
 
         var existingWindows = SnapshotBrowserWindows(browserDescriptor.ProcessName);
 
@@ -185,6 +195,183 @@ internal sealed class ChromiumBrowserSession : IDisposable
 
         Directory.CreateDirectory(directory);
         return directory;
+    }
+
+    // R7: a per-run warmed profile template. Chromium writes its first-run/baseline state (Local State,
+    // default profile) on the first launch; copying that state into each fresh, isolated session profile
+    // lets subsequent launches skip most first-run UI without sharing a live profile directory (which
+    // would collide with the still-open read-only fixture session). Warm-up is a pure optimization: any
+    // failure falls back to a cold profile, matching the previous behavior exactly.
+    private static readonly object s_templateGate = new();
+    private static readonly Dictionary<string, string?> s_warmedTemplates = new(StringComparer.OrdinalIgnoreCase);
+    private static int s_templateCleanupHooked;
+
+    private static string PrepareUserDataDirectory(string browserExecutable, BrowserDescriptor descriptor)
+    {
+        var sessionDirectory = CreateUserDataDirectory();
+
+        try
+        {
+            var template = GetOrCreateWarmedTemplate(browserExecutable, descriptor);
+            if (template is not null)
+            {
+                CopyProfileTemplate(template, sessionDirectory);
+            }
+        }
+        catch
+        {
+            // Fall back to a cold profile on any warm-up/copy failure.
+        }
+
+        return sessionDirectory;
+    }
+
+    private static string? GetOrCreateWarmedTemplate(string browserExecutable, BrowserDescriptor descriptor)
+    {
+        lock (s_templateGate)
+        {
+            if (s_warmedTemplates.TryGetValue(descriptor.ProcessName, out var existing))
+            {
+                return existing;
+            }
+
+            string? template;
+            try
+            {
+                template = BuildWarmedTemplate(browserExecutable);
+            }
+            catch
+            {
+                template = null;
+            }
+
+            s_warmedTemplates[descriptor.ProcessName] = template;
+            HookTemplateCleanup();
+            return template;
+        }
+    }
+
+    private static string? BuildWarmedTemplate(string browserExecutable)
+    {
+        var templateDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "mcp-windows-chromium-tests",
+            $"warm-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(templateDirectory);
+
+        string[] arguments =
+        [
+            "--headless=new",
+            $"--user-data-dir=\"{templateDirectory}\"",
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-sync",
+            "--disable-extensions",
+            "about:blank",
+        ];
+
+        using var warmProcess = Process.Start(new ProcessStartInfo
+        {
+            FileName = browserExecutable,
+            Arguments = string.Join(" ", arguments),
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+
+        if (warmProcess is null)
+        {
+            return null;
+        }
+
+        // Wait until Chromium has written its baseline profile state, then shut the warm-up down.
+        var localState = Path.Combine(templateDirectory, "Local State");
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline && !File.Exists(localState))
+        {
+            Thread.Sleep(100);
+        }
+
+        try
+        {
+            if (!warmProcess.HasExited)
+            {
+                warmProcess.Kill(entireProcessTree: true);
+            }
+        }
+        catch
+        {
+            // Best-effort shutdown of the warm-up process.
+        }
+
+        try
+        {
+            warmProcess.WaitForExit((int)ProcessExitTimeout.TotalMilliseconds);
+        }
+        catch
+        {
+            // Ignore — locks are released on exit regardless.
+        }
+
+        return File.Exists(localState) ? templateDirectory : null;
+    }
+
+    private static void CopyProfileTemplate(string sourceDirectory, string destinationDirectory)
+    {
+        foreach (var directory in Directory.GetDirectories(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            Directory.CreateDirectory(directory.Replace(sourceDirectory, destinationDirectory, StringComparison.Ordinal));
+        }
+
+        foreach (var file in Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+        {
+            var fileName = Path.GetFileName(file);
+
+            // Skip single-instance lock artifacts — they must not be shared between profiles.
+            if (fileName.StartsWith("Singleton", StringComparison.OrdinalIgnoreCase) ||
+                fileName.StartsWith("lockfile", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var target = file.Replace(sourceDirectory, destinationDirectory, StringComparison.Ordinal);
+
+            try
+            {
+                File.Copy(file, target, overwrite: true);
+            }
+            catch (IOException)
+            {
+                // Skip files still locked by the browser; they are non-essential for warm start.
+            }
+        }
+    }
+
+    private static void HookTemplateCleanup()
+    {
+        if (Interlocked.Exchange(ref s_templateCleanupHooked, 1) != 0)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.ProcessExit += static (_, _) =>
+        {
+            foreach (var directory in s_warmedTemplates.Values)
+            {
+                if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch
+                {
+                    // Best-effort cleanup at process exit.
+                }
+            }
+        };
     }
 
     private static string FindLocalPagePath()

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumReadOnlySessionFixture.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumReadOnlySessionFixture.cs
@@ -1,0 +1,61 @@
+namespace Sbroenne.WindowsMcp.Tests.Integration.ChromiumBrowser;
+
+/// <summary>
+/// Shares a single read-only Chromium session per browser across all read-only tests in a class,
+/// so the local test page is only launched once per browser instead of once per test method (R6).
+/// Mutating tests (type/click) must NOT use this fixture — they own isolated sessions so their
+/// page-state changes never leak into read-only assertions.
+/// </summary>
+public sealed class ChromiumReadOnlySessionFixture : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<ChromiumBrowserKind, ChromiumBrowserSession> _sessions = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Returns the shared, lazily-launched read-only session for the given browser. The fixture owns
+    /// the session's lifetime — callers must not dispose the returned session.
+    /// </summary>
+    internal ChromiumBrowserSession GetSession(ChromiumBrowserKind browser)
+    {
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (!_sessions.TryGetValue(browser, out var session))
+            {
+                session = ChromiumBrowserSession.LaunchLocalPage(browser);
+                _sessions[browser] = session;
+            }
+
+            return session;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            foreach (var session in _sessions.Values)
+            {
+                try
+                {
+                    session.Dispose();
+                }
+                catch
+                {
+                    // Best-effort cleanup in test code.
+                }
+            }
+
+            _sessions.Clear();
+        }
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
@@ -5,13 +5,20 @@ namespace Sbroenne.WindowsMcp.Tests.Integration.ChromiumBrowser;
 [Collection("ChromiumBrowser")]
 [Trait("Category", "RequiresDesktop")]
 [Trait("Category", "ChromiumBrowser")]
-public sealed class ChromiumLocalPageTests
+public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessionFixture>
 {
     private const int QueryTimeoutMs = 5000;
     private const string SearchInputName = "Docs Search";
     private const string SignInButtonName = "Sign in";
     private const string SignedOutStatus = "Signed out";
     private const string FocusedButtonMessage = "Sign in button focused";
+
+    private readonly ChromiumReadOnlySessionFixture _readOnlySessions;
+
+    public ChromiumLocalPageTests(ChromiumReadOnlySessionFixture readOnlySessions)
+    {
+        _readOnlySessions = readOnlySessions;
+    }
 
     [Theory]
     [InlineData(ChromiumBrowserKind.Edge)]
@@ -20,7 +27,7 @@ public sealed class ChromiumLocalPageTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(browser);
 
-        using var session = ChromiumBrowserSession.LaunchLocalPage(browser);
+        var session = _readOnlySessions.GetSession(browser);
         using var harness = new ChromiumAutomationHarness();
 
         var result = await harness.AutomationService.FindElementsAsync(new ElementQuery
@@ -42,7 +49,7 @@ public sealed class ChromiumLocalPageTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(browser);
 
-        using var session = ChromiumBrowserSession.LaunchLocalPage(browser);
+        var session = _readOnlySessions.GetSession(browser);
         using var harness = new ChromiumAutomationHarness();
 
         var result = await harness.AutomationService.FindElementsAsync(new ElementQuery
@@ -66,7 +73,7 @@ public sealed class ChromiumLocalPageTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(browser);
 
-        using var session = ChromiumBrowserSession.LaunchLocalPage(browser);
+        var session = _readOnlySessions.GetSession(browser);
         using var harness = new ChromiumAutomationHarness();
 
         var result = await harness.AutomationService.FindElementsAsync(new ElementQuery
@@ -138,7 +145,7 @@ public sealed class ChromiumLocalPageTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(browser);
 
-        using var session = ChromiumBrowserSession.LaunchLocalPage(browser);
+        var session = _readOnlySessions.GetSession(browser);
         using var harness = new ChromiumAutomationHarness();
 
         var statusElement = await FindSingleElementAsync(harness, session.WindowHandleString, SignedOutStatus, "Text");

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
@@ -67,6 +67,7 @@ public sealed class CallToolResultMigrationSmokeTests
             sortByProminence: false,
             inRegion: null,
             nearElement: null,
+            visibleOnly: null,
             timeoutMs: 5000,
             includeDiagnostics: false,
             cancellationToken: CancellationToken.None);

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/AppToolChromiumArgumentsTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/AppToolChromiumArgumentsTests.cs
@@ -1,0 +1,54 @@
+using System.Runtime.Versioning;
+using Sbroenne.WindowsMcp.Tools;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="AppTool.AugmentChromiumArguments"/>, which forces renderer
+/// accessibility on Chromium browser launches so their page a11y tree is fully populated.
+/// </summary>
+[SupportedOSPlatform("windows")]
+public class AppToolChromiumArgumentsTests
+{
+    [Theory]
+    [InlineData("msedge.exe")]
+    [InlineData("chrome.exe")]
+    [InlineData("MSEDGE.EXE")]
+    [InlineData(@"C:\Program Files\Google\Chrome\Application\chrome.exe")]
+    [InlineData("brave.exe")]
+    public void AugmentChromiumArguments_ChromiumBrowser_NoArgs_AddsFlag(string programPath)
+    {
+        var result = AppTool.AugmentChromiumArguments(programPath, null);
+
+        Assert.Equal("--force-renderer-accessibility", result);
+    }
+
+    [Fact]
+    public void AugmentChromiumArguments_ChromiumBrowser_WithUrl_PrependsFlag()
+    {
+        var result = AppTool.AugmentChromiumArguments("msedge.exe", "https://example.com");
+
+        Assert.Equal("--force-renderer-accessibility https://example.com", result);
+    }
+
+    [Fact]
+    public void AugmentChromiumArguments_FlagAlreadyPresent_DoesNotDuplicate()
+    {
+        var args = "--force-renderer-accessibility https://example.com";
+
+        var result = AppTool.AugmentChromiumArguments("chrome.exe", args);
+
+        Assert.Equal(args, result);
+    }
+
+    [Theory]
+    [InlineData("notepad.exe")]
+    [InlineData("calc.exe")]
+    [InlineData("winword.exe")]
+    [InlineData("firefox.exe")]
+    public void AugmentChromiumArguments_NonChromium_LeavesArgsUnchanged(string programPath)
+    {
+        Assert.Null(AppTool.AugmentChromiumArguments(programPath, null));
+        Assert.Equal("--foo", AppTool.AugmentChromiumArguments(programPath, "--foo"));
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/ElementIdGeneratorTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/ElementIdGeneratorTests.cs
@@ -110,6 +110,23 @@ public class ElementIdGeneratorTests
         Assert.Null(exception);
     }
 
+    [Theory]
+    [InlineData("window:12345|runtime:42.7.1|path:0.1|sel:Button~Submit")]
+    [InlineData("window:0|runtime:0|path:stale|sel:Hyperlink~Sign in")]
+    [InlineData("window:123|runtime:0|path:cached|sel:Edit~")]
+    public void ResolveToAutomationElement_SelectorSegment_DoesNotThrowAndReturnsNull(string fullId)
+    {
+        // Locator-style ids carry an optional "|sel:{controlType}~{name}" fallback segment.
+        // With a non-existent window handle nothing resolves, but parsing must not throw.
+        var exception = Record.Exception(() =>
+        {
+            var result = ElementIdGenerator.ResolveToAutomationElement(fullId);
+            Assert.Null(result);
+        });
+
+        Assert.Null(exception);
+    }
+
     #endregion
 
     #region Thread Safety Tests


### PR DESCRIPTION
Implements the browser-usage optimization spike from #136 — semantic UIA-first, not Playwright/CDP (Playwright referenced only for design patterns).

## Runtime (production)
- **R1 – faster ui_find**: substring/regex/className/inRegion criteria now route through a single `FindAllBuildCache` + in-process cached-property filter with a scan budget, instead of a raw per-node `TreeWalker` (many COM round-trips per node).
- **R2 – visibleOnly**: new `visibleOnly` param / `ElementQuery.VisibleOnly` drops offscreen matches.
- **R0 – Locator-style ids**: element ids carry an optional `|sel:{controlType}~{name}` segment; `ResolveToAutomationElement` re-finds by that selector when the runtime id and tree path both go stale (Chromium re-render churn). Purely additive fallback.
- **R3 – renderer accessibility**: `app()` auto-appends `--force-renderer-accessibility` when launching Chromium browsers so the full page a11y tree is exposed.
- **R4 – truncation surfaced**: `get_tree` reports scan-budget truncation via `diagnostics.Warnings`.
- **Actionability gate**: `ui_click`/`ui_type` fail fast with a clear message on disabled targets instead of silently no-oping.

## Chromium test harness
- **R6**: shared read-only session per browser via a class fixture (6 → 3 cold launches/browser).
- **R7**: warm a profile template once and copy it into each isolated session profile to skip first-run UI, with a cold-profile fallback on any failure.
- **R9**: Chrome coverage is opt-in via `MCP_TEST_CHROME`; Edge stays always-on.

## Validation
- Solution builds clean; **273 unit tests pass** (+14 new for arg augmentation and selector-id parsing).
- Browser integration tests require an interactive desktop + Edge/Chrome and were not run in this environment; harness changes are guarded to fall back to prior behavior.

Closes #136