### PR TITLE
perf(ui_find): scan content view for Chromium strategy (R5, #139)

### DIFF
--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
@@ -36,6 +36,7 @@ public static partial class UIFindTool
     /// <param name="inRegion">Filter to region: 'x,y,width,height' in screen coordinates.</param>
     /// <param name="nearElement">Find elements near this elementId (results sorted by distance).</param>
     /// <param name="visibleOnly">Exclude off-screen elements. Default (unset): excluded for Chromium/Edge/Electron (which expose many hidden nodes), included elsewhere. Set false to include hidden nodes.</param>
+    /// <param name="contentViewOnly">Scan only the leaner UI Automation content view (meaningful, user-facing elements) instead of the full control view. Default (unset): content view for Chromium/Edge/Electron (whose control view is bloated with structural nodes), control view elsewhere; automatically falls back to the control view if nothing is found. Set false to force the full control view.</param>
     /// <param name="timeoutMs">Timeout in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -56,6 +57,7 @@ public static partial class UIFindTool
         [DefaultValue(null)] string? inRegion,
         [DefaultValue(null)] string? nearElement,
         [DefaultValue(null)] bool? visibleOnly,
+        [DefaultValue(null)] bool? contentViewOnly,
         [DefaultValue(5000)] int timeoutMs,
         [DefaultValue(false)] bool includeDiagnostics,
         CancellationToken cancellationToken)
@@ -86,6 +88,7 @@ public static partial class UIFindTool
                 InRegion = inRegion,
                 NearElement = nearElement,
                 VisibleOnly = visibleOnly,
+                ContentViewOnly = contentViewOnly,
                 TimeoutMs = Math.Clamp(timeoutMs, 0, 60000)
             };
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
@@ -20,6 +20,7 @@ public sealed class UIA3Automation : IDisposable
     private readonly UIA.IUIAutomation _automation;
     private readonly UIA.IUIAutomationTreeWalker _controlViewWalker;
     private readonly UIA.IUIAutomationCondition _trueCondition;
+    private readonly UIA.IUIAutomationCondition _contentViewCondition;
     private bool _disposed;
 
     /// <summary>
@@ -41,6 +42,7 @@ public sealed class UIA3Automation : IDisposable
 
         _controlViewWalker = _automation.ControlViewWalker;
         _trueCondition = _automation.CreateTrueCondition();
+        _contentViewCondition = _automation.ContentViewCondition;
     }
 
     /// <summary>
@@ -57,6 +59,14 @@ public sealed class UIA3Automation : IDisposable
     /// Gets a cached TRUE condition.
     /// </summary>
     public UIA.IUIAutomationCondition TrueCondition => _trueCondition;
+
+    /// <summary>
+    /// Gets the predefined condition that selects only elements in the UI Automation content view.
+    /// The content view is a subset of the control view that excludes purely structural or
+    /// decorative nodes (containers, scrollbars, etc.), leaving the meaningful, user-facing
+    /// elements. Used to shrink Chromium/Electron candidate sets during find operations.
+    /// </summary>
+    public UIA.IUIAutomationCondition ContentViewCondition => _contentViewCondition;
 
     /// <summary>
     /// Gets the desktop root element.

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -100,35 +100,68 @@ public sealed partial class UIAutomationService
                 // off-screen nodes for Chromium/Electron (huge hidden/virtualized trees), include elsewhere.
                 var visibleOnly = query.VisibleOnly ?? strategy.UsePostHocFiltering;
 
+                // R5: Chromium/Electron control view is bloated with structural, non-interactive nodes
+                // that inflate FindAll result sets. Scan the leaner content view instead (meaningful,
+                // user-facing elements only). Caller can force on/off via ContentViewOnly. Only applies
+                // to the FindAll/cached-filter paths - ExactDepth counts control-view depth, so it keeps
+                // the control view to preserve depth semantics.
+                var useContentView = (query.ContentViewOnly ?? strategy.UseContentView) && !query.ExactDepth.HasValue;
+
                 // Use framework-aware depth: if caller used default (null or 20), use framework recommendation
                 // Otherwise respect explicit caller value
                 var effectiveMaxDepth = !query.MaxDepth.HasValue || query.MaxDepth.Value == 20
                     ? strategy.RecommendedMaxDepth
                     : query.MaxDepth.Value;
 
