### PR TITLE
Harden the UI Automation runtime

### DIFF
--- a/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
@@ -140,6 +140,27 @@ internal static class COMExceptionHelper
     }
 
     /// <summary>
+    /// Determines if an exception is an expected per-element provider failure.
+    /// UI Automation surfaces E_INVALIDARG as <see cref="ArgumentException"/> for some
+    /// unsupported property and cache combinations.
+    /// </summary>
+    public static bool IsExpectedElementFailure(Exception ex)
+    {
+        return ex.GetType() == typeof(ArgumentException) ||
+            ex is COMException comException && IsExpectedElementFailure(comException);
+    }
+
+    /// <summary>
+    /// Determines if best-effort tree traversal can skip an element that disappeared or exposed
+    /// an unsupported property/cache combination.
+    /// </summary>
+    public static bool IsExpectedElementTraversalFailure(Exception ex)
+    {
+        return ex.GetType() == typeof(ArgumentException) ||
+            ex is COMException comException && IsElementStale(comException);
+    }
+
+    /// <summary>
     /// Determines if the provider failed while its accessibility tree was transitioning.
     /// These failures are safe to retry only inside an already bounded observation loop.
     /// </summary>

--- a/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Sbroenne.WindowsMcp.Models;
 
 namespace Sbroenne.WindowsMcp.Automation;
 
@@ -33,6 +34,8 @@ internal static class COMExceptionHelper
     private const int UIA_E_ELEMENTNOTAVAILABLE = unchecked((int)0x80040201);
     private const int UIA_E_NOCLICKABLEPOINT = unchecked((int)0x80040202);
     private const int UIA_E_PROXYASSEMBLYNOTLOADED = unchecked((int)0x80040203);
+    private const int UIA_E_NOTSUPPORTED = unchecked((int)0x80040204);
+    private const int UIA_E_TIMEOUT = unchecked((int)0x80131505);
 
     /// <summary>
     /// Gets a user-friendly error message for a COMException.
@@ -64,8 +67,30 @@ internal static class COMExceptionHelper
             UIA_E_ELEMENTNOTAVAILABLE => "Element is no longer available. The UI may have changed.",
             UIA_E_NOCLICKABLEPOINT => "Element has no clickable point. It may be obscured or zero-sized.",
             UIA_E_PROXYASSEMBLYNOTLOADED => "UI Automation proxy assembly not loaded.",
+            UIA_E_NOTSUPPORTED => "The provider does not support the requested property or pattern.",
+            UIA_E_TIMEOUT => "The UI Automation provider did not respond before the configured timeout.",
             _ => null
         };
+    }
+
+    /// <summary>
+    /// Maps a UI Automation COM failure to the MCP error taxonomy.
+    /// </summary>
+    public static string GetErrorType(COMException ex)
+    {
+        if (IsElementStale(ex))
+        {
+            return UIAutomationErrorType.ElementStale;
+        }
+
+        if (IsAccessDenied(ex))
+        {
+            return UIAutomationErrorType.ElevatedTarget;
+        }
+
+        return IsProviderTimeout(ex)
+            ? UIAutomationErrorType.Timeout
+            : UIAutomationErrorType.InternalError;
     }
 
     /// <summary>
@@ -94,6 +119,25 @@ internal static class COMExceptionHelper
     public static bool IsInvalidState(COMException ex)
     {
         return ex.HResult is E_INVALIDOPERATION or UIA_E_ELEMENTNOTENABLED;
+    }
+
+    /// <summary>
+    /// Determines if the provider exceeded the UI Automation transaction timeout.
+    /// </summary>
+    public static bool IsProviderTimeout(COMException ex)
+    {
+        return ex.HResult == UIA_E_TIMEOUT;
+    }
+
+    /// <summary>
+    /// Determines if a best-effort element operation can safely return an unavailable result.
+    /// Infrastructure, access, and timeout failures are intentionally excluded.
+    /// </summary>
+    public static bool IsExpectedElementFailure(COMException ex)
+    {
+        return IsElementStale(ex) ||
+            IsInvalidState(ex) ||
+            ex.HResult is UIA_E_NOCLICKABLEPOINT or UIA_E_NOTSUPPORTED;
     }
 
     /// <summary>

--- a/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/COMExceptionHelper.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using Sbroenne.WindowsMcp.Models;
 
 namespace Sbroenne.WindowsMcp.Automation;
 

--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using UIA = Interop.UIAutomationClient;
 
@@ -13,10 +14,16 @@ namespace Sbroenne.WindowsMcp.Automation;
 [SupportedOSPlatform("windows")]
 public static class ElementIdGenerator
 {
+    internal const int MaxRetainedIds = 4096;
+
     // Thread-safe cache for mapping short IDs to full IDs
     private static readonly ConcurrentDictionary<string, string> s_shortToFull = new();
     private static readonly ConcurrentDictionary<string, string> s_fullToShort = new();
+    private static readonly Queue<(string ShortId, string FullId)> s_registrationOrder = new();
+    private static readonly Lock s_registrationLock = new();
     private static long s_counter;
+
+    internal static int RetainedIdCount => s_shortToFull.Count;
 
     /// <summary>
     /// Generates a unique ID for a UI Automation element.
@@ -108,7 +115,15 @@ public static class ElementIdGenerator
 
             return element;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        {
+            return null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (OverflowException)
         {
             return null;
         }
@@ -153,7 +168,7 @@ public static class ElementIdGenerator
 
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:{treePath}{BuildSelectorSegment(element, cached: false)}";
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:stale";
         }
@@ -176,7 +191,7 @@ public static class ElementIdGenerator
                 {
                     windowHandle = rootElement.GetCachedNativeWindowHandle();
                 }
-                catch
+                catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
                 {
                     // Fall back to current property if not in cache
                     windowHandle = rootElement.GetNativeWindowHandle();
@@ -189,7 +204,7 @@ public static class ElementIdGenerator
             {
                 runtimeId = (int[]?)element.GetCachedPropertyValue(UIA3PropertyIds.RuntimeId);
             }
-            catch
+            catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
             {
                 // Fall back to current if not cached
                 runtimeId = element.GetRuntimeId();
@@ -202,7 +217,7 @@ public static class ElementIdGenerator
             // Simplified format - no tree path (expensive to calculate)
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:cached{BuildSelectorSegment(element, cached: true)}";
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:error";
         }
@@ -233,7 +248,7 @@ public static class ElementIdGenerator
             // Simplified format - no tree path
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:fast{BuildSelectorSegment(element, cached: false)}";
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:error";
         }
@@ -317,7 +332,7 @@ public static class ElementIdGenerator
 
             return $"|sel:{sanitizedType}~{sanitizedName}";
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return string.Empty;
         }
