### PR TITLE
ui_read: clean article/markdown mode for web pages (#167)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -253,6 +253,7 @@ Read text from elements using UI Automation or OCR.
 | `controlType` | Control type filter | No |
 | `includeChildren` | Include child element text | No (default: false) |
 | `language` | OCR language code (e.g., 'en-US') | No |
+| `format` | `raw` (default) or `article` for clean web-page text | No |
 
 ### Capabilities
 
@@ -260,6 +261,11 @@ Read text from elements using UI Automation or OCR.
 - Automatic OCR fallback for custom-rendered text
 - Windows.Media.Ocr for local text recognition
 - Language support for international text
+- **Article mode (`format: "article"`)** for web pages in Edge/Chrome: returns the main
+  content only — navigation chrome, breadcrumbs, and "in this article" rails are dropped,
+  inline link URLs are stripped (visible link text is kept), and headings/lists are emitted
+  as lightweight markdown. Because it reads the live signed-in browser window via UI
+  Automation, it also works for authenticated/internal pages that an HTTP fetch cannot reach.
 
 ---
 

--- a/plugin/skills/windows-automation/SKILL.md
+++ b/plugin/skills/windows-automation/SKILL.md
@@ -43,6 +43,7 @@ This plugin bundles the Windows MCP Server for Windows-only desktop automation. 
 ### Browsers and signed-in sessions
 
 - Treat Edge and Chrome page content like any other semantic UI surface: start with `window_management`, then use `ui_find`, `ui_click`, `ui_type`, and `ui_read` against visible text or ARIA labels.
+- To read the readable content of a web page, call `ui_read` with `format: "article"`: it returns the main article text only (navigation chrome, breadcrumbs, and "in this article" rails removed, inline link URLs stripped, headings/lists as markdown) — far more token-efficient than the raw document dump. Reading the live signed-in window this way also works for authenticated/internal pages an HTTP fetch cannot reach.
 - For authenticated or SSO-only sites, **reuse an existing signed-in browser window/session first** before launching the URL again.
 - Do not interpret a Chromium launcher helper exiting immediately as a failed launch until you check whether the existing browser session already opened or focused the target page.
 - Keep browser chrome (address bar, tabs, profile menus, extension flyouts) as best-effort; page content is the strong path.

--- a/plugin/skills/windows-cli/SKILL.md
+++ b/plugin/skills/windows-cli/SKILL.md
@@ -28,6 +28,7 @@ so there is no server session to keep alive).
 2. `wincli ui snapshot --window <handle>` to see the accessible element tree.
 3. `wincli ui find|click|type|select|read --window <handle> ...` for normal controls.
 4. `wincli ui read-table --window <handle> --automation-id <grid>` to pull a grid/table/details-list into structured rows + headers in one call.
+   For a web page, add `--format article` to `wincli ui read` to get clean main-content text (nav/breadcrumb chrome and inline link URLs stripped, headings/lists as markdown).
 5. `wincli file-save --window <handle> --path <file>` for Save / Save As - never raw Ctrl+S.
    Use `wincli file-open --window <handle> --path <file>` for Open flows.
 6. `wincli clipboard get|set|clear` for fast bulk text IO; `wincli macro save|run|list|get|delete`

--- a/src/Sbroenne.WindowsMcp.Cli/Cli/CommandDispatcher.cs
+++ b/src/Sbroenne.WindowsMcp.Cli/Cli/CommandDispatcher.cs
@@ -368,6 +368,7 @@ internal static class CommandDispatcher
                         a.GetInt("found-index", "index") ?? 1,
                         a.GetFlag("include-children", "children"),
                         a.GetString("language", "lang"),
+                        a.GetString("format"),
                         diag,
                         ct);
                     return Emit.Result(result);

--- a/src/Sbroenne.WindowsMcp.Cli/Cli/HelpText.cs
+++ b/src/Sbroenne.WindowsMcp.Cli/Cli/HelpText.cs
@@ -73,7 +73,7 @@ internal static class HelpText
         ui click    --window <h> [selectors|--element-id <id>] [--found-index <n>] [--with-snapshot]
         ui type     --window <h> --text <s> [selectors|--element-id <id>] [--clear-first] [--with-snapshot]
         ui select   --window <h> --value <s> [selectors] [--with-snapshot]