-                // Route to the cheapest correct strategy:
+                // Routes to the cheapest correct strategy and applies off-screen filtering.
+                // Resets counters so it can be re-run for the content-view -> control-view fallback.
                 // - No advanced criteria: single FindAllBuildCache (fastest).
                 // - Advanced criteria without ExactDepth: cached bulk fetch + in-process filter.
                 //   This avoids the per-node COM storm of the raw TreeWalker, which is the dominant
                 //   cost for Chromium/Electron where nameContains/namePattern is the recommended path.
                 // - ExactDepth requires depth-aware traversal, so keep the TreeWalker.
-                if (!hasAdvancedCriteria)
+                void RunScan(UIA.IUIAutomationCondition scanCondition)
                 {
-                    FindElementsWithFindAll(rootElement, condition, query, elementInfos, ref elementsScanned, maxResults);
-                }
-                else if (!query.ExactDepth.HasValue)
-                {
-                    FindElementsWithCachedFilter(rootElement, condition, query, elementInfos, ref elementsScanned, ref matchCount, maxResults);
-                }
-                else
-                {
-                    FindElementsWithTreeWalker(rootElement, rootElement, condition, query, effectiveMaxDepth, 0, elementInfos, ref elementsScanned, ref matchCount, maxResults, query.IncludeChildren);
+                    elementInfos.Clear();
+                    elementsScanned = 0;
+                    matchCount = 0;
+
+                    if (!hasAdvancedCriteria)
+                    {
+                        FindElementsWithFindAll(rootElement, scanCondition, query, elementInfos, ref elementsScanned, maxResults);
+                    }
+                    else if (!query.ExactDepth.HasValue)
+                    {
+                        FindElementsWithCachedFilter(rootElement, scanCondition, query, elementInfos, ref elementsScanned, ref matchCount, maxResults);
+                    }
+                    else
+                    {
+                        FindElementsWithTreeWalker(rootElement, rootElement, scanCondition, query, effectiveMaxDepth, 0, elementInfos, ref elementsScanned, ref matchCount, maxResults, query.IncludeChildren);
+                    }
+
+                    // Exclude off-screen elements when visibility filtering is in effect.
+                    if (visibleOnly && elementInfos.Count > 0)
+                    {
+                        elementInfos.RemoveAll(e => e.IsOffscreen);
+                    }
                 }
 
-                // Exclude off-screen elements when visibility filtering is in effect.
-                if (visibleOnly && elementInfos.Count > 0)
+                // AND the caller's condition with the predefined content-view condition so FindAll
+                // returns only content-view elements (a strict subset of the control view).
+                var contentCondition = useContentView
+                    ? Uia.CreateAndCondition(condition, Uia.ContentViewCondition)
+                    : condition;
+
+                var usedContentView = useContentView;
+                RunScan(contentCondition);
+
+                // Guardrail: the content view can hide nodes some flows target (custom ARIA roles,
+                // decorative-but-interactive widgets). Fall back to the full control view when the
+                // content-view scan comes up empty so discoverability never regresses.
+                if (useContentView && elementInfos.Count == 0)
                 {
-                    elementInfos.RemoveAll(e => e.IsOffscreen);
+                    usedContentView = false;
+                    RunScan(condition);
                 }
 
                 stopwatch.Stop();
@@ -147,6 +180,8 @@ public sealed partial class UIAutomationService
                     elementsScanned = 0;
                     matchCount = 0;
 
+                    // Relaxation scans the control view for maximum recall.
+                    usedContentView = false;
                     FindElementsWithCachedFilter(rootElement, relaxedCondition, relaxedQuery, elementInfos, ref elementsScanned, ref matchCount, maxResults);
 
                     if (visibleOnly && elementInfos.Count > 0)
@@ -166,7 +201,7 @@ public sealed partial class UIAutomationService
                         "find",
                         UIAutomationErrorType.ElementNotFound,
                         BuildNotFoundMessage(query),
-                        CreateDiagnosticsWithContext(stopwatch, rootElement, query, elementsScanned, windowTitle, query.WindowHandle));
+                        CreateDiagnosticsWithContext(stopwatch, rootElement, query, elementsScanned, windowTitle, query.WindowHandle, usedContentView));
                 }
 
                 // Filter by region if specified (post-processing for FindAll path)
@@ -199,7 +234,7 @@ public sealed partial class UIAutomationService
                 }
 
                 // Always use compact format for Find to reduce token count by ~70%