@@ -325,68 +340,61 @@ public static class ElementIdGenerator
 
     private static ElementIdParts? ParseElementId(string elementId)
     {
-        try
-        {
-            var parts = elementId.Split('|');
-            if (parts.Length < 3)
-            {
-                return null;
-            }
-
-            string? windowPart = null;
-            string? runtimePart = null;
-            string? pathPart = null;
-            string? controlType = null;
-            string? name = null;
-
-            foreach (var part in parts)
-            {
-                if (part.StartsWith("window:", StringComparison.Ordinal))
-                {
-                    windowPart = part["window:".Length..];
-                }
-                else if (part.StartsWith("runtime:", StringComparison.Ordinal))
-                {
-                    runtimePart = part["runtime:".Length..];
-                }
-                else if (part.StartsWith("path:", StringComparison.Ordinal))
-                {
-                    pathPart = part["path:".Length..];
-                }
-                else if (part.StartsWith("sel:", StringComparison.Ordinal))
-                {
-                    var sel = part["sel:".Length..];
-                    var tilde = sel.IndexOf('~');
-                    if (tilde >= 0)
-                    {
-                        controlType = sel[..tilde];
-                        name = sel[(tilde + 1)..];
-                    }
-                    else
-                    {
-                        name = sel;
-                    }
-                }
-            }
-
-            // Require the original three segments so malformed ids (e.g., "window:0|runtime:0")
-            // still fail closed.
-            if (windowPart == null || runtimePart == null || pathPart == null)
-            {
-                return null;
-            }
-
-            if (!nint.TryParse(windowPart, out var windowHandle))
-            {
-                return null;
-            }
-
-            return new ElementIdParts(windowHandle, runtimePart, pathPart, controlType, name);
-        }
-        catch
+        var parts = elementId.Split('|');
+        if (parts.Length < 3)
         {
             return null;
         }
+
+        string? windowPart = null;
+        string? runtimePart = null;
+        string? pathPart = null;
+        string? controlType = null;
+        string? name = null;
+
+        foreach (var part in parts)
+        {
+            if (part.StartsWith("window:", StringComparison.Ordinal))
+            {
+                windowPart = part["window:".Length..];
+            }
+            else if (part.StartsWith("runtime:", StringComparison.Ordinal))
+            {
+                runtimePart = part["runtime:".Length..];
+            }
+            else if (part.StartsWith("path:", StringComparison.Ordinal))
+            {
+                pathPart = part["path:".Length..];
+            }
+            else if (part.StartsWith("sel:", StringComparison.Ordinal))
+            {
+                var sel = part["sel:".Length..];
+                var tilde = sel.IndexOf('~');
+                if (tilde >= 0)
+                {
+                    controlType = sel[..tilde];
+                    name = sel[(tilde + 1)..];
+                }
+                else
+                {
+                    name = sel;
+                }
+            }
+        }
+
+        // Require the original three segments so malformed ids (e.g., "window:0|runtime:0")
+        // still fail closed.
+        if (windowPart == null || runtimePart == null || pathPart == null)
+        {
+            return null;
+        }
+
+        if (!nint.TryParse(windowPart, out var windowHandle))
+        {
+            return null;
+        }
+
+        return new ElementIdParts(windowHandle, runtimePart, pathPart, controlType, name);
     }
 
     private static UIA.IUIAutomationElement? FindByRuntimeId(nint windowHandle, int[] runtimeId)
@@ -414,7 +422,7 @@ public static class ElementIdGenerator
             var condition = uia.CreatePropertyCondition(UIA3PropertyIds.RuntimeId, runtimeId);
             return root.FindFirst(UIA.TreeScope.TreeScope_Descendants, condition);
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -440,7 +448,7 @@ public static class ElementIdGenerator
             foreach (var index in indices)
             {
                 var children = current.FindAll(UIA.TreeScope.TreeScope_Children, uia.TrueCondition);
-                if (children == null || index >= children.Length)
+                if (children == null || index < 0 || index >= children.Length)
                 {
                     return null;
                 }
@@ -454,7 +462,15 @@ public static class ElementIdGenerator
 
             return current;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        {
+            return null;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (OverflowException)
         {
             return null;
         }
@@ -509,7 +525,7 @@ public static class ElementIdGenerator
                             return candidate;
                         }
                     }
-                    catch
+                    catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
                     {
                         return candidate;
                     }
@@ -520,7 +536,7 @@ public static class ElementIdGenerator
 
             return typeMatch ?? firstAny;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -533,39 +549,51 @@ public static class ElementIdGenerator
     /// If the full ID is already registered, returns the existing short ID.
     /// Thread-safe with automatic deduplication.
     /// </summary>
-    private static string RegisterFullId(string fullId)
+    internal static string RegisterFullId(string fullId)
     {
         ArgumentNullException.ThrowIfNull(fullId);
 
-        // Check if already registered (common case for repeated element access)
-        if (s_fullToShort.TryGetValue(fullId, out var existingShortId))
+        lock (s_registrationLock)
         {
-            return existingShortId;
-        }
+            if (s_fullToShort.TryGetValue(fullId, out var existingShortId))
+            {
+                return existingShortId;
+            }
 
-        // Generate new short ID
-        var shortId = Interlocked.Increment(ref s_counter).ToString();
-
-        // Try to add to both dictionaries atomically
-        // Use GetOrAdd to handle race conditions where another thread registered the same fullId
-        var actualShortId = s_fullToShort.GetOrAdd(fullId, shortId);
-
-        // Only add to shortToFull if we won the race
-        if (actualShortId == shortId)
-        {
+            var shortId = Interlocked.Increment(ref s_counter).ToString();
+            s_fullToShort[fullId] = shortId;
             s_shortToFull[shortId] = fullId;
-        }
+            s_registrationOrder.Enqueue((shortId, fullId));
 
-        return actualShortId;
+            while (s_registrationOrder.Count > MaxRetainedIds)
+            {
+                var expired = s_registrationOrder.Dequeue();
+                _ = s_shortToFull.TryRemove(expired.ShortId, out _);
+                _ = s_fullToShort.TryRemove(expired.FullId, out _);
+            }
+
+            return shortId;
+        }
     }
 
     /// <summary>
     /// Resolves a short ID to the full element ID.
     /// </summary>
-    private static string? ResolveFullId(string shortId)
+    internal static string? ResolveFullId(string shortId)
     {
         ArgumentNullException.ThrowIfNull(shortId);
 
         return s_shortToFull.TryGetValue(shortId, out var fullId) ? fullId : null;
+    }
+
+    internal static void Clear()
+    {
+        lock (s_registrationLock)
+        {
+            s_shortToFull.Clear();
+            s_fullToShort.Clear();
+            s_registrationOrder.Clear();
+            Interlocked.Exchange(ref s_counter, 0);
+        }
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -168,7 +168,7 @@ public static class ElementIdGenerator
 
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:{treePath}{BuildSelectorSegment(element, cached: false)}";
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:stale";
         }
