### PR TITLE
Fix deterministic VS Code extension packaging failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'vscode-extension/**'
       - '*.sln'
       - 'Directory.Packages.props'
       - '.github/workflows/ci.yml'
@@ -16,6 +17,7 @@ on:
     paths:
       - 'src/**'
       - 'tests/**'
+      - 'vscode-extension/**'
       - '*.sln'
       - 'Directory.Packages.props'
       - '.github/workflows/ci.yml'
@@ -30,6 +32,35 @@ permissions:
   contents: read
 
 jobs:
+  vscode-extension:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v7
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: vscode-extension/package-lock.json
+
+    - name: Install Dependencies
+      working-directory: vscode-extension
+      run: npm ci --no-audit --no-fund
+
+    - name: Check Manifest Compatibility
+      working-directory: vscode-extension
+      run: npm test
+
+    - name: Lint
+      working-directory: vscode-extension
+      run: npm run lint
+
+    - name: Compile
+      working-directory: vscode-extension
+      run: npm run compile
+
   build-and-test:
     runs-on: windows-latest
 

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -8,6 +8,7 @@ tsconfig.json
 # Development files
 .vscode/**
 node_modules/**
+test/**
 *.ts
 *.map
 eslint.config.mjs

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@types/node": "^26.1.1",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "1.120.0",
         "@vscode/vsce": "^3.9.2",
         "oxlint": "^1.74.0",
         "typescript": "^7.0.2"
@@ -913,9 +913,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.120.0.tgz",
+      "integrity": "sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==",
       "dev": true,
       "license": "MIT"
     },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -62,12 +62,13 @@
     "vscode:prepublish": "npm run build:mcp-server && npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "package": "npm run build:mcp-server && vsce package",
+    "test": "node --test test/*.test.js",
+    "package": "npm test && npm run build:mcp-server && vsce package",
     "lint": "oxlint src"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "1.120.0",
     "@vscode/vsce": "^3.9.2",
     "oxlint": "^1.74.0",
     "typescript": "^7.0.2"

--- a/vscode-extension/test/manifest-compatibility.test.js
+++ b/vscode-extension/test/manifest-compatibility.test.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+const test = require('node:test');
+
+const manifest = JSON.parse(
+    readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+);
+
+function versionParts(versionRange) {
+    const match = versionRange.match(/(\d+)\.(\d+)\.(\d+)/);
+    assert.ok(match, `Expected a semantic version in "${versionRange}"`);
+    return match.slice(1).map(Number);
+}
+
+test('@types/vscode does not exceed the minimum supported VS Code version', () => {
+    const engineVersion = versionParts(manifest.engines.vscode);
+    const typesVersion = versionParts(manifest.devDependencies['@types/vscode']);
+    const comparison = typesVersion.findIndex(
+        (part, index) => part !== engineVersion[index]
+    );
+
+    assert.ok(
+        comparison === -1 || typesVersion[comparison] < engineVersion[comparison],
+        `@types/vscode ${manifest.devDependencies['@types/vscode']} exceeds engines.vscode ${manifest.engines.vscode}`
+    );
+});


### PR DESCRIPTION
## Summary
- pin `@types/vscode` to the extension's existing VS Code 1.120 compatibility floor
- add a manifest compatibility test that prevents API types from exceeding `engines.vscode`
- run extension install, compatibility, lint, and compile checks in CI
- exclude development tests from the packaged VSIX

## Validation
- `npm test`
- `npm run lint`
- `npm run compile`
- `npm run package` (created `windows-mcp-1.0.0.vsix`)