-                return UIAutomationResult.CreateSuccessCompact("find", [.. elementInfos], CreateDiagnosticsWithContext(stopwatch, rootElement, query, elementsScanned, windowTitle, query.WindowHandle));
+                return UIAutomationResult.CreateSuccessCompact("find", [.. elementInfos], CreateDiagnosticsWithContext(stopwatch, rootElement, query, elementsScanned, windowTitle, query.WindowHandle, usedContentView));
             }, cancellationToken);
         }
         catch (COMException ex)

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -29,13 +29,23 @@ public readonly struct FrameworkStrategy
     public bool UsePostHocFiltering { get; init; }
 
     /// <summary>
+    /// Gets whether find operations should scan the UI Automation content view instead of the
+    /// full control view. True for Chromium/Electron (and unknown) frameworks, whose control view
+    /// exposes many non-interactive structural nodes that inflate candidate sets; the content view
+    /// is closer to the meaningful, user-facing elements an agent targets. False for native desktop
+    /// frameworks, where the control view is already compact and content view could hide relevant nodes.
+    /// </summary>
+    public bool UseContentView { get; init; }
+
+    /// <summary>
     /// Creates a strategy for Electron/Chromium apps (deep trees, need post-hoc filtering).
     /// </summary>
     public static FrameworkStrategy Electron => new()
     {
         FrameworkName = "Chromium/Electron",
         RecommendedMaxDepth = 15,
-        UsePostHocFiltering = true
+        UsePostHocFiltering = true,
+        UseContentView = true
     };
 
     /// <summary>
@@ -45,7 +55,8 @@ public readonly struct FrameworkStrategy
     {
         FrameworkName = "WinForms",
         RecommendedMaxDepth = 5,
-        UsePostHocFiltering = false
+        UsePostHocFiltering = false,
+        UseContentView = false
     };
 
     /// <summary>
@@ -55,7 +66,8 @@ public readonly struct FrameworkStrategy
     {
         FrameworkName = "WPF",
         RecommendedMaxDepth = 10,
-        UsePostHocFiltering = false
+        UsePostHocFiltering = false,
+        UseContentView = false
     };
 
     /// <summary>
@@ -65,7 +77,8 @@ public readonly struct FrameworkStrategy
     {
         FrameworkName = "Win32",
         RecommendedMaxDepth = 5,
-        UsePostHocFiltering = false
+        UsePostHocFiltering = false,
+        UseContentView = false
     };
 
     /// <summary>
@@ -75,7 +88,8 @@ public readonly struct FrameworkStrategy
     {
         FrameworkName = null,
         RecommendedMaxDepth = 15,
-        UsePostHocFiltering = true
+        UsePostHocFiltering = true,
+        UseContentView = true
     };
 }
 
@@ -350,7 +364,8 @@ public sealed partial class UIAutomationService
         ElementQuery? query,
         int elementsScanned,
         string? windowTitle,
-        string? windowHandle)
+        string? windowHandle,
+        bool? usedContentView = null)
     {
         return new UIAutomationDiagnostics
         {
@@ -359,7 +374,8 @@ public sealed partial class UIAutomationService
             ElementsScanned = elementsScanned,
             WindowTitle = windowTitle,
             WindowHandle = windowHandle,
-            DetectedFramework = DetectFramework(rootElement)
+            DetectedFramework = DetectFramework(rootElement),
+            UsedContentView = usedContentView
         };
     }
 

--- a/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
+++ b/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
@@ -49,6 +49,12 @@ public sealed record UIAutomationDiagnostics
     /// Detected UI framework of the target window (e.g., "Win32", "WPF", "WinForms", "Chromium/Electron", "Qt").
     /// </summary>
     public string? DetectedFramework { get; init; }
+
+    /// <summary>
+    /// Whether the find scanned the UI Automation content view (true) rather than the full control
+    /// view (false). Null when not applicable. Used to observe the R5 content-view optimization.
+    /// </summary>
+    public bool? UsedContentView { get; init; }
 }
 
 /// <summary>
@@ -155,4 +161,13 @@ public sealed record ElementQuery
     /// hidden/virtualized nodes), included otherwise. Set explicitly to override.
     /// </summary>
     public bool? VisibleOnly { get; init; }