@@ -191,7 +191,7 @@ public static class ElementIdGenerator
                 {
                     windowHandle = rootElement.GetCachedNativeWindowHandle();
                 }
-                catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+                catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
                 {
                     // Fall back to current property if not in cache
                     windowHandle = rootElement.GetNativeWindowHandle();
@@ -204,7 +204,7 @@ public static class ElementIdGenerator
             {
                 runtimeId = (int[]?)element.GetCachedPropertyValue(UIA3PropertyIds.RuntimeId);
             }
-            catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+            catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
             {
                 // Fall back to current if not cached
                 runtimeId = element.GetRuntimeId();
@@ -217,7 +217,7 @@ public static class ElementIdGenerator
             // Simplified format - no tree path (expensive to calculate)
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:cached{BuildSelectorSegment(element, cached: true)}";
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:error";
         }
@@ -248,7 +248,7 @@ public static class ElementIdGenerator
             // Simplified format - no tree path
             return $"window:{windowHandle}|runtime:{runtimeIdStr}|path:fast{BuildSelectorSegment(element, cached: false)}";
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return "window:0|runtime:0|path:error";
         }
@@ -332,7 +332,7 @@ public static class ElementIdGenerator
 
             return $"|sel:{sanitizedType}~{sanitizedName}";
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return string.Empty;
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIA3Automation.cs
@@ -16,6 +16,8 @@ namespace Sbroenne.WindowsMcp.Automation;
 [SupportedOSPlatform("windows")]
 public sealed class UIA3Automation : IDisposable
 {
+    private static readonly TimeSpan DefaultConnectionTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultTransactionTimeout = TimeSpan.FromSeconds(10);
     private static readonly Lazy<UIA3Automation> LazyInstance = new(() => new UIA3Automation(), LazyThreadSafetyMode.ExecutionAndPublication);
     private readonly UIA.IUIAutomation _automation;
     private readonly UIA.IUIAutomationTreeWalker _controlViewWalker;
@@ -40,6 +42,7 @@ public sealed class UIA3Automation : IDisposable
             _automation = new UIA.CUIAutomation();
         }
 
+        ConfigureProvider(_automation);
         _controlViewWalker = _automation.ControlViewWalker;
         _trueCondition = _automation.CreateTrueCondition();
         _contentViewCondition = _automation.ContentViewCondition;
@@ -49,6 +52,21 @@ public sealed class UIA3Automation : IDisposable
     /// Gets the native IUIAutomation interface.
     /// </summary>
     public UIA.IUIAutomation Automation => _automation;
+
+    internal TimeSpan ConnectionTimeout =>
+        _automation is UIA.IUIAutomation2 automation
+            ? TimeSpan.FromMilliseconds(automation.ConnectionTimeout)
+            : Timeout.InfiniteTimeSpan;
+
+    internal TimeSpan TransactionTimeout =>
+        _automation is UIA.IUIAutomation2 automation
+            ? TimeSpan.FromMilliseconds(automation.TransactionTimeout)
+            : Timeout.InfiniteTimeSpan;
+
+    internal bool ConnectionRecoveryEnabled =>
+        _automation is UIA.IUIAutomation6 automation &&
+        automation.ConnectionRecoveryBehavior ==
+        UIA.ConnectionRecoveryBehaviorOptions.ConnectionRecoveryBehaviorOptions_Enabled;
 
     /// <summary>
     /// Gets the control view tree walker.
@@ -83,14 +101,9 @@ public sealed class UIA3Automation : IDisposable
         {
             return _automation.ElementFromHandle(hwnd);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
-            // Window handle may be invalid, stale, or the window may be unresponsive
-            return null;
-        }
-        catch (TimeoutException)
-        {
-            // COM operation may timeout for unresponsive windows
+            // Window handle may be invalid or stale.
             return null;
         }
     }
@@ -105,7 +118,7 @@ public sealed class UIA3Automation : IDisposable
             var point = new UIA.tagPOINT { x = x, y = y };
             return _automation.ElementFromPoint(point);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return null;
         }
@@ -120,7 +133,7 @@ public sealed class UIA3Automation : IDisposable
         {
             return _automation.GetFocusedElement();
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return null;
         }
@@ -158,6 +171,21 @@ public sealed class UIA3Automation : IDisposable
     public UIA.IUIAutomationCacheRequest CreateCacheRequest()
     {
         return _automation.CreateCacheRequest();
+    }
+
+    private static void ConfigureProvider(UIA.IUIAutomation automation)
+    {
+        if (automation is UIA.IUIAutomation2 automation2)
+        {
+            automation2.ConnectionTimeout = checked((uint)DefaultConnectionTimeout.TotalMilliseconds);
+            automation2.TransactionTimeout = checked((uint)DefaultTransactionTimeout.TotalMilliseconds);
+        }
+
+        if (automation is UIA.IUIAutomation6 automation6)
+        {
+            automation6.ConnectionRecoveryBehavior =
+                UIA.ConnectionRecoveryBehaviorOptions.ConnectionRecoveryBehaviorOptions_Enabled;
+        }
     }
 
     /// <summary>

