### PR TITLE
docs: add sister-projects note pointing to mcp-server-excel as authoritative template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,24 @@
 # Copilot Instructions for mcp-windows
 
+## Sister Projects
+
+`mcp-windows` is one of a family of Windows-only MCP-server repos maintained by the same author
+(`sbroenne`). The family also includes:
+
+- **`mcp-server-excel`** (`sbroenne/mcp-server-excel`) — Excel COM automation. This is the
+  **authoritative architectural template** for the family's general server-side patterns: layered
+  architecture (Core → Service → CLI/MCP Server), the "two equal entry points" (MCP Server + CLI)
+  principle, Unified Service Architecture (shared daemon/session registry), and its support/audit
+  scripts (`scripts/*.ps1`) and CI Gate workflow. `mcp-windows` is UI-automation-focused (FlaUI/
+  pywinauto patterns) rather than COM/Office-interop-focused, so not every Excel pattern applies
+  directly — but when solving a cross-cutting problem (session lifecycle, CLI/MCP parity, daemon
+  process management, pre-commit audit tooling), check how Excel solved it first.
+- **`mcp-server-powerpoint`** (`sbroenne/mcp-server-powerpoint`) — PowerPoint COM automation,
+  structurally mirrors `mcp-server-excel`.
+
+If you fix a real bug or process/tooling gap here that likely also exists in the other repos,
+flag it so the same fix can be considered there.
+
 ## Core Principles
 
 The project follows these NON-NEGOTIABLE principles:


### PR DESCRIPTION
## Summary
Adds a Sister Projects note to \.github/copilot-instructions.md\, mirroring the equivalent note already added to \mcp-server-excel\ and \mcp-server-powerpoint\.

\mcp-windows\ is one of a family of Windows-only MCP-server repos maintained by the same author. This documents that \mcp-server-excel\ is the **authoritative architectural template** for cross-cutting server-side patterns (layered architecture, MCP Server + CLI parity, session/daemon management, pre-commit audit tooling) - while noting that \mcp-windows\ itself is UI-automation-focused (FlaUI/pywinauto) rather than COM/Office-interop-focused, so not every Excel pattern applies directly.

## Why
Keeps agent guidance consistent across the sister-repo family so future work references a single source of truth for cross-cutting patterns instead of re-deriving them independently in each repo.