-        ui read     --window <h> [selectors|--element-id <id>] [--include-children] [--language <c>]
+        ui read     --window <h> [selectors|--element-id <id>] [--include-children] [--language <c>] [--format raw|article]
         ui read-table --window <h> [selectors|--element-id <id>] [--max-rows <n>] [--max-columns <n>]
         ui wait     [--window <h>] [--mode appear|disappear|...] [--element-id <id>]
                      [--desired-state <s>] [selectors] [--timeout-ms <n>]

--- a/src/Sbroenne.WindowsMcp/Automation/ArticleTextExtraction.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ArticleTextExtraction.cs
@@ -1,0 +1,188 @@
+using System.Buffers;
+using System.Text;
+
+namespace Sbroenne.WindowsMcp.Automation;
+
+/// <summary>
+/// A single piece of readable content collected from a page while extracting article text.
+/// </summary>
+/// <param name="Text">The visible text of the node (never a raw URL).</param>
+/// <param name="HeadingLevel">Heading level 1-9, or 0 when the node is body text.</param>
+/// <param name="IsListItem">Whether the node is (inside) a list item.</param>
+internal readonly record struct ArticleNode(string Text, int HeadingLevel, bool IsListItem);
+
+/// <summary>
+/// Pure, dependency-free helpers that turn a flat list of collected <see cref="ArticleNode"/>s into
+/// clean, token-efficient article text. Kept free of any UI Automation / COM dependency so the
+/// cleaning and formatting rules can be unit-tested deterministically.
+/// </summary>
+internal static class ArticleTextExtraction
+{
+    private static readonly SearchValues<char> Whitespace = SearchValues.Create(" \t\r\n\f\v");
+
+    /// <summary>
+    /// Returns <c>true</c> when the supplied text is, in its entirety, a bare URL/link target rather
+    /// than human-readable prose. Used to drop the inline href noise that <c>ui_read</c> otherwise
+    /// interleaves with the article body (nav links, breadcrumbs, "in this article" anchors).
+    /// </summary>
+    /// <remarks>
+    /// Conservative on purpose: only a single whitespace-free token that looks like a link target is
+    /// treated as a URL, so ordinary sentences that merely contain a domain are preserved.
+    /// </remarks>
+    public static bool LooksLikeUrl(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var trimmed = text.Trim();
+
+        // Prose contains spaces; a bare link target does not.
+        if (trimmed.AsSpan().IndexOfAny(Whitespace) >= 0)
+        {
+            return false;
+        }
+
+        if (StartsWithScheme(trimmed, "http://") ||
+            StartsWithScheme(trimmed, "https://") ||
+            StartsWithScheme(trimmed, "ftp://") ||
+            StartsWithScheme(trimmed, "file://") ||
+            StartsWithScheme(trimmed, "mailto:") ||
+            StartsWithScheme(trimmed, "tel:"))
+        {
+            return true;
+        }
+
+        // Bare host/path such as "www.example.com/docs".
+        if (trimmed.StartsWith("www.", StringComparison.OrdinalIgnoreCase) && trimmed.Contains('.', StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Formats collected nodes into clean article text: markdown-ish headings (<c>#</c>), list
+    /// bullets (<c>-</c>), URL noise removed, whitespace normalized, and adjacent duplicate lines
+    /// collapsed.
+    /// </summary>
+    public static string FormatArticle(IReadOnlyList<ArticleNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        var lines = new List<string>(nodes.Count);
+        string? previous = null;
+
+        foreach (var node in nodes)
+        {
+            var text = NormalizeWhitespace(node.Text);
+            if (text.Length == 0 || LooksLikeUrl(text))
+            {
+                continue;
+            }
+
+            var line = Render(text, node.HeadingLevel, node.IsListItem);
+
+            // Drop a line that exactly repeats the one immediately before it (Chromium frequently
+            // exposes a container's aggregated name and its child text as separate nodes).
+            if (string.Equals(line, previous, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // A heading reads better with a blank line above it once real content exists.
+            if (node.HeadingLevel > 0 && lines.Count > 0 && lines[^1].Length > 0)
+            {
+                lines.Add(string.Empty);
+            }
+
+            lines.Add(line);
+            previous = line;
+        }
+
+        // Trim leading/trailing blank lines and collapse runs of blanks to a single separator.
+        return CollapseBlankLines(lines);
+    }
+
+    private static string Render(string text, int headingLevel, bool isListItem)
+    {
+        if (headingLevel is > 0 and <= 9)
+        {
+            return string.Concat(new string('#', headingLevel), " ", text);
+        }
+
+        if (isListItem)
+        {
+            return string.Concat("- ", text);
+        }
+
+        return text;
+    }
+
+    private static string NormalizeWhitespace(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder(text.Length);
+        var pendingSpace = false;
+
+        foreach (var ch in text)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                pendingSpace = builder.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                builder.Append(' ');
+                pendingSpace = false;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string CollapseBlankLines(List<string> lines)
+    {
+        var builder = new StringBuilder();
+        var atBlockStart = true;
+        var pendingBlank = false;
+
+        foreach (var line in lines)
+        {
+            if (line.Length == 0)
+            {
+                pendingBlank = !atBlockStart;
+                continue;
+            }
+
+            if (pendingBlank)
+            {
+                builder.Append('\n');
+                pendingBlank = false;
+            }
+
+            if (!atBlockStart)
+            {
+                builder.Append('\n');
+            }
+
+            builder.Append(line);
+            atBlockStart = false;
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool StartsWithScheme(string value, string scheme)
+        => value.StartsWith(scheme, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Sbroenne.WindowsMcp/Automation/TextExtractionMode.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/TextExtractionMode.cs
@@ -1,0 +1,20 @@
+namespace Sbroenne.WindowsMcp.Automation;
+
+/// <summary>
+/// Controls how <c>ui_read</c> extracts text from an element or window.
+/// </summary>
+public enum TextExtractionMode
+{
+    /// <summary>
+    /// Raw aggregation of element/descendant text (current default). Complete but noisy for web pages:
+    /// the article body is interleaved with navigation chrome and inline link URLs.
+    /// </summary>
+    Raw = 0,
+
+    /// <summary>
+    /// Clean article extraction for web pages: prefers the <c>main</c> landmark, drops navigation,
+    /// search and complementary chrome, strips inline URL noise, and emits lightweight markdown
+    /// (headings and list bullets). Token-efficient for LLM/coding-agent consumption.
+    /// </summary>
+    Article = 1,
+}

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIReadTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIReadTool.cs
@@ -19,6 +19,10 @@ public static partial class UIReadTool
     /// </summary>
     /// <remarks>
     /// Extract text from UI elements or screen regions. Auto-falls back to OCR if normal text extraction fails.
+    /// For web pages in Edge/Chrome, pass format='article' to get clean, token-efficient article text
+    /// (main content only, navigation chrome and inline link URLs stripped, headings/lists as markdown).
+    /// Reading the live signed-in browser window this way also works for authenticated/internal pages that
+    /// an HTTP fetch cannot reach.
     /// </remarks>
     /// <param name="windowHandle">Window handle as decimal string (from window_management 'find' or 'list'). REQUIRED.</param>
     /// <param name="name">Element name (exact match, case-insensitive).</param>
@@ -29,8 +33,9 @@ public static partial class UIReadTool
     /// <param name="className">Element class name.</param>
     /// <param name="elementId">Stable element id from a prior ui_find/ui_snapshot. When provided, reads that exact element directly and ignores the name/type selectors (avoids re-querying).</param>
     /// <param name="foundIndex">Return Nth match (1-based, default: 1).</param>
-    /// <param name="includeChildren">Include child element text (default: false).</param>
+    /// <param name="includeChildren">Include child element text (default: false). Ignored when format='article'.</param>
     /// <param name="language">OCR language code (e.g., 'en-US', 'de-DE'). Uses system default if not specified. Only used if OCR fallback triggers.</param>
+    /// <param name="format">Text extraction mode: 'raw' (default, complete but includes nav chrome and link URLs) or 'article' (clean main-content text for web pages, chrome and inline URLs stripped, headings/lists as markdown).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A call result containing a text content block with the JSON payload of the extracted text content from the element or screen region. <c>IsError</c> reflects operation success.</returns>
@@ -47,6 +52,7 @@ public static partial class UIReadTool
         [DefaultValue(1)] int foundIndex,
         [DefaultValue(false)] bool includeChildren,
         [DefaultValue(null)] string? language,
+        [DefaultValue(null)] string? format,
         [DefaultValue(false)] bool includeDiagnostics,
         CancellationToken cancellationToken)
     {
@@ -62,6 +68,12 @@ public static partial class UIReadTool
         if (foundIndexError is not null)
         {
             return foundIndexError;
+        }
+
+        if (!TryParseTextExtractionMode(format, out var mode))
+        {
+            return WindowsToolsBase.FailResult(
+                $"Invalid format '{format}'. Use 'raw' (default) or 'article'.");
         }
 
         try
@@ -99,8 +111,15 @@ public static partial class UIReadTool
                 }
             }
 
-            var result = await automationService.GetTextAsync(elementIdToRead, windowHandle, includeChildren, cancellationToken);
+            var result = await automationService.GetTextAsync(elementIdToRead, windowHandle, includeChildren, mode, cancellationToken);
             if (result.Success && !string.IsNullOrWhiteSpace(result.Text))
+            {
+                return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
+            }
+
+            // Article mode is a UIA-only, structure-aware extraction; OCR (which returns raw pixels
+            // as flat text) cannot honor it, so skip the OCR fallback and return the UIA result.
+            if (mode == TextExtractionMode.Article)
             {
                 return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
             }
@@ -146,6 +165,30 @@ public static partial class UIReadTool
         catch (Exception ex)
         {
             return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
+        }
+    }
+
+    private static bool TryParseTextExtractionMode(string? format, out TextExtractionMode mode)
+    {
+        mode = TextExtractionMode.Raw;
+
+        if (string.IsNullOrWhiteSpace(format))
+        {
+            return true;
+        }
+
+        switch (format.Trim().ToLowerInvariant())
+        {
+            case "raw":
+                mode = TextExtractionMode.Raw;
+                return true;
+            case "article":
+            case "markdown":
+            case "clean":
+                mode = TextExtractionMode.Article;
+                return true;
+            default:
+                return false;
         }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
@@ -282,6 +282,42 @@ internal static class UIA3PropertyIds
 
     // Window pattern properties
     internal const int WindowIsModal = 30077;
+
+    // Landmark / structure properties (used for article-mode reading of web pages)
+    internal const int LandmarkType = 30157;
+    internal const int LocalizedLandmarkType = 30158;
+    internal const int HeadingLevel = 30173;
+}
+
+/// <summary>
+/// UI Automation landmark type IDs and heading-level values used to identify main content
+/// and navigation chrome when reading web pages in article mode.
+/// </summary>
+internal static class UIA3LandmarkTypeIds
+{
+    internal const int Custom = 80000;
+    internal const int Form = 80001;
+    internal const int Main = 80002;
+    internal const int Navigation = 80003;
+    internal const int Search = 80004;
+
+    // HeadingLevel property returns HeadingLevel_None (80050) or HeadingLevel1..9 (80051..80059).
+    internal const int HeadingLevelNone = 80050;
+    internal const int HeadingLevel1 = 80051;
+    internal const int HeadingLevel9 = 80059;
+
+    /// <summary>
+    /// Converts a raw UIA HeadingLevel property value to a 1-9 level, or 0 when the element is not a heading.
+    /// </summary>
+    internal static int ToHeadingLevel(int rawHeadingLevelValue)
+    {
+        if (rawHeadingLevelValue is >= HeadingLevel1 and <= HeadingLevel9)
+        {
+            return rawHeadingLevelValue - HeadingLevelNone;
+        }
+
+        return 0;
+    }
 }
 
 /// <summary>

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Article.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Article.cs
@@ -1,0 +1,211 @@
+using UIA = Interop.UIAutomationClient;
+
+namespace Sbroenne.WindowsMcp.Automation;
+
+/// <summary>
+/// Clean "article" text extraction for web pages, used by <c>ui_read</c> in
+/// <see cref="TextExtractionMode.Article"/> mode.
+/// </summary>
+/// <remarks>
+/// Strategy (single cached tree walk, no per-node cross-process calls in the hot loop):
+/// <list type="number">
+/// <item>Resolve the primary content region by locating the <c>main</c> landmark; fall back to the
+/// whole element when a page exposes no landmark.</item>
+/// <item>Cache the content subtree in a single <c>FindFirstBuildCache</c> call and walk it with
+/// <c>GetCachedChildren</c> so the poll loop makes no additional COM calls (this is what previously
+/// starved the shared UIA STA thread).</item>
+/// <item>Skip navigation, search and complementary landmark subtrees (site header, left nav,
+/// breadcrumbs, "in this article" rails, footer).</item>
+/// <item>Collect visible leaf text and headings only, preferring the accessible name (never the
+/// ValuePattern href), so link text is preserved without inline URL noise.</item>
+/// </list>
+/// </remarks>
+public sealed partial class UIAutomationService
+{
+    private const int MaxArticleNodesToScan = 6000;
+    private const int MaxArticleDepth = 60;
+
+    private static string ExtractArticleText(UIA.IUIAutomationElement element)
+    {
+        var contentRoot = FindMainLandmark(element) ?? element;
+
+        UIA.IUIAutomationElement cachedRoot;
+        try
+        {
+            var cacheRequest = CreateArticleCacheRequest();
+            var built = contentRoot.FindFirstBuildCache(UIA.TreeScope.TreeScope_Element, Uia.TrueCondition, cacheRequest);
+            if (built == null)
+            {
+                return string.Empty;
+            }
+
+            cachedRoot = built;
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return string.Empty;
+        }
+
+        var nodes = new List<ArticleNode>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var scanned = 0;
+        CollectArticleNodes(cachedRoot, nodes, seen, insideList: false, inheritedHeadingLevel: 0, depth: 0, ref scanned);
+
+        return ArticleTextExtraction.FormatArticle(nodes);
+    }
+
+    private static UIA.IUIAutomationCacheRequest CreateArticleCacheRequest()
+    {
+        var request = Uia.CreateCacheRequest();
+        request.AddProperty(UIA3PropertyIds.Name);
+        request.AddProperty(UIA3PropertyIds.ControlType);
+        request.AddProperty(UIA3PropertyIds.IsOffscreen);
+        request.AddProperty(UIA3PropertyIds.LandmarkType);
+        request.AddProperty(UIA3PropertyIds.LocalizedLandmarkType);
+        request.AddProperty(UIA3PropertyIds.HeadingLevel);
+        request.TreeScope = UIA.TreeScope.TreeScope_Subtree;
+        return request;
+    }
+
+    private static UIA.IUIAutomationElement? FindMainLandmark(UIA.IUIAutomationElement element)
+    {
+        try
+        {
+            var mainCondition = Uia.CreatePropertyCondition(UIA3PropertyIds.LandmarkType, UIA3LandmarkTypeIds.Main);
+            return element.FindFirst(UIA.TreeScope.TreeScope_Descendants, mainCondition);
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return null;
+        }
+    }
+
+    private static void CollectArticleNodes(
+        UIA.IUIAutomationElement node,
+        List<ArticleNode> nodes,
+        HashSet<string> seen,
+        bool insideList,
+        int inheritedHeadingLevel,
+        int depth,
+        ref int scanned)
+    {
+        if (scanned >= MaxArticleNodesToScan || depth > MaxArticleDepth)
+        {
+            return;
+        }
+
+        scanned++;
+
+        if (IsSkippableLandmark(node))
+        {
+            return;
+        }
+
+        var controlTypeId = SafeCachedControlTypeId(node);
+        var headingLevel = Math.Max(inheritedHeadingLevel, GetHeadingLevel(node));
+        var isList = insideList || controlTypeId == UIA3ControlTypeIds.ListItem;
+
+        var children = SafeCachedChildren(node);
+        if (children == null || children.Length == 0)
+        {
+            // Leaf: this is where the real text lives. Use the accessible name (visible link text),
+            // never the ValuePattern value (which would be a raw href).
+            var name = node.GetCachedName();
+            if (!string.IsNullOrWhiteSpace(name) && !ArticleTextExtraction.LooksLikeUrl(name) && seen.Add(name))
+            {
+                nodes.Add(new ArticleNode(name, headingLevel, isList));
+            }
+
+            return;
+        }
+
+        for (var i = 0; i < children.Length && scanned < MaxArticleNodesToScan; i++)
+        {
+            UIA.IUIAutomationElement? child;
+            try
+            {
+                child = children.GetElement(i);
+            }
+            catch (System.Runtime.InteropServices.COMException)
+            {
+                continue;
+            }
+
+            if (child == null)
+            {
+                continue;
+            }
+
+            CollectArticleNodes(child, nodes, seen, isList, headingLevel, depth + 1, ref scanned);
+        }
+    }
+
+    private static bool IsSkippableLandmark(UIA.IUIAutomationElement node)
+    {
+        try
+        {
+            var landmark = node.GetCachedPropertyValue(UIA3PropertyIds.LandmarkType);
+            if (landmark is int landmarkId &&
+                (landmarkId == UIA3LandmarkTypeIds.Navigation || landmarkId == UIA3LandmarkTypeIds.Search))
+            {
+                return true;
+            }
+
+            var localized = node.GetCachedPropertyValue(UIA3PropertyIds.LocalizedLandmarkType) as string;
+            if (!string.IsNullOrEmpty(localized) &&
+                (localized.Equals("complementary", StringComparison.OrdinalIgnoreCase) ||
+                 localized.Equals("banner", StringComparison.OrdinalIgnoreCase) ||
+                 localized.Equals("contentinfo", StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // Property not cached / element gone - treat as non-landmark.
+        }
+
+        return false;
+    }
+
+    private static int GetHeadingLevel(UIA.IUIAutomationElement node)
+    {
+        try
+        {
+            if (node.GetCachedPropertyValue(UIA3PropertyIds.HeadingLevel) is int raw)
+            {
+                return UIA3LandmarkTypeIds.ToHeadingLevel(raw);
+            }
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // Not a heading.
+        }
+
+        return 0;
+    }
+
+    private static int SafeCachedControlTypeId(UIA.IUIAutomationElement node)
+    {
+        try
+        {
+            return node.GetCachedControlTypeId();
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return 0;
+        }
+    }
+
+    private static UIA.IUIAutomationElementArray? SafeCachedChildren(UIA.IUIAutomationElement node)
+    {
+        try
+        {
+            return node.GetCachedChildren();
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Text.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Text.cs
@@ -10,7 +10,18 @@ namespace Sbroenne.WindowsMcp.Automation;
 public sealed partial class UIAutomationService
 {
     /// <inheritdoc/>
-    public async Task<UIAutomationResult> GetTextAsync(string? elementId, string? windowHandle, bool includeChildren, CancellationToken cancellationToken = default)
+    public Task<UIAutomationResult> GetTextAsync(string? elementId, string? windowHandle, bool includeChildren, CancellationToken cancellationToken = default)
+        => GetTextAsync(elementId, windowHandle, includeChildren, TextExtractionMode.Raw, cancellationToken);
+
+    /// <summary>
+    /// Extracts text from an element or window, either as raw aggregated text or as clean article text.
+    /// </summary>
+    /// <param name="elementId">Optional stable element id to read directly.</param>
+    /// <param name="windowHandle">Window handle used when no element id is supplied.</param>
+    /// <param name="includeChildren">Whether to aggregate descendant text (raw mode only).</param>
+    /// <param name="mode">Raw aggregation or clean article extraction.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<UIAutomationResult> GetTextAsync(string? elementId, string? windowHandle, bool includeChildren, TextExtractionMode mode, CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
 
@@ -45,7 +56,9 @@ public sealed partial class UIAutomationService
                     }
                 }
 
-                var text = ExtractText(targetElement, includeChildren);
+                var text = mode == TextExtractionMode.Article
+                    ? ExtractArticleText(targetElement)
+                    : ExtractText(targetElement, includeChildren);
 
                 return UIAutomationResult.CreateSuccessWithText("get_text", text, CreateDiagnostics(stopwatch));
             }, cancellationToken);

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
@@ -1,3 +1,4 @@
+using Sbroenne.WindowsMcp.Automation;
 using Sbroenne.WindowsMcp.Models;
 
 namespace Sbroenne.WindowsMcp.Tests.Integration.ChromiumBrowser;
@@ -153,6 +154,46 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
 
         Assert.True(readResult.Success, $"Read failed: {readResult.ErrorMessage}");
         Assert.Equal(SignedOutStatus, readResult.Text);
+    }
+
+    [Theory]
+    [InlineData(ChromiumBrowserKind.Edge)]
+    [InlineData(ChromiumBrowserKind.Chrome)]
+    public async Task Read_LocalChromiumPage_ArticleMode_ReturnsCleanMainContent(ChromiumBrowserKind browser)
+    {
+        ChromiumBrowserSession.SkipUnlessSupported(browser);
+
+        var session = _readOnlySessions.GetSession(browser);
+        using var harness = new ChromiumAutomationHarness();
+
+        var readResult = await harness.AutomationService.GetTextAsync(
+            elementId: null,
+            windowHandle: session.WindowHandleString,
+            includeChildren: false,
+            mode: TextExtractionMode.Article);
+
+        Assert.True(readResult.Success, $"Read failed: {readResult.ErrorMessage}");
+        Assert.False(string.IsNullOrWhiteSpace(readResult.Text), "Article text should not be empty.");
+
+        var article = readResult.Text!;
+
+        // Main content is present.
+        Assert.Contains("Chromium browser smoke page", article, StringComparison.Ordinal);
+        Assert.Contains("Getting started", article, StringComparison.Ordinal);
+        Assert.Contains("official guide", article, StringComparison.Ordinal); // visible link text is kept
+
+        // Lightweight markdown structure survives.
+        Assert.Contains("# ", article, StringComparison.Ordinal); // at least one heading marker
+        Assert.Contains("- Install the runtime", article, StringComparison.Ordinal); // list bullet
+
+        // Inline link URLs are stripped.
+        Assert.DoesNotContain("https://example.com", article, StringComparison.Ordinal);
+
+        // Navigation chrome (outside <main>) is excluded.
+        Assert.DoesNotContain("Pricing", article, StringComparison.Ordinal);
+
+        // Complementary rail (aria complementary landmark inside <main>) is excluded.
+        Assert.DoesNotContain("Complementary rail link", article, StringComparison.Ordinal);
     }
 
     private static ElementQuery CreateLocalPageQuery(string windowHandle, string name, string controlType)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/chromium-local-page.html
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/chromium-local-page.html
@@ -36,6 +36,17 @@
             <p class="focus-status">Sign in button focused</p>
             <p id="sign-in-status" role="status">Signed out</p>
         </section>
+
+        <h2 id="getting-started">Getting started</h2>
+        <p>Read the <a href="https://example.com/agency-guide">official guide</a> before you begin.</p>
+        <ul>
+            <li>Install the runtime</li>
+            <li>Launch a session</li>
+        </ul>
+
+        <aside aria-label="On this page">
+            <a href="#getting-started">Complementary rail link</a>
+        </aside>
     </main>
 </body>
 </html>

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/ArticleTextExtractionTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/ArticleTextExtractionTests.cs
@@ -1,0 +1,137 @@
+using Sbroenne.WindowsMcp.Automation;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+/// <summary>
+/// Unit tests for the pure article-text cleaning/formatting rules used by <c>ui_read</c>
+/// in <see cref="TextExtractionMode.Article"/> mode.
+/// </summary>
+public sealed class ArticleTextExtractionTests
+{
+    [Theory]
+    [InlineData("https://eng.ms/docs/foo/bar")]
+    [InlineData("http://example.com")]
+    [InlineData("HTTPS://Example.COM/Path")]
+    [InlineData("ftp://files.example.com/x")]
+    [InlineData("mailto:someone@example.com")]
+    [InlineData("tel:+1-555-0100")]
+    [InlineData("www.example.com/docs")]
+    public void LooksLikeUrl_BareLinkTargets_ReturnsTrue(string text)
+    {
+        Assert.True(ArticleTextExtraction.LooksLikeUrl(text));
+    }
+
+    [Theory]
+    [InlineData("Using the Agency CLI")]
+    [InlineData("Visit https://example.com for details")] // contains a URL but is prose
+    [InlineData("Install the agency executable")]
+    [InlineData("e.g. this is fine")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void LooksLikeUrl_Prose_ReturnsFalse(string? text)
+    {
+        Assert.False(ArticleTextExtraction.LooksLikeUrl(text));
+    }
+
+    [Fact]
+    public void FormatArticle_DropsBareUrlNodes()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("Overview", 0, false),
+            new("https://eng.ms/docs/overview", 0, false),
+            new("Body text here", 0, false),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+
+        Assert.DoesNotContain("https://", result, StringComparison.Ordinal);
+        Assert.Contains("Overview", result, StringComparison.Ordinal);
+        Assert.Contains("Body text here", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatArticle_RendersHeadingsAsMarkdown()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("Title", 1, false),
+            new("Intro paragraph", 0, false),
+            new("Subsection", 2, false),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+        var lines = result.Split('\n');
+
+        Assert.Contains("# Title", lines);
+        Assert.Contains("## Subsection", lines);
+        Assert.Contains("Intro paragraph", lines);
+    }
+
+    [Fact]
+    public void FormatArticle_RendersListItemsWithBullets()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("First step", 0, true),
+            new("Second step", 0, true),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+
+        Assert.Contains("- First step", result, StringComparison.Ordinal);
+        Assert.Contains("- Second step", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatArticle_CollapsesAdjacentDuplicateLines()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("Repeated line", 0, false),
+            new("Repeated line", 0, false),
+            new("Unique line", 0, false),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+        var occurrences = result.Split('\n').Count(line => line == "Repeated line");
+
+        Assert.Equal(1, occurrences);
+    }
+
+    [Fact]
+    public void FormatArticle_NormalizesWhitespace()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("  lots   of\t\tspace\n here ", 0, false),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+
+        Assert.Equal("lots of space here", result);
+    }
+
+    [Fact]
+    public void FormatArticle_EmptyInput_ReturnsEmptyString()
+    {
+        var result = ArticleTextExtraction.FormatArticle([]);
+
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void FormatArticle_InsertsBlankLineBeforeHeadings()
+    {
+        var nodes = new List<ArticleNode>
+        {
+            new("Body before heading", 0, false),
+            new("Next Section", 2, false),
+        };
+
+        var result = ArticleTextExtraction.FormatArticle(nodes);
+
+        Assert.Contains("Body before heading\n\n## Next Section", result, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #167.

`ui_read` returned complete but **noisy** text for web pages: the article body was interleaved with every navigation/breadcrumb URL and chrome label - token-inefficient for coding agents. This adds an opt-in `format: "article"` mode that returns clean main-content text.

Reading the live signed-in browser window via UI Automation (which is what this does) also works for authenticated/internal pages that an HTTP fetch cannot reach - the original motivation, from an SSO-gated `eng.ms` page that `web_fetch` bounced to a login redirect.

## Extraction strategy

Single cached tree walk - **no per-node cross-process calls in the hot loop**, to avoid starving the shared UIA STA thread:

- Resolve the primary content region via the `main` landmark; fall back to the whole element when a page exposes no landmark.
- Cache the content subtree in one `FindFirstBuildCache` call and walk it with `GetCachedChildren`.
- Skip navigation, search and complementary landmark subtrees (site header, left nav, breadcrumbs, "in this article" rails, footer).
- Collect visible **leaf** text and headings only, using the accessible **name** (never the `ValuePattern` href) so link text is kept without URL noise.
- Emit lightweight markdown: `#` headings (UIA `HeadingLevel`) and `-` list bullets.

The cleaning/formatting rules live in a **pure, dependency-free** `ArticleTextExtraction` helper so they are deterministically unit-testable.

## API

- New `TextExtractionMode` enum + `GetTextAsync` overload (raw behavior unchanged, remains default).
- `format` param on the `ui_read` MCP tool and `wincli ui read --format raw|article`.
- Article mode skips the OCR fallback (structure-aware, UIA-only).

## Tests

- **21 new unit tests** for `ArticleTextExtraction` (URL stripping, dedupe, heading/list rendering, whitespace collapse). 450 unit/contract pass locally.
- **Chromium integration test** asserts article mode returns main content, renders markdown headings/bullets, and excludes nav links, the complementary rail, and inline URLs. Local test page enriched with a main-content link, list, and an `aside` complementary landmark.

## Docs

`FEATURES.md`, `windows-automation` and `windows-cli` `SKILL.md` updated.