+
+    /// <summary>
+    /// When set, controls whether the search scans only the UI Automation content view (meaningful,
+    /// user-facing elements) instead of the full control view. When null, the framework strategy
+    /// decides: content view for Chromium/Electron (whose control view is bloated with structural
+    /// nodes), control view otherwise. Set explicitly to override. Even when content view is used,
+    /// the search automatically falls back to the control view if the content-view scan finds nothing.
+    /// </summary>
+    public bool? ContentViewOnly { get; init; }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumContentViewTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumContentViewTests.cs
@@ -1,0 +1,112 @@
+using Sbroenne.WindowsMcp.Models;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.ChromiumBrowser;
+
+/// <summary>
+/// Integration coverage for the R5 content-view optimization (#136 follow-up #139).
+/// Verifies that, under the Chromium strategy, <c>ui_find</c> scans the leaner UI Automation
+/// content view by default, that this never scans more elements than the full control view, and
+/// that meaningful elements remain discoverable (with a control-view fallback escape hatch).
+/// </summary>
+[Collection("ChromiumBrowser")]
+[Trait("Category", "RequiresDesktop")]
+[Trait("Category", "ChromiumBrowser")]
+public sealed class ChromiumContentViewTests : IClassFixture<ChromiumReadOnlySessionFixture>
+{
+    private const int QueryTimeoutMs = 5000;
+    private const string PrimaryNavigationName = "Primary navigation";
+
+    private readonly ChromiumReadOnlySessionFixture _readOnlySessions;
+
+    public ChromiumContentViewTests(ChromiumReadOnlySessionFixture readOnlySessions)
+    {
+        _readOnlySessions = readOnlySessions;
+    }
+
+    [Theory]
+    [InlineData(ChromiumBrowserKind.Edge)]
+    [InlineData(ChromiumBrowserKind.Chrome)]
+    public async Task Find_DefaultOnChromium_UsesContentView(ChromiumBrowserKind browser)
+    {
+        ChromiumBrowserSession.SkipUnlessSupported(browser);
+
+        var session = _readOnlySessions.GetSession(browser);
+        using var harness = new ChromiumAutomationHarness();
+
+        var result = await harness.AutomationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = session.WindowHandleString,
+            Name = PrimaryNavigationName,
+            TimeoutMs = QueryTimeoutMs,
+        });
+
+        Assert.True(result.Success, $"Find failed: {result.ErrorMessage}");
+        Assert.NotEmpty(result.Items!);
+        Assert.NotNull(result.Diagnostics);
+        Assert.True(result.Diagnostics!.UsedContentView, "Chromium find should default to the content view.");
+    }
+
+    [Theory]
+    [InlineData(ChromiumBrowserKind.Edge)]
+    [InlineData(ChromiumBrowserKind.Chrome)]
+    public async Task Find_ContentView_ScansNoMoreThanControlView(ChromiumBrowserKind browser)
+    {
+        ChromiumBrowserSession.SkipUnlessSupported(browser);
+
+        var session = _readOnlySessions.GetSession(browser);
+        using var harness = new ChromiumAutomationHarness();
+
+        // Broad, unfiltered scan so the full candidate set is exercised on both views.
+        var controlView = await harness.AutomationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = session.WindowHandleString,
+            ContentViewOnly = false,
+            TimeoutMs = QueryTimeoutMs,
+        });
+
+        var contentView = await harness.AutomationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = session.WindowHandleString,
+            ContentViewOnly = true,
+            TimeoutMs = QueryTimeoutMs,
+        });
+
+        Assert.True(controlView.Success, $"Control-view find failed: {controlView.ErrorMessage}");
+        Assert.True(contentView.Success, $"Content-view find failed: {contentView.ErrorMessage}");
+
+        var controlScanned = controlView.Diagnostics!.ElementsScanned!.Value;
+        var contentScanned = contentView.Diagnostics!.ElementsScanned!.Value;
+
+        Assert.True(contentScanned > 0, "Content view should still surface elements.");
+        Assert.False(controlView.Diagnostics.UsedContentView);
+        Assert.True(contentView.Diagnostics.UsedContentView);
+
+        // Content view is a strict subset of the control view, so it can never scan more nodes.
+        Assert.True(
+            contentScanned <= controlScanned,
+            $"Content view scanned {contentScanned} elements but control view scanned {controlScanned}.");
+    }
+
+    [Theory]
+    [InlineData(ChromiumBrowserKind.Edge)]
+    [InlineData(ChromiumBrowserKind.Chrome)]
+    public async Task Find_ContentViewOff_StillFindsElement(ChromiumBrowserKind browser)
+    {
+        ChromiumBrowserSession.SkipUnlessSupported(browser);
+
+        var session = _readOnlySessions.GetSession(browser);
+        using var harness = new ChromiumAutomationHarness();
+
+        var result = await harness.AutomationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = session.WindowHandleString,
+            Name = PrimaryNavigationName,
+            ContentViewOnly = false,
+            TimeoutMs = QueryTimeoutMs,
+        });
+
+        Assert.True(result.Success, $"Find failed: {result.ErrorMessage}");
+        Assert.NotEmpty(result.Items!);
+        Assert.False(result.Diagnostics!.UsedContentView, "Explicit contentViewOnly=false must scan the control view.");
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/CallToolResultMigrationSmokeTests.cs
@@ -68,6 +68,7 @@ public sealed class CallToolResultMigrationSmokeTests
             inRegion: null,
             nearElement: null,
             visibleOnly: null,