--- a/src/Sbroenne.WindowsMcp/Automation/UIA3Extensions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIA3Extensions.cs
@@ -22,7 +22,7 @@ public static class UIA3Extensions
         {
             return element.CachedName;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -38,7 +38,7 @@ public static class UIA3Extensions
         {
             return element.CachedAutomationId;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -54,7 +54,7 @@ public static class UIA3Extensions
         {
             return element.CachedControlType;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -80,7 +80,7 @@ public static class UIA3Extensions
             var rect = element.CachedBoundingRectangle;
             return (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return (0, 0, 0, 0);
         }
@@ -96,7 +96,7 @@ public static class UIA3Extensions
         {
             return element.CachedIsEnabled != 0;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -112,7 +112,7 @@ public static class UIA3Extensions
         {
             return element.CachedIsOffscreen != 0;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return true;
         }
@@ -128,7 +128,7 @@ public static class UIA3Extensions
         {
             return element.CachedFrameworkId;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -144,7 +144,7 @@ public static class UIA3Extensions
         {
             return element.CachedClassName;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -160,7 +160,7 @@ public static class UIA3Extensions
         {
             return element.CachedNativeWindowHandle;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -176,7 +176,7 @@ public static class UIA3Extensions
         {
             return element.GetCachedChildren();
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -196,7 +196,7 @@ public static class UIA3Extensions
         {
             return element.CurrentName;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -212,7 +212,7 @@ public static class UIA3Extensions
         {
             return element.CurrentAutomationId;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -228,7 +228,7 @@ public static class UIA3Extensions
         {
             return element.CurrentClassName;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -244,7 +244,7 @@ public static class UIA3Extensions
         {
             return element.CurrentControlType;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -269,7 +269,7 @@ public static class UIA3Extensions
         {
             return element.CurrentNativeWindowHandle;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -285,7 +285,7 @@ public static class UIA3Extensions
         {
             return element.CurrentIsEnabled != 0;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -301,7 +301,7 @@ public static class UIA3Extensions
         {
             return element.CurrentIsOffscreen != 0;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return true;
         }
@@ -318,7 +318,7 @@ public static class UIA3Extensions
             var rect = element.CurrentBoundingRectangle;
             return (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return (0, 0, 0, 0);
         }
@@ -334,7 +334,7 @@ public static class UIA3Extensions
         {
             return element.GetRuntimeId();
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -350,7 +350,7 @@ public static class UIA3Extensions
         {
             return element.CurrentFrameworkId;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -367,7 +367,7 @@ public static class UIA3Extensions
             element.SetFocus();
             return true;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -384,7 +384,7 @@ public static class UIA3Extensions
             var pattern = element.GetCurrentPattern(patternId);
             return pattern as T;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIA3Extensions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIA3Extensions.cs
@@ -22,7 +22,7 @@ public static class UIA3Extensions
         {
             return element.CachedName;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -38,7 +38,7 @@ public static class UIA3Extensions
         {
             return element.CachedAutomationId;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -54,7 +54,7 @@ public static class UIA3Extensions
         {
             return element.CachedControlType;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -80,7 +80,7 @@ public static class UIA3Extensions
             var rect = element.CachedBoundingRectangle;
             return (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return (0, 0, 0, 0);
         }
@@ -96,7 +96,7 @@ public static class UIA3Extensions
         {
             return element.CachedIsEnabled != 0;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -112,7 +112,7 @@ public static class UIA3Extensions
         {
             return element.CachedIsOffscreen != 0;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return true;
         }
@@ -128,7 +128,7 @@ public static class UIA3Extensions
         {
             return element.CachedFrameworkId;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -144,7 +144,7 @@ public static class UIA3Extensions
         {
             return element.CachedClassName;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -160,7 +160,7 @@ public static class UIA3Extensions
         {
             return element.CachedNativeWindowHandle;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -176,7 +176,7 @@ public static class UIA3Extensions
         {
             return element.GetCachedChildren();
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -196,7 +196,7 @@ public static class UIA3Extensions
         {
             return element.CurrentName;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -212,7 +212,7 @@ public static class UIA3Extensions
         {
             return element.CurrentAutomationId;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -228,7 +228,7 @@ public static class UIA3Extensions
         {
             return element.CurrentClassName;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -244,7 +244,7 @@ public static class UIA3Extensions
         {
             return element.CurrentControlType;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -269,7 +269,7 @@ public static class UIA3Extensions
         {
             return element.CurrentNativeWindowHandle;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return 0;
         }
@@ -285,7 +285,7 @@ public static class UIA3Extensions
         {
             return element.CurrentIsEnabled != 0;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -301,7 +301,7 @@ public static class UIA3Extensions
         {
             return element.CurrentIsOffscreen != 0;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return true;
         }
@@ -318,7 +318,7 @@ public static class UIA3Extensions
             var rect = element.CurrentBoundingRectangle;
             return (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return (0, 0, 0, 0);
         }
@@ -334,7 +334,7 @@ public static class UIA3Extensions
         {
             return element.GetRuntimeId();
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -350,7 +350,7 @@ public static class UIA3Extensions
         {
             return element.CurrentFrameworkId;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -367,7 +367,7 @@ public static class UIA3Extensions
             element.SetFocus();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -384,7 +384,7 @@ public static class UIA3Extensions
             var pattern = element.GetCurrentPattern(patternId);
             return pattern as T;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -401,7 +401,7 @@ public static class UIA3Extensions
             var pattern = element.GetCurrentPattern(patternId);
             return pattern != null;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -486,7 +486,7 @@ public static class UIA3Extensions
         {
             return element.FindFirst(scope, condition);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -503,7 +503,7 @@ public static class UIA3Extensions
         {
             return element.FindAll(scope, condition);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -519,7 +519,7 @@ public static class UIA3Extensions
         {
             return UIA3Automation.Instance.ControlViewWalker.GetParentElement(element);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -535,7 +535,7 @@ public static class UIA3Extensions
         {
             return UIA3Automation.Instance.ControlViewWalker.GetFirstChildElement(element);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -551,7 +551,7 @@ public static class UIA3Extensions
         {
             return UIA3Automation.Instance.ControlViewWalker.GetNextSiblingElement(element);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -579,7 +579,7 @@ public static class UIA3Extensions
                 }
             }
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             // Ignore errors during enumeration
         }
@@ -598,7 +598,7 @@ public static class UIA3Extensions
             var pattern = element.GetPattern<UIA.IUIAutomationValuePattern>(UIA3PatternIds.Value);
             return pattern?.CurrentValue;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -621,7 +621,7 @@ public static class UIA3Extensions
             pattern.SetValue(value);
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -644,7 +644,7 @@ public static class UIA3Extensions
             pattern.Invoke();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -667,7 +667,7 @@ public static class UIA3Extensions
             pattern.DoDefaultAction();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -690,7 +690,7 @@ public static class UIA3Extensions
             pattern.Toggle();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -718,7 +718,7 @@ public static class UIA3Extensions
                 _ => null
             };
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -741,7 +741,7 @@ public static class UIA3Extensions
             pattern.Expand();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -764,7 +764,7 @@ public static class UIA3Extensions
             pattern.Collapse();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -787,7 +787,7 @@ public static class UIA3Extensions
             pattern.Select();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -810,7 +810,7 @@ public static class UIA3Extensions
             pattern.ScrollIntoView();
             return true;
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -846,7 +846,7 @@ public static class UIA3Extensions
             // Fall back to Name
             return element.GetName();
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -875,7 +875,7 @@ public static class UIA3Extensions
 
             return id1.SequenceEqual(id2);
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return false;
         }
@@ -919,7 +919,7 @@ public static class UIA3Extensions
                 return true;
             }
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             // Element may be stale or offscreen
         }
@@ -944,7 +944,7 @@ public static class UIA3Extensions
                 return ((int)(bounds.X + bounds.Width / 2), (int)(bounds.Y + bounds.Height / 2));
             }
         }
-        catch (COMException)
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             // Element may be stale or offscreen
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -62,7 +62,7 @@ public sealed partial class UIAutomationService
             LogFindAndClickError(_logger, query.Name ?? query.AutomationId ?? "unknown", ex);
             return UIAutomationResult.CreateFailure(
                 "click",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Click"),
                 CreateDiagnostics(stopwatch));
         }
@@ -200,7 +200,7 @@ public sealed partial class UIAutomationService
             LogFindAndTypeError(_logger, query.Name ?? query.AutomationId ?? "unknown", ex);
             return UIAutomationResult.CreateFailure(
                 "type",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Type"),
                 CreateDiagnostics(stopwatch));
         }
@@ -237,7 +237,7 @@ public sealed partial class UIAutomationService
             LogFindAndTypeError(_logger, elementId, ex);
             return UIAutomationResult.CreateFailure(
                 "type",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Type"),
                 CreateDiagnostics(stopwatch));
         }
@@ -454,7 +454,7 @@ public sealed partial class UIAutomationService
             LogFindAndSelectError(_logger, query.Name ?? query.AutomationId ?? "unknown", value, ex);
             return UIAutomationResult.CreateFailure(
                 "select",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Select"),
                 CreateDiagnostics(stopwatch));
         }
@@ -703,7 +703,7 @@ public sealed partial class UIAutomationService
             LogFindAndClickError(_logger, elementId, ex);
             return UIAutomationResult.CreateFailure(
                 "click",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Click"),
                 CreateDiagnostics(stopwatch));
         }
@@ -765,7 +765,7 @@ public sealed partial class UIAutomationService
         {
             return UIAutomationResult.CreateFailure(
                 "highlight",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Highlight"),
                 CreateDiagnostics(stopwatch));
         }
@@ -989,7 +989,7 @@ public sealed partial class UIAutomationService
         {
             return UIAutomationResult.CreateFailure(
                 "save",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Save"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -307,7 +307,7 @@ public sealed partial class UIAutomationService
                 }
             }
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             // Element disappeared during search
         }
@@ -371,7 +371,7 @@ public sealed partial class UIAutomationService
                 }
             }
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             // Element tree changed during search - return whatever was collected.
         }
@@ -430,7 +430,7 @@ public sealed partial class UIAutomationService
 
             return true;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             return false;
         }
@@ -497,7 +497,7 @@ public sealed partial class UIAutomationService
                 child = child.GetNextSibling();
             }
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             // Element disappeared - skip it
         }
@@ -556,7 +556,7 @@ public sealed partial class UIAutomationService
 
             return true;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             return false;
         }
@@ -573,7 +573,7 @@ public sealed partial class UIAutomationService
             var result = element.FindFirst(UIA.TreeScope.TreeScope_Element, condition);
             return result != null;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             return false;
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -240,14 +240,9 @@ public sealed partial class UIAutomationService
         catch (COMException ex)
         {
             LogFindElementsError(_logger, ex);
-            var errorType = COMExceptionHelper.IsElementStale(ex)
-                ? UIAutomationErrorType.ElementStale
-                : COMExceptionHelper.IsAccessDenied(ex)
-                    ? UIAutomationErrorType.ElevatedTarget
-                    : UIAutomationErrorType.InternalError;
             return UIAutomationResult.CreateFailure(
                 "find",
-                errorType,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Find"),
                 CreateDiagnostics(stopwatch, query));
         }
@@ -312,7 +307,7 @@ public sealed partial class UIAutomationService
                 }
             }
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             // Element disappeared during search
         }
@@ -376,7 +371,7 @@ public sealed partial class UIAutomationService
                 }
             }
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             // Element tree changed during search - return whatever was collected.
         }
@@ -414,7 +409,11 @@ public sealed partial class UIAutomationService
                         return false;
                     }
                 }
-                catch
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+                catch (RegexMatchTimeoutException)
                 {
                     return false;
                 }
@@ -431,7 +430,7 @@ public sealed partial class UIAutomationService
 
             return true;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return false;
         }
@@ -498,7 +497,7 @@ public sealed partial class UIAutomationService
                 child = child.GetNextSibling();
             }
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             // Element disappeared - skip it
         }
@@ -536,7 +535,11 @@ public sealed partial class UIAutomationService
                         return false;
                     }
                 }
-                catch
+                catch (ArgumentException)
+                {
+                    return false;
+                }
+                catch (RegexMatchTimeoutException)
                 {
                     return false;
                 }
@@ -553,7 +556,7 @@ public sealed partial class UIAutomationService
 
             return true;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return false;
         }
