### PR TITLE
fix(deps): bump electron to 42.9.1 to drop vulnerable extract-zip

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,6 +132,26 @@ jobs:
           --runtime win-x64
           --no-restore
 
+      - name: Ensure Visual C++ runtime
+        shell: pwsh
+        run: |
+          if (Test-Path "$env:SystemRoot\System32\vcruntime140.dll") {
+            Write-Host "Visual C++ 2015-2022 runtime already present."
+            exit 0
+          }
+
+          Write-Host "Installing the Visual C++ 2015-2022 redistributable."
+          $installer = Join-Path $env:TEMP "vc_redist.x64.exe"
+          Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile $installer -UseBasicParsing
+          $process = Start-Process $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru
+          Remove-Item $installer -Force
+          if ($process.ExitCode -notin @(0, 3010)) {
+            throw "Visual C++ redistributable installation failed with exit code $($process.ExitCode)."
+          }
+          if (-not (Test-Path "$env:SystemRoot\System32\vcruntime140.dll")) {
+            throw "Visual C++ redistributable installation did not produce vcruntime140.dll."
+          }
+
       - name: Install Electron harness
         shell: pwsh
         working-directory: tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness

--- a/docs/AZURE_SELFHOSTED_RUNNER_SETUP.md
+++ b/docs/AZURE_SELFHOSTED_RUNNER_SETUP.md
@@ -91,7 +91,8 @@ this from an elevated PowerShell window:
   -WindowsPassword "<vm-admin-password>"
 ```
 
-The script installs .NET 10, Git, PowerShell 7, Node.js LTS, Chrome, and the latest
+The script installs the Visual C++ 2015-2022 redistributable, .NET 10, Git,
+PowerShell 7, Node.js LTS, Chrome, and the latest
 GitHub Actions runner. It registers the `windows-ui` label, configures en-US locale,
 stores the Windows password as an LSA secret with Sysinternals Autologon, and starts
 the runner from a non-elevated interactive scheduled task. The secrets are not written

--- a/infrastructure/azure/setup-runner.ps1
+++ b/infrastructure/azure/setup-runner.ps1
@@ -59,7 +59,26 @@ function Install-Msi {
     }
 }
 
+function Install-VisualCppRuntime {
+    # Native Node addons (for example Electron's bundled unzip binding) link against
+    # the Visual C++ 2015-2022 runtime, which a clean Windows image does not ship.
+    if (Test-Path (Join-Path $env:SystemRoot "System32\vcruntime140.dll")) {
+        return
+    }
+
+    Write-SetupLog "Installing the Visual C++ 2015-2022 redistributable."
+    $installer = Join-Path $env:TEMP "vc_redist.x64.exe"
+    Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile $installer -UseBasicParsing
+    $process = Start-Process $installer -ArgumentList "/install", "/quiet", "/norestart" -Wait -PassThru
+    Remove-Item $installer -Force
+    if ($process.ExitCode -notin @(0, 3010)) {
+        throw "Visual C++ redistributable installation failed with exit code $($process.ExitCode)."
+    }
+}
+
 function Install-Prerequisites {
+    Install-VisualCppRuntime
+
     $dotnet = Join-Path $env:ProgramFiles "dotnet\dotnet.exe"
     $installedSdks = if (Test-Path $dotnet) { & $dotnet --list-sdks } else { @() }
     if (-not ($installedSdks -match "^10\.")) {

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
@@ -13,6 +13,16 @@
         "typescript": "^6.0.3"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/get": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
@@ -44,27 +54,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -84,15 +73,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.1.0.tgz",
-      "integrity": "sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==",
+      "version": "42.9.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.9.1.tgz",
+      "integrity": "sha512-apvDsEzRHvMG6zzanotY+iSYT3RA6+U8OYmBllADOdtztTdaEXGZYeu9NLpbro0QFgGJHiJZNCZliFcN5xZUxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js",
@@ -119,16 +108,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/env-paths": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
@@ -137,53 +116,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -203,23 +135,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -228,17 +143,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/semver": {
@@ -298,24 +202,6 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert [#69](https://github.com/sbroenne/mcp-windows/security/dependabot/69).

## Problem

`extract-zip` 2.0.1 is flagged by [GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv) / CVE-2026-56876 (high, CVSS 8.1) — unvalidated symlink path traversal during zip extraction.

It's a transitive **dev** dependency of `electron` in the Electron test harness (`tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness`), used when downloading and unpacking the Electron binary.

## Why not just bump extract-zip

There is no patched release. `2.0.1` is the latest publish on npm (June 2020) and the advisory reports `first_patched_version: null`.

## Fix

Electron 42.9.1 replaces `extract-zip` with `@electron-internal/extract-zip` 1.0.5. Since `package.json` already declares `electron: ^42.1.0`, a lockfile refresh (`npm update electron --package-lock-only`) was sufficient — no manifest change required.

Removed from the tree: `extract-zip`, `yauzl`, `fd-slicer`, `pend`, `buffer-crc32`, `get-stream`, `end-of-stream`, `@types/yauzl`.

## Follow-on CI fix

The first CI run surfaced a real regression from the bump. `@electron-internal/extract-zip` is a **native** addon, and its `index.win32-x64-msvc.node` imports `vcruntime140.dll`. The `windows-ui` runner image never had the Visual C++ 2015-2022 redistributable installed, so the Electron binary download failed:

```
Error: Cannot find native binding.
[cause]: Error: The specified module could not be found.
  ...\@electron-internal\extract-zip\index.win32-x64-msvc.node
  code: 'ERR_DLOPEN_FAILED'
```

`setup-runner.ps1` provisions .NET 10, Git, PowerShell 7, Node.js LTS and Chrome, but not the VC++ runtime — a latent gap that would have bitten any native Node addon, not just this one.

This PR therefore also:
- adds an idempotent `Install-VisualCppRuntime` to `infrastructure/azure/setup-runner.ps1` so newly provisioned runners get it
- adds an idempotent **Ensure Visual C++ runtime** step to `integration-tests.yml`, so the already-provisioned VM self-heals without manual intervention (it's a no-op once `vcruntime140.dll` is present)
- updates `docs/AZURE_SELFHOSTED_RUNNER_SETUP.md`

## Verification

- `npm ci` — clean, `found 0 vulnerabilities`
- `npm run build` (tsc) — exit 0
- `npm ls extract-zip` — no longer present
- `setup-runner.ps1` parses clean; `integration-tests.yml` parses as valid YAML
- Confirmed locally that the native addon loads once `vcruntime140.dll` is available

## Follow-up

Checked `sbroenne/mcp-server-excel` and `sbroenne/mcp-server-powerpoint`: neither pulls in `extract-zip`, both have Dependabot alerts enabled with 0 open alerts. No action needed there.
