### PR TITLE
Update pytest-skill-engineering to v0.6.13

### DIFF
--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "LLM integration tests for Windows MCP Server using pytest-skill-engineering"
 requires-python = ">=3.12"
 dependencies = [
-    "pytest-skill-engineering[copilot]",
+    "pytest-skill-engineering",
     "anyio==4.11.0",
     "pytest-asyncio",
     "socksio",
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-pytest-skill-engineering = { git = "https://github.com/sbroenne/pytest-skill-engineering", rev = "f5f452dfd8069f8ef086750ebd3b1f5cbc9b02d4" }
+pytest-skill-engineering = { git = "https://github.com/sbroenne/pytest-skill-engineering", rev = "v0.6.13" }
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
Bumps the pinned `pytest-skill-engineering` dependency in `tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml` from an old unreleased commit to the tagged **v0.6.13** release.

- Migrates to the Copilot SDK 1.x API (upstream change)
- Drops the now-nonexistent `[copilot]` extra — `github-copilot-sdk` is a core dependency in this version

## Verification
- `uv sync` resolves and installs cleanly (used Python 3.13 x86_64; the ARM64 interpreter fails to build `cryptography` from source locally — no MSVC linker, unrelated to this change)
- `pytest --collect-only` collects all 135 LLM integration tests with no errors
- Ran the suite live: 100+ tests passed before the run was intentionally stopped (these tests drive real desktop UI automation, so a full unattended run wasn't completed in this shared session — no failures were attributable to the dependency bump)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>