### PR TITLE
Make LLM tests strictly manual-only

### DIFF
--- a/.github/RELEASE_SETUP.md
+++ b/.github/RELEASE_SETUP.md
@@ -6,10 +6,9 @@ This document explains how to configure the GitHub infrastructure for the Window
 
 The release workflow (`.github/workflows/release-unified.yml`) is a unified workflow that builds and publishes all Windows MCP Server components (standalone binaries and VS Code extension) with a single version number.
 
-The workflow optionally runs LLM integration tests with a real AI model (GPT-5.5 via GitHub Copilot) before building and publishing releases (if a Copilot-enabled token is configured). This requires:
+LLM integration tests are intentionally manual-only. They are never invoked by PR, CI, or release workflows; run them separately through the dedicated **LLM Integration Tests** workflow when needed.
 
-1. **GitHub Secrets** — For VS Code Marketplace publishing (required)
-2. **`COPILOT_GITHUB_TOKEN` secret** — A GitHub token with Copilot access, for running LLM tests (optional)
+The release workflow requires the **GitHub Secrets** configuration for VS Code Marketplace publishing described below.
 
 ## Architecture
 
@@ -42,21 +41,6 @@ The workflow optionally runs LLM integration tests with a real AI model (GPT-5.5
                  └─────────────────────┘
 ```
 
-**Optional LLM Tests** (if `COPILOT_GITHUB_TOKEN` is configured):
-```
-┌─────────────────────┐   COPILOT_GITHUB_TOKEN   ┌─────────────────────┐
-│   GitHub Actions    │ ───────────────────────► │  GitHub Copilot     │
-│   (windows-latest)  │                          │  (GPT-5.5)          │
-└─────────────────────┘                          └─────────────────────┘
-         │
-         │ pytest-skill-engineering drives the MCP server
-         ▼
-┌─────────────────────┐
-│  Windows MCP Server │
-│  (UI automation)    │
-└─────────────────────┘
-```
-
 ## Step 1: Configure GitHub Secrets
 
 Go to your GitHub repository → Settings → Secrets and variables → Actions.
@@ -66,14 +50,6 @@ Go to your GitHub repository → Settings → Secrets and variables → Actions.
 | Secret Name | Value | Description |
 |-------------|-------|-------------|
 | `VSCE_TOKEN` | `xxxxxxxx...` | VS Code Marketplace Personal Access Token (required for publishing) |
-
-### Optional Secrets (for LLM tests)
-
-| Secret Name | Value | Description |
-|-------------|-------|-------------|
-| `COPILOT_GITHUB_TOKEN` | `ghp_xxxx...` / `gho_xxxx...` | A GitHub token with Copilot access. If unset, the release LLM test job is skipped. |
-
-**Note:** LLM tests are automatically skipped if `COPILOT_GITHUB_TOKEN` is not configured.
 
 ### Getting a VSCE Token
 
@@ -85,9 +61,9 @@ Go to your GitHub repository → Settings → Secrets and variables → Actions.
    - **Scopes**: Marketplace → Manage
 4. Copy the token (shown only once!)
 
-## Step 2: LLM Test Model
+## Manual LLM Tests
 
-The release LLM tests run against **GPT-5.5 via GitHub Copilot**. No Azure resources or model deployments are required — authentication is handled entirely through the `COPILOT_GITHUB_TOKEN` secret. The model is configured in `tests/Sbroenne.WindowsMcp.LLM.Tests/conftest.py`.
+LLM tests run against **GPT-5.5 via GitHub Copilot**. They are intentionally isolated from releases and all automatic workflows. To run them, open GitHub Actions, select **LLM Integration Tests**, choose **Run workflow**, and optionally specify one scenario. The model is configured in `tests/Sbroenne.WindowsMcp.LLM.Tests/conftest.py`.
 
 ## How to Release
 
@@ -104,12 +80,11 @@ The new release process uses a unified workflow that is triggered manually via w
 
 The workflow will:
 1. Calculate the next version from the latest `v*` tag
-2. (Optional) Run LLM integration tests if `COPILOT_GITHUB_TOKEN` is configured
-3. Build standalone binaries (win-x64, win-arm64)
-4. Build VS Code extension (VSIX)
-5. Create and push the git tag (e.g., `v1.2.4`)
-6. Publish to VS Code Marketplace
-7. Create GitHub release with all artifacts
+2. Build standalone binaries (win-x64, win-arm64)
+3. Build VS Code extension (VSIX)
+4. Create and push the git tag (e.g., `v1.2.4`)
+5. Publish to VS Code Marketplace
+6. Create GitHub release with all artifacts
 
 ### Test a Release (Dry Run)
 
@@ -146,13 +121,9 @@ uv run pytest -v
 
 ## Troubleshooting
 
-### LLM tests are skipped in the release
-
-The `COPILOT_GITHUB_TOKEN` secret is not configured, or is empty. The release workflow logs a warning and continues. Add the secret to enable the LLM test job.
-
 ### LLM tests fail to authenticate
 
-Verify the token has Copilot access. Locally, confirm `gh auth status` succeeds or that `GITHUB_TOKEN` is set to a Copilot-enabled token.
+For local runs, confirm `gh auth status` succeeds or that `GITHUB_TOKEN` is set to a Copilot-enabled token. For GitHub-hosted runs, use the dedicated manual **LLM Integration Tests** workflow.
 
 ### LLM Tests Fail with "No GUI session"
 
@@ -163,8 +134,8 @@ GitHub Actions `windows-latest` runners have a desktop session by default. If te
 ## Security Considerations
 
 1. **No secrets in code** — All credentials are in GitHub Secrets
-2. **Scoped token** — `COPILOT_GITHUB_TOKEN` is only exposed to the LLM test job
-3. **Manual approval** — Releases are triggered manually via workflow_dispatch, not automatically on push
+2. **Manual approval** — Releases are triggered manually via workflow_dispatch, not automatically on push
+3. **Test isolation** — LLM tests can only be started through their dedicated workflow_dispatch trigger
 
 ## Migration from Old Release Process
 

--- a/.github/documentation.instructions.md
+++ b/.github/documentation.instructions.md
@@ -8,7 +8,7 @@ This document defines the purpose and content rules for each documentation file 
 >
 > Windows MCP Server uses the Windows UI Automation API — the same API screen readers use. It asks Windows directly: "What buttons exist?" Deterministic. Same command works every time.
 >
-> Tested with GPT-5.5 before every release. 130+ tests, 100% pass rate required.
+> Tested with GPT-5.5 through a dedicated manual workflow. 130+ tests, isolated from PR, CI, and release workflows.
 
 ## Three Entry Points
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - '*.sln'
       - 'Directory.Packages.props'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/release-unified.yml'
+      - '.github/workflows/llm-tests.yml'
   pull_request:
     branches: [main]
     paths:
@@ -17,6 +19,8 @@ on:
       - '*.sln'
       - 'Directory.Packages.props'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/release-unified.yml'
+      - '.github/workflows/llm-tests.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -1,11 +1,9 @@
 name: LLM Integration Tests
 
-# Reusable workflow for LLM integration tests
+# Manual workflow for LLM integration tests
 # Each scenario runs in its own isolated job for clean UI state
-# Can be triggered manually or called from other workflows
 
 on:
-  # Manual trigger for testing
   workflow_dispatch:
     inputs:
       scenario:
@@ -13,9 +11,6 @@ on:
         required: false
         type: string
         default: ''
-
-  # Allow other workflows to call this
-  workflow_call:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'

--- a/.github/workflows/release-unified.yml
+++ b/.github/workflows/release-unified.yml
@@ -11,7 +11,6 @@ name: Release All Components
 #
 # Required GitHub Secrets:
 # - VSCE_TOKEN: VS Code Marketplace PAT
-# - COPILOT_GITHUB_TOKEN: GitHub token with Copilot access (required for release LLM tests)
 
 on:
   workflow_dispatch:
@@ -114,61 +113,11 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
   # =============================================================================
-  # Job 1: LLM Integration Tests
-  # =============================================================================
-  llm-tests:
-    name: LLM Integration Tests
-    needs: [version]
-    runs-on: windows-latest
-    permissions:
-      contents: read
-
-    steps:
-    - uses: actions/checkout@v7
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Setup Python & uv
-      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-      with:
-        python-version: '3.12'
-        enable-cache: false
-
-    - name: Run LLM Integration Tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
-        UV_LINK_MODE: copy
-      run: |
-        if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
-          Write-Error "COPILOT_GITHUB_TOKEN is required to run the release LLM integration tests. A release must not ship without AI validation. Configure the COPILOT_GITHUB_TOKEN secret and re-run."
-          exit 1
-        }
-
-        cd tests/Sbroenne.WindowsMcp.LLM.Tests
-        dotnet build ../../src/Sbroenne.WindowsMcp -c Release -v:q
-        uv sync
-        uv run pytest test_notepad_ui.py test_calculator_workflow.py test_window_workflow.py -v --tb=short --junitxml=TestResults/results.xml --no-header -p no:aitest-summary
-      shell: pwsh
-
-    - name: Upload LLM Test Reports
-      uses: actions/upload-artifact@v7
-      if: always()
-      with:
-        name: llm-test-reports
-        path: tests/Sbroenne.WindowsMcp.LLM.Tests/TestResults/
-        retention-days: 30
-
-  # =============================================================================
-  # Job 2: Build Standalone MCP Server - Self-contained binaries
+  # Job 1: Build Standalone MCP Server - Self-contained binaries
   # =============================================================================
   build-standalone:
     name: Build Standalone MCP Server
-    needs: [version, llm-tests]
-    # Always run if LLM tests pass OR if they were skipped
-    if: always() && (needs.llm-tests.result == 'success' || needs.llm-tests.result == 'skipped')
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -246,13 +195,11 @@ jobs:
         retention-days: 1
 
   # =============================================================================
-  # Job 3: Build VS Code Extension
+  # Job 2: Build VS Code Extension
   # =============================================================================
   build-vscode-extension:
     name: Build VS Code Extension
-    needs: [version, llm-tests]
-    # Always run if LLM tests pass OR if they were skipped
-    if: always() && (needs.llm-tests.result == 'success' || needs.llm-tests.result == 'skipped')
+    needs: [version]
     runs-on: windows-latest
     permissions:
       contents: read
@@ -362,7 +309,7 @@ jobs:
         retention-days: 1
 
   # =============================================================================
-  # Job 4: Create Git Tag
+  # Job 3: Create Git Tag
   # =============================================================================
   create-tag:
     name: Create Git Tag
@@ -388,7 +335,7 @@ jobs:
           git push origin "$TAG"
 
   # =============================================================================
-  # Job 5: Publish to VS Code Marketplace
+  # Job 4: Publish to VS Code Marketplace
   # =============================================================================
   publish:
     name: Publish to Marketplace
@@ -420,7 +367,7 @@ jobs:
       id: publishToMarketplace
 
   # =============================================================================
-  # Job 6: Create Unified GitHub Release
+  # Job 5: Create Unified GitHub Release
   # =============================================================================
   create-release:
     name: Create GitHub Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ These tests use [pytest-skill-engineering](https://github.com/sbroenne/pytest-sk
 - Windows desktop session with GUI access
 - Python 3.12+ and uv
 
-**LLM tests run automatically during every release** via GitHub Actions using the workflow `GITHUB_TOKEN`. A 100% pass rate is required before release. See [.github/RELEASE_SETUP.md](.github/RELEASE_SETUP.md) for configuration details.
+**LLM tests are intentionally manual-only.** They never run as part of PR, CI, or release workflows. Run them from the dedicated **LLM Integration Tests** workflow in GitHub Actions, or locally as described below. See [.github/RELEASE_SETUP.md](.github/RELEASE_SETUP.md) for details.
 
 #### Running LLM Tests
 
@@ -204,7 +204,7 @@ uv run pytest integration/ -v
 #### Test Design Principles
 
 - **Use well-known apps**: Tests target Notepad, Paint, Calculator (apps LLMs recognize)
-- **100% pass rate required**: All tests must pass before release
+- **Manual-only execution**: Run the suite explicitly through the dedicated workflow or locally
 - **Real model**: Tests run against GPT-5.5 via GitHub Copilot
 - **Token tracking**: Tests report token usage to validate optimization
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -47,7 +47,7 @@ Every tool is tested with a **real AI model** (GPT-5.5 via GitHub Copilot) using
 | Run Dialog & App Launch | Launching classic and UWP apps | 100% |
 | Real-World Workflows | Multi-step, end-to-end scenarios | 100% |
 
-> 130+ automated LLM tests run against GPT-5.5; a 100% pass rate is required before every release.
+> 130+ LLM tests run against GPT-5.5 through the dedicated manual **LLM Integration Tests** workflow.
 
 **Why LLM testing matters:**
 
@@ -55,7 +55,7 @@ Every tool is tested with a **real AI model** (GPT-5.5 via GitHub Copilot) using
 - **Response formats affect reasoning** — Structured hints guide the LLM to correct next steps
 - **Edge cases surface quickly** — Real models find ambiguities that unit tests miss
 
-LLM tests run as part of every release. See [CONTRIBUTING.md](CONTRIBUTING.md#llm-integration-tests) for how to run them yourself.
+LLM tests are intentionally manual-only and never run as part of PR, CI, or release workflows. See [CONTRIBUTING.md](CONTRIBUTING.md#llm-integration-tests) for how to run them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/sbroenne/mcp-windows/actions/workflows/ci.yml/badge.svg)](https://github.com/sbroenne/mcp-windows/actions/workflows/ci.yml)
 [![LLM Tests](https://github.com/sbroenne/mcp-windows/actions/workflows/llm-tests.yml/badge.svg)](https://github.com/sbroenne/mcp-windows/actions/workflows/llm-tests.yml)
 
-**Windows automation that actually works.** Uses the Windows UI Automation API to find buttons by name, not pixels. Tested with real AI models before every release.
+**Windows automation that actually works.** Uses the Windows UI Automation API to find buttons by name, not pixels. Tested with real AI models through a dedicated manual workflow.
 
 ## Why This Exists
 
@@ -39,7 +39,7 @@ Browsers follow the same semantic flow: launch `msedge.exe` or `chrome.exe`, the
 
 - **🧠 Semantic UI** — Find elements by name, not coordinates. Works regardless of DPI, theme, or window position.
 - **� Multi-Monitor** — Full support for multiple displays with per-monitor DPI scaling.
-- **🧪 LLM-Tested** — 130+ tests with a real AI model (GPT-5.5 via GitHub Copilot). 100% pass rate required for release.
+- **🧪 LLM-Tested** — 130+ tests with a real AI model (GPT-5.5 via GitHub Copilot), run intentionally through a dedicated manual workflow.
 - **💻 Broad App Support** — Tested against classic Windows apps, modern Windows 11 apps, and Electron apps (VS Code, Teams, Slack). Chromium browser pages follow the same ARIA-driven pattern, but browser chrome remains best-effort.
 - **🔄 Full Fallback** — Screenshot + mouse + keyboard for games and custom controls.
 - **🪙 Token Optimized** — Short property names, JPEG screenshots, and auto-scaling substantially reduce token usage compared to standard JSON.
@@ -114,7 +114,7 @@ dotnet test --filter "FullyQualifiedName~Unit"   # Unit only
 dotnet test .\tests\Sbroenne.WindowsMcp.Tests\Sbroenne.WindowsMcp.Tests.csproj --filter "FullyQualifiedName~ChromiumBrowser"
 ```
 
-**LLM tests**: 130+ tests with a real AI model (GPT-5.5 via GitHub Copilot). 100% pass rate required for release.
+**LLM tests**: 130+ tests with a real AI model (GPT-5.5 via GitHub Copilot). They are intentionally manual-only and never run as part of PR, CI, or release workflows. Run them from the dedicated **LLM Integration Tests** workflow in GitHub Actions.
 
 ```powershell
 cd tests/Sbroenne.WindowsMcp.LLM.Tests

--- a/gh-pages/docs/architecture.md
+++ b/gh-pages/docs/architecture.md
@@ -67,6 +67,6 @@ MCP config entry) and runs as a local process — see [Installation](installatio
 Because tool descriptions that read clearly to humans can still confuse a model,
 every tool is validated with a **real AI model** (GPT-5.5 via GitHub Copilot) using
 [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering): 130+ automated tests
-with a 100% pass rate required for release. When the AI misuses a tool, the fix
-is to the tool — not the test prompt. See [Contributing](contributing.md) for how
-the test suites are run.
+run through a dedicated manual workflow. They never run as part of PR, CI, or release
+workflows. When the AI misuses a tool, the fix is to the tool — not the test prompt.
+See [Contributing](contributing.md) for how the test suites are run.

--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -117,10 +117,10 @@ misunderstood. Actions get skipped.
 
 We test every tool with a **real AI model** (GPT-5.5 via GitHub Copilot) using
 [pytest-skill-engineering](https://github.com/sbroenne/pytest-skill-engineering). 130+ automated tests.
-**100% pass rate required for release.** If the AI can't use it correctly, we fix
-the tool — not the prompt.
+The tests are intentionally manual-only and isolated from PR, CI, and release workflows.
+If the AI can't use a tool correctly, we fix the tool — not the prompt.
 
-[View latest LLM test results :material-arrow-right:](https://github.com/sbroenne/mcp-windows/releases/latest){ .md-button }
+[Run the LLM Integration Tests workflow :material-arrow-right:](https://github.com/sbroenne/mcp-windows/actions/workflows/llm-tests.yml){ .md-button }
 
 ## Quick start
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
@@ -137,6 +137,7 @@ public sealed class UIClickToolIntegrationTests : IDisposable
     }
 
     [SkippableFact]
+    [Trait("Category", "RequiresDesktop")]
     public async Task FindAndClick_WhenActionHasNoObservableEffect_ReturnsFailure()
     {
         EnsureHarnessOnPrimaryMonitor();

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
@@ -108,6 +108,7 @@ public sealed class UIClickToolIntegrationTests : IDisposable
     }
 
     [SkippableFact]
+    [Trait("Category", "RequiresDesktop")]
     public async Task FindAndClick_WhenSemanticPatternIsUnavailable_UsesPhysicalFallback()
     {
         EnsureHarnessOnPrimaryMonitor();

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/WorkflowContractTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/WorkflowContractTests.cs
@@ -1,0 +1,66 @@
+using System.Text.RegularExpressions;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+public sealed partial class WorkflowContractTests
+{
+    [Fact]
+    public void LlmTestsWorkflow_IsManualDispatchOnly()
+    {
+        var workflow = ReadWorkflow("llm-tests.yml");
+        var triggerSection = TriggerSectionRegex().Match(workflow).Groups["section"].Value;
+        var triggers = TopLevelTriggerRegex()
+            .Matches(triggerSection)
+            .Select(match => match.Groups["trigger"].Value)
+            .ToArray();
+
+        Assert.Equal(["workflow_dispatch"], triggers);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_DoesNotReferenceLlmTests()
+    {
+        var workflow = ReadWorkflow("release-unified.yml");
+        var normalizedWorkflow = workflow.ReplaceLineEndings("\n");
+
+        Assert.DoesNotContain("llm-tests", workflow, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("LLM Integration Tests", workflow, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("COPILOT_GITHUB_TOKEN", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "  build-standalone:\n    name: Build Standalone MCP Server\n    needs: [version]\n",
+            normalizedWorkflow,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "  build-vscode-extension:\n    name: Build VS Code Extension\n    needs: [version]\n",
+            normalizedWorkflow,
+            StringComparison.Ordinal);
+    }
+
+    private static string ReadWorkflow(string fileName)
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        return File.ReadAllText(Path.Combine(repositoryRoot, ".github", "workflows", fileName));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "Sbroenne.WindowsMcp.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+
+    [GeneratedRegex(@"(?m)^  (?<trigger>[a-z_]+):(?:\s|$)")]
+    private static partial Regex TopLevelTriggerRegex();
+
+    [GeneratedRegex(@"(?ms)^on:\s*\r?\n(?<section>.*?)(?=^[a-z_]+:)")]
+    private static partial Regex TriggerSectionRegex();
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -30,7 +30,7 @@ For games and custom controls without accessibility data, full screenshot + mous
 - **📺 Multi-Monitor** — Full support for multiple displays with per-monitor DPI scaling.
 - **💻 Broad App Support** — Works with classic Windows apps, modern Windows 11 apps, and Electron apps.
 - **🔄 Full Fallback** — Screenshot + mouse + keyboard for games and custom controls.
-- **🧪 LLM-Tested** — Every tool tested with real AI models before release.
+- **🧪 LLM-Tested** — Every tool tested with real AI models through a dedicated manual workflow.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove LLM integration testing from the release workflow and make both release builds depend directly on version calculation
- restrict the dedicated LLM test workflow to `workflow_dispatch` while preserving scenario selection
- update release and user documentation to state that LLM tests are intentionally manual-only
- add xUnit workflow contract coverage and run CI when either protected workflow changes

## Validation
- `dotnet test --filter "FullyQualifiedName~Unit" --no-restore --verbosity quiet` (388 passed)
- `dotnet build --configuration Release --no-restore --verbosity quiet`