@@ -570,7 +573,7 @@ public sealed partial class UIAutomationService
             var result = element.FindFirst(UIA.TreeScope.TreeScope_Element, condition);
             return result != null;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return false;
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Focus.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Focus.cs
@@ -53,14 +53,9 @@ public sealed partial class UIAutomationService
         catch (COMException ex)
         {
             LogFocusElementError(_logger, elementId, ex);
-            var errorType = COMExceptionHelper.IsElementStale(ex)
-                ? UIAutomationErrorType.ElementStale
-                : COMExceptionHelper.IsAccessDenied(ex)
-                    ? UIAutomationErrorType.ElevatedTarget
-                    : UIAutomationErrorType.InternalError;
             return UIAutomationResult.CreateFailure(
                 "focus",
-                errorType,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Focus"),
                 CreateDiagnostics(stopwatch));
         }
@@ -114,7 +109,7 @@ public sealed partial class UIAutomationService
             LogGetFocusedElementError(_logger, ex);
             return UIAutomationResult.CreateFailure(
                 "get_focused_element",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "GetFocusedElement"),
                 CreateDiagnostics(stopwatch));
         }
@@ -170,7 +165,7 @@ public sealed partial class UIAutomationService
             LogGetElementAtCursorError(_logger, ex);
             return UIAutomationResult.CreateFailure(
                 "get_element_at_cursor",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "GetElementAtCursor"),
                 CreateDiagnostics(stopwatch));
         }
@@ -244,7 +239,7 @@ public sealed partial class UIAutomationService
             LogGetAncestorsError(_logger, elementId, ex);
             return UIAutomationResult.CreateFailure(
                 "get_ancestors",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "GetAncestors"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -307,7 +307,7 @@ public sealed partial class UIAutomationService
 
             return info;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -333,7 +333,7 @@ public sealed partial class UIAutomationService
                 count++;
                 child = walker.GetNextSiblingElement(child);
             }
-            catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+            catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
             {
                 break;
             }
@@ -458,7 +458,7 @@ public sealed partial class UIAutomationService
                         child = walker.GetNextSiblingElement(child);
                         childCount++;
                     }
-                    catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+                    catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
                     {
                         break;
                     }
@@ -467,7 +467,7 @@ public sealed partial class UIAutomationService
 
             return frameworkId;
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -512,7 +512,7 @@ public sealed partial class UIAutomationService
                     null);
             }
         }
-        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             // Best effort
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Sbroenne.WindowsMcp.Native;
 using UIA = Interop.UIAutomationClient;
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Sbroenne.WindowsMcp.Native;
 using UIA = Interop.UIAutomationClient;
 