+            contentViewOnly: null,
             timeoutMs: 5000,
             includeDiagnostics: false,
             cancellationToken: CancellationToken.None);

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/FrameworkStrategyTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/FrameworkStrategyTests.cs
@@ -1,0 +1,47 @@
+using Sbroenne.WindowsMcp.Automation;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for <see cref="FrameworkStrategy"/> content-view selection (R5 from #136).
+/// The content view is only meaningful for Chromium/Electron (and unknown) frameworks, whose
+/// control view is bloated with structural nodes. Native frameworks keep the control view.
+/// </summary>
+public class FrameworkStrategyTests
+{
+    [Fact]
+    public void Electron_UsesContentView()
+    {
+        Assert.True(FrameworkStrategy.Electron.UseContentView);
+    }
+
+    [Fact]
+    public void Unknown_UsesContentView()
+    {
+        // Unknown defaults to the Chromium-safe behavior.
+        Assert.True(FrameworkStrategy.Unknown.UseContentView);
+    }
+
+    [Theory]
+    [MemberData(nameof(NativeStrategies))]
+    public void NativeFrameworks_DoNotUseContentView(FrameworkStrategy strategy)
+    {
+        Assert.False(strategy.UseContentView);
+    }
+
+    public static TheoryData<FrameworkStrategy> NativeStrategies => new()
+    {
+        FrameworkStrategy.Win32,
+        FrameworkStrategy.WinForms,
+        FrameworkStrategy.Wpf,
+    };
+
+    [Fact]
+    public void ContentViewFrameworks_AlsoUsePostHocFiltering()
+    {
+        // Content-view frameworks are exactly the ones that need off-screen post-hoc filtering,
+        // so the two flags should stay aligned for Electron/Unknown.
+        Assert.True(FrameworkStrategy.Electron is { UseContentView: true, UsePostHocFiltering: true });
+        Assert.True(FrameworkStrategy.Unknown is { UseContentView: true, UsePostHocFiltering: true });
+    }
+}


### PR DESCRIPTION
Implements **R5** from the browser-optimization spike (#136), tracked in #139.

## What
Under the Chromium/Electron framework strategy, `ui_find` now scans the UI Automation **content view** instead of the full **control view**. It ANDs the caller's condition with the predefined `ContentViewCondition` so `FindAllBuildCache` returns only the meaningful, user-facing subset of nodes.

## Why
The control view exposes many non-interactive/structural nodes (containers, wrappers, scrollbars) that inflate `FindAllBuildCache` result sets and client-side filtering cost. The content view is closer to what an agent actually targets → smaller candidate sets, cheaper cached-property filtering, and better LLM selection reliability. Builds on R1's `FindAllBuildCache` path.

## Scope & guardrails
- **Chromium/Electron (and Unknown) only** — native desktop frameworks (Win32/WinForms/WPF) keep the control view (`FrameworkStrategy.UseContentView`).
- **Automatic fallback**: if a content-view scan comes up empty, it re-runs against the full control view, so discoverability never regresses (handles custom ARIA roles / decorative-but-interactive widgets).
- **`ExactDepth` keeps the control view** to preserve depth semantics.
- Composes with R2 `visibleOnly` (off-screen filtering) and R3 scoping.

## Open question (resolved)
Default-on vs opt-in → **default-on** for Chromium, made safe by the fallback. Escape hatch: new `contentViewOnly` query flag on `ui_find` (`ElementQuery.ContentViewOnly`). Diagnostics expose `UsedContentView` for observability.

## Tests
- `FrameworkStrategyTests` (unit): content-view flags per framework.
- `ChromiumContentViewTests` (integration): default-on uses content view; content-view scan count never exceeds control view; explicit `contentViewOnly=false` still finds elements.
- Full unit suite green (279 passed). Chromium integration tests validate in CI (local runs are browser-launch-flaky in this environment).

Closes #139