@@ -306,7 +307,7 @@ public sealed partial class UIAutomationService
 
             return info;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -332,7 +333,7 @@ public sealed partial class UIAutomationService
                 count++;
                 child = walker.GetNextSiblingElement(child);
             }
-            catch
+            catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
             {
                 break;
             }
@@ -457,7 +458,7 @@ public sealed partial class UIAutomationService
                         child = walker.GetNextSiblingElement(child);
                         childCount++;
                     }
-                    catch
+                    catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
                     {
                         break;
                     }
@@ -466,7 +467,7 @@ public sealed partial class UIAutomationService
 
             return frameworkId;
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             return null;
         }
@@ -511,7 +512,7 @@ public sealed partial class UIAutomationService
                     null);
             }
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
         {
             // Best effort
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
@@ -104,7 +104,7 @@ public sealed partial class UIAutomationService
         {
             return UIAutomationResult.CreateFailure(
                 "open",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Open"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Patterns.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Patterns.cs
@@ -74,16 +74,9 @@ public sealed partial class UIAutomationService
         {
             LogInvokePatternError(_logger, pattern ?? "Invoke", elementId, ex);
 
-            // Provide detailed error based on HRESULT
-            var errorType = COMExceptionHelper.IsElementStale(ex)
-                ? UIAutomationErrorType.ElementStale
-                : COMExceptionHelper.IsAccessDenied(ex)
-                    ? UIAutomationErrorType.ElevatedTarget
-                    : UIAutomationErrorType.InternalError;
-
             return UIAutomationResult.CreateFailure(
                 "invoke",
-                errorType,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, pattern ?? "Invoke"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Scroll.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Scroll.cs
@@ -105,12 +105,9 @@ public sealed partial class UIAutomationService
         catch (COMException ex)
         {
             LogScrollIntoViewError(_logger, elementId, ex);
-            var errorType = COMExceptionHelper.IsElementStale(ex)
-                ? UIAutomationErrorType.ElementStale
-                : UIAutomationErrorType.InternalError;
             return UIAutomationResult.CreateFailure(
                 "scroll_into_view",
-                errorType,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "ScrollIntoView"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Table.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Table.cs
@@ -138,7 +138,7 @@ public sealed partial class UIAutomationService
             LogReadTableError(_logger, elementId, ex);
             return UIAutomationResult.CreateFailure(
                 "read_table",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "ReadTable"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Text.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Text.cs
@@ -68,7 +68,7 @@ public sealed partial class UIAutomationService
             LogGetTextError(_logger, elementId, ex);
             return UIAutomationResult.CreateFailure(
                 "get_text",
-                COMExceptionHelper.IsElementStale(ex) ? UIAutomationErrorType.ElementStale : UIAutomationErrorType.InternalError,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "GetText"),
                 CreateDiagnostics(stopwatch));
         }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -334,7 +334,7 @@ public sealed partial class UIAutomationService
                 usePostHocFiltering,
                 ref elementsScanned);
         }
-        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+        catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
         {
             return null;
         }
@@ -373,7 +373,7 @@ public sealed partial class UIAutomationService
             {
                 cachedChildren = element.GetCachedChildren();
             }
-            catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
+            catch (Exception ex) when (COMExceptionHelper.IsExpectedElementTraversalFailure(ex))
             {
                 // Children not cached - this shouldn't happen with TreeScope_Subtree
                 // Fall through with null

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -102,14 +102,9 @@ public sealed partial class UIAutomationService
         catch (COMException ex)
         {
             LogGetTreeError(_logger, windowHandle, ex);
-            var errorType = COMExceptionHelper.IsElementStale(ex)
-                ? UIAutomationErrorType.ElementStale
-                : COMExceptionHelper.IsAccessDenied(ex)
-                    ? UIAutomationErrorType.ElevatedTarget
-                    : UIAutomationErrorType.InternalError;
             return UIAutomationResult.CreateFailure(
                 "get_tree",
-                errorType,
+                COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "GetTree"),
                 CreateDiagnostics(stopwatch));
         }
@@ -339,7 +334,7 @@ public sealed partial class UIAutomationService
                 usePostHocFiltering,
                 ref elementsScanned);
         }
-        catch
+        catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
         {
             return null;
         }
@@ -378,7 +373,7 @@ public sealed partial class UIAutomationService
             {
                 cachedChildren = element.GetCachedChildren();
             }
-            catch
+            catch (COMException ex) when (COMExceptionHelper.IsElementStale(ex))
             {
                 // Children not cached - this shouldn't happen with TreeScope_Subtree
                 // Fall through with null

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationThread.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationThread.cs
@@ -10,17 +10,29 @@ namespace Sbroenne.WindowsMcp.Automation;
 [SupportedOSPlatform("windows")]
 public sealed class UIAutomationThread : IDisposable
 {
+    private const int DefaultQueueCapacity = 256;
     private readonly Thread _staThread;
     private readonly BlockingCollection<WorkItem> _workQueue;
     private readonly CancellationTokenSource _shutdownCts;
+    private readonly Lock _cleanupLock = new();
     private volatile bool _disposed;
+    private bool _resourcesDisposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UIAutomationThread"/> class.
     /// </summary>
     public UIAutomationThread()
+        : this(DefaultQueueCapacity)
     {
-        _workQueue = new BlockingCollection<WorkItem>();
+    }
+
+    internal UIAutomationThread(int boundedCapacity)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(boundedCapacity, 1);
+
+        _workQueue = new BlockingCollection<WorkItem>(
+            new ConcurrentQueue<WorkItem>(),
+            boundedCapacity);
         _shutdownCts = new CancellationTokenSource();
 
         _staThread = new Thread(ProcessWorkItems)
@@ -44,25 +56,35 @@ public sealed class UIAutomationThread : IDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var workItem = new WorkItem(() =>
-        {
-            try
+        var workItem = new WorkItem(
+            () =>
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                var result = func();
-                tcs.TrySetResult(result);
-            }
-            catch (OperationCanceledException)
-            {
-                tcs.TrySetCanceled(cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                tcs.TrySetException(ex);
-            }
-        });
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var result = func();
+                    tcs.TrySetResult(result);
+                }
+                catch (OperationCanceledException)
+                {
+                    tcs.TrySetCanceled(cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            },
+            () => tcs.TrySetException(new ObjectDisposedException(nameof(UIAutomationThread))));
 
-        if (!_workQueue.TryAdd(workItem))
+        try
+        {
+            if (!_workQueue.TryAdd(workItem))
+            {
+                tcs.TrySetException(new InvalidOperationException(
+                    "The UI Automation queue is full. Retry after the current operation completes."));
+            }
+        }
+        catch (InvalidOperationException)
         {
             tcs.TrySetException(new ObjectDisposedException(nameof(UIAutomationThread)));
         }
@@ -91,40 +113,75 @@ public sealed class UIAutomationThread : IDisposable
         {
             foreach (var workItem in _workQueue.GetConsumingEnumerable(_shutdownCts.Token))
             {
+                if (_disposed)
+                {
+                    workItem.Cancel();
+                    continue;
+                }
+
                 workItem.Execute();
             }
         }
         catch (OperationCanceledException)
         {
-            // Shutdown requested
+            // Shutdown requested.
+        }
+        finally
+        {
+            CancelPendingWork();
+            CleanupResources();
         }
     }
 
     /// <inheritdoc/>
     public void Dispose()
     {
-        if (_disposed)
+        lock (_cleanupLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            _workQueue.CompleteAdding();
+            _shutdownCts.Cancel();
+            CancelPendingWork();
         }
 
-        _disposed = true;
-
-        _workQueue.CompleteAdding();
-        _shutdownCts.Cancel();
-
-        // Give the thread a chance to finish current work
-        if (!_staThread.Join(TimeSpan.FromSeconds(5)))
-        {
-            // Thread didn't stop in time - it will be killed when the process exits
-        }
-
-        _shutdownCts.Dispose();
-        _workQueue.Dispose();
+        // Give the thread a chance to finish current work.
+        _ = _staThread.Join(TimeSpan.FromSeconds(5));
     }
 
-    private sealed class WorkItem(Action work)
+    private void CancelPendingWork()
     {
-        public void Execute() => work();
+        while (_workQueue.TryTake(out var pending))
+        {
+            pending.Cancel();
+        }
+    }
+
+    private void CleanupResources()
+    {
+        lock (_cleanupLock)
+        {
+            if (_resourcesDisposed)
+            {
+                return;
+            }
+
+            CancelPendingWork();
+            _shutdownCts.Dispose();
+            _workQueue.Dispose();
+            _resourcesDisposed = true;
+        }
+    }
+
+    private sealed class WorkItem(Action execute, Action cancel)
+    {
+        public void Execute() => execute();
+
+        public void Cancel() => cancel();
     }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Models;
 
 namespace Sbroenne.WindowsMcp.Tests.Unit;
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
@@ -135,6 +135,24 @@ public sealed class COMExceptionHelperTests
     }
 
     [Fact]
+    public void IsExpectedElementFailure_AllowsInteropArgumentExceptions()
+    {
+        Assert.True(COMExceptionHelper.IsExpectedElementFailure(new ArgumentException()));
+        Assert.False(COMExceptionHelper.IsExpectedElementFailure(new ArgumentNullException()));
+        Assert.False(COMExceptionHelper.IsExpectedElementFailure(new ArgumentOutOfRangeException()));
+        Assert.False(COMExceptionHelper.IsExpectedElementFailure(new InvalidOperationException()));
+    }
+
+    [Fact]
+    public void IsExpectedElementTraversalFailure_OnlyAllowsStaleOrInteropArgumentFailures()
+    {
+        Assert.True(COMExceptionHelper.IsExpectedElementTraversalFailure(new ArgumentException()));
+        Assert.True(COMExceptionHelper.IsExpectedElementTraversalFailure(MakeException(UIA_E_ELEMENTNOTAVAILABLE)));
+        Assert.False(COMExceptionHelper.IsExpectedElementTraversalFailure(MakeException(UIA_E_NOTSUPPORTED)));
+        Assert.False(COMExceptionHelper.IsExpectedElementTraversalFailure(MakeException(UIA_E_TIMEOUT)));
+    }
+
+    [Fact]
     public void TryExecute_WhenActionSucceeds_ReturnsSuccess()
     {
         var (success, error) = COMExceptionHelper.TryExecute(() => { }, "Op");

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/COMExceptionHelperTests.cs
@@ -20,6 +20,8 @@ public sealed class COMExceptionHelperTests
     private const int UIA_E_ELEMENTNOTENABLED = unchecked((int)0x80040200);
     private const int UIA_E_ELEMENTNOTAVAILABLE = unchecked((int)0x80040201);
     private const int UIA_E_NOCLICKABLEPOINT = unchecked((int)0x80040202);
+    private const int UIA_E_NOTSUPPORTED = unchecked((int)0x80040204);
+    private const int UIA_E_TIMEOUT = unchecked((int)0x80131505);
 
     private static COMException MakeException(int hresult) =>
 #pragma warning disable CA2201 // Constructing COMException directly is intentional: tests must simulate specific UIA HRESULTs.
@@ -98,6 +100,37 @@ public sealed class COMExceptionHelperTests
     public void IsTransientProviderFailure_ClassifiesRetryableHResults(int hresult, bool expected)
     {
         Assert.Equal(expected, COMExceptionHelper.IsTransientProviderFailure(MakeException(hresult)));
+    }
+
+    [Theory]
+    [InlineData(UIA_E_TIMEOUT, true)]
+    [InlineData(E_ACCESSDENIED, false)]
+    [InlineData(UIA_E_ELEMENTNOTAVAILABLE, false)]
+    public void IsProviderTimeout_ClassifiesTimeoutHResults(int hresult, bool expected)
+    {
+        Assert.Equal(expected, COMExceptionHelper.IsProviderTimeout(MakeException(hresult)));
+    }
+
+    [Theory]
+    [InlineData(UIA_E_TIMEOUT, UIAutomationErrorType.Timeout)]
+    [InlineData(E_ACCESSDENIED, UIAutomationErrorType.ElevatedTarget)]
+    [InlineData(UIA_E_ELEMENTNOTAVAILABLE, UIAutomationErrorType.ElementStale)]
+    [InlineData(UIA_E_NOCLICKABLEPOINT, UIAutomationErrorType.InternalError)]
+    public void GetErrorType_MapsKnownHResults(int hresult, string expected)
+    {
+        Assert.Equal(expected, COMExceptionHelper.GetErrorType(MakeException(hresult)));
+    }
+
+    [Theory]
+    [InlineData(UIA_E_ELEMENTNOTAVAILABLE, true)]
+    [InlineData(UIA_E_ELEMENTNOTENABLED, true)]
+    [InlineData(UIA_E_NOCLICKABLEPOINT, true)]
+    [InlineData(UIA_E_NOTSUPPORTED, true)]
+    [InlineData(UIA_E_TIMEOUT, false)]
+    [InlineData(E_ACCESSDENIED, false)]
+    public void IsExpectedElementFailure_ExcludesInfrastructureFailures(int hresult, bool expected)
+    {
+        Assert.Equal(expected, COMExceptionHelper.IsExpectedElementFailure(MakeException(hresult)));
     }
 
     [Fact]

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/ElementIdGeneratorTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/ElementIdGeneratorTests.cs
@@ -10,6 +10,34 @@ namespace Sbroenne.WindowsMcp.Tests.Unit;
 [SupportedOSPlatform("windows")]
 public class ElementIdGeneratorTests
 {
+    [Fact]
+    public void RegisterFullId_WhenCapacityExceeded_EvictsOldestId()
+    {
+        ElementIdGenerator.Clear();
+        var firstShortId = ElementIdGenerator.RegisterFullId("window:1|runtime:1|path:cached");
+
+        for (var i = 2; i <= ElementIdGenerator.MaxRetainedIds + 1; i++)
+        {
+            ElementIdGenerator.RegisterFullId($"window:1|runtime:{i}|path:cached");
+        }
+
+        Assert.Null(ElementIdGenerator.ResolveFullId(firstShortId));
+        Assert.Equal(ElementIdGenerator.MaxRetainedIds, ElementIdGenerator.RetainedIdCount);
+    }
+
+    [Fact]
+    public void RegisterFullId_WhenIdAlreadyExists_ReusesShortIdWithoutGrowingCache()
+    {
+        ElementIdGenerator.Clear();
+        const string FullId = "window:1|runtime:7|path:cached";
+
+        var first = ElementIdGenerator.RegisterFullId(FullId);
+        var second = ElementIdGenerator.RegisterFullId(FullId);
+
+        Assert.Equal(first, second);
+        Assert.Equal(1, ElementIdGenerator.RetainedIdCount);
+    }
+
     #region ResolveToAutomationElement Tests
 
     [Fact]
@@ -51,6 +79,14 @@ public class ElementIdGeneratorTests
     {
         // Window handle part is not a valid number
         var result = ElementIdGenerator.ResolveToAutomationElement("window:abc|runtime:0|path:0");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ResolveToAutomationElement_MalformedFullId_NegativeTreeIndex_ReturnsNull()
+    {
+        var result = ElementIdGenerator.ResolveToAutomationElement("window:0|runtime:0|path:-1");
 
         Assert.Null(result);
     }

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/UIA3AutomationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/UIA3AutomationTests.cs
@@ -1,0 +1,18 @@
+using System.Runtime.Versioning;
+using Sbroenne.WindowsMcp.Automation;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+[SupportedOSPlatform("windows")]
+public sealed class UIA3AutomationTests
+{
+    [Fact]
+    public void Instance_ConfiguresBoundedProviderTimeoutsAndRecovery()
+    {
+        var automation = UIA3Automation.Instance;
+
+        Assert.Equal(TimeSpan.FromSeconds(5), automation.ConnectionTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(10), automation.TransactionTimeout);
+        Assert.True(automation.ConnectionRecoveryEnabled);
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/UIAutomationThreadTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/UIAutomationThreadTests.cs
@@ -6,6 +6,8 @@ namespace Sbroenne.WindowsMcp.Tests.Unit;
 [SupportedOSPlatform("windows")]
 public sealed class UIAutomationThreadTests
 {
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
     [Fact]
     public async Task ExecuteAsync_WhenQueueIsFull_FailsWithoutBlockingCaller()
     {
@@ -16,9 +18,12 @@ public sealed class UIAutomationThreadTests
         var running = executor.ExecuteAsync(() =>
         {
             runningWorkStarted.SetResult();
-            releaseRunningWork.Wait();
+            if (!releaseRunningWork.Wait(TestTimeout))
+            {
+                throw new TimeoutException("Timed out waiting to release the running work item.");
+            }
         });
-        await runningWorkStarted.Task;
+        await runningWorkStarted.Task.WaitAsync(TestTimeout);
 
         var queued = executor.ExecuteAsync(() => { });
         var rejected = executor.ExecuteAsync(() => { });
@@ -40,9 +45,12 @@ public sealed class UIAutomationThreadTests
         var running = executor.ExecuteAsync(() =>
         {
             runningWorkStarted.SetResult();
-            releaseRunningWork.Wait();
+            if (!releaseRunningWork.Wait(TestTimeout))
+            {
+                throw new TimeoutException("Timed out waiting to release the running work item.");
+            }
         });
-        await runningWorkStarted.Task;
+        await runningWorkStarted.Task.WaitAsync(TestTimeout);
 
         var queued = executor.ExecuteAsync(() => { });
         var disposing = Task.Run(executor.Dispose);

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/UIAutomationThreadTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/UIAutomationThreadTests.cs
@@ -1,0 +1,54 @@
+using System.Runtime.Versioning;
+using Sbroenne.WindowsMcp.Automation;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+[SupportedOSPlatform("windows")]
+public sealed class UIAutomationThreadTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenQueueIsFull_FailsWithoutBlockingCaller()
+    {
+        using var executor = new UIAutomationThread(boundedCapacity: 1);
+        using var releaseRunningWork = new ManualResetEventSlim();
+        var runningWorkStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var running = executor.ExecuteAsync(() =>
+        {
+            runningWorkStarted.SetResult();
+            releaseRunningWork.Wait();
+        });
+        await runningWorkStarted.Task;
+
+        var queued = executor.ExecuteAsync(() => { });
+        var rejected = executor.ExecuteAsync(() => { });
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => rejected);
+        Assert.Contains("queue is full", exception.Message, StringComparison.OrdinalIgnoreCase);
+
+        releaseRunningWork.Set();
+        await Task.WhenAll(running, queued);
+    }
+
+    [Fact]
+    public async Task Dispose_CancelsQueuedWork()
+    {
+        var executor = new UIAutomationThread(boundedCapacity: 1);
+        using var releaseRunningWork = new ManualResetEventSlim();
+        var runningWorkStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var running = executor.ExecuteAsync(() =>
+        {
+            runningWorkStarted.SetResult();
+            releaseRunningWork.Wait();
+        });
+        await runningWorkStarted.Task;
+
+        var queued = executor.ExecuteAsync(() => { });
+        var disposing = Task.Run(executor.Dispose);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => queued);
+        releaseRunningWork.Set();
+        await Task.WhenAll(running, disposing);
+    }
+}


### PR DESCRIPTION
## Summary
- configure bounded UIA3 connection and transaction timeouts with connection recovery
- bound retained element locators and reject malformed tree paths
- add executor backpressure and deterministic pending-work cancellation
- preserve provider timeout, access, and infrastructure failures instead of collapsing them into not-found results
- add focused unit coverage for provider configuration, HRESULT classification, locator retention, and executor lifecycle

## Validation
- independent compile/runtime harness passed for the changed UIA foundations and concurrency behavior
- repository test execution is currently blocked locally because the configured package feed does not contain `ModelContextProtocol` 2.2.0 or `xunit.runner.visualstudio` 4.0.0, while direct NuGet access fails during TLS negotiation; CI should run the committed targeted tests