### PR TITLE
Native ClassName condition, action responsiveness gate, and two integration harness fixes

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,6 +69,60 @@ jobs:
             throw "Failed to set the VM auto-shutdown watchdog."
           }
 
+      # `az vm start` only proves the VM powered on. The runner itself is launched by the
+      # WindowsMcp-GitHub-Runner scheduled task, which has an *interactive logon* trigger so the
+      # tests get a real desktop. If nobody logs on (for example when autologon is disabled), the
+      # task never fires, no runner registers, and the integration job sits queued until GitHub
+      # discards it 24 hours later. Fail fast here instead, with an actionable message.
+      - name: Wait for the self-hosted runner to come online
+        shell: pwsh
+        env:
+          RUNNER_ONLINE_TIMEOUT_MINUTES: '10'
+        run: |
+          $probePath = Join-Path $env:RUNNER_TEMP 'probe-windows-ui-runner.ps1'
+          @'
+          $listener = Get-Process Runner.Listener -ErrorAction SilentlyContinue
+          $hasSession = @(quser 2>$null | Select-String -Pattern '\sActive\s').Count -gt 0
+          if ($listener -and $hasSession) { Write-Output 'RUNNER_ONLINE' }
+          elseif ($hasSession) { Write-Output 'SESSION_BUT_NO_LISTENER' }
+          else { Write-Output 'NO_INTERACTIVE_SESSION' }
+          '@ | Set-Content -Path $probePath -Encoding utf8
+
+          $deadline = (Get-Date).AddMinutes([int]$env:RUNNER_ONLINE_TIMEOUT_MINUTES)
+          $lastState = 'no probe completed'
+
+          while ((Get-Date) -lt $deadline) {
+            $probeOutput = az vm run-command invoke `
+              --resource-group $env:AZURE_RESOURCE_GROUP `
+              --name $env:AZURE_VM_NAME `
+              --command-id RunPowerShellScript `
+              --scripts "@$probePath" `
+              --query "value[].message" -o tsv
+
+            if ($LASTEXITCODE -eq 0 -and $probeOutput) {
+              $lastState = ($probeOutput | Out-String).Trim()
+              if ($lastState -match 'RUNNER_ONLINE') {
+                Write-Host 'Runner is online and attached to an interactive desktop session.'
+                exit 0
+              }
+            }
+
+            Write-Host "Runner not ready yet (state: $lastState). Retrying in 30s."
+            Start-Sleep -Seconds 30
+          }
+
+          throw @"
+          The Windows UI runner did not come online within $env:RUNNER_ONLINE_TIMEOUT_MINUTES minutes.
+          Last probe state: $lastState
+
+          NO_INTERACTIVE_SESSION means the VM booted to a login screen and nobody logged on, so the
+          WindowsMcp-GitHub-Runner logon-triggered scheduled task never fired. Verify that autologon
+          is enabled for the runner account on $env:AZURE_VM_NAME.
+
+          SESSION_BUT_NO_LISTENER means someone is logged on but Runner.Listener is not running.
+          Check C:\actions-runner\_diag on the VM and the state of the scheduled task.
+          "@
+
   integration-tests:
     name: Windows UI integration suite
     needs: start-runner

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Sbroenne.WindowsMcp.Utilities;
 using UIA = Interop.UIAutomationClient;
@@ -8,6 +9,7 @@ public sealed partial class UIAutomationService
 {
     private static readonly TimeSpan ActionVerificationTimeout = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan ActionVerificationPollInterval = TimeSpan.FromMilliseconds(25);
+    private static readonly TimeSpan ElementResponsivenessTimeout = TimeSpan.FromSeconds(2);
 
     private readonly record struct ElementActionOutcome(
         bool Success,
@@ -28,12 +30,69 @@ public sealed partial class UIAutomationService
         UIA.ToggleState? ToggleState,
         bool? IsSelected);
 
+    /// <summary>
+    /// Waits, up to <see cref="ElementResponsivenessTimeout"/>, for the process owning
+    /// <paramref name="element"/> to stop being busy. Purely advisory: every failure mode
+    /// (no process id, exited process, non-UI process) falls through so the caller still acts.
+    /// </summary>
+    private async Task WaitForElementResponsiveAsync(
+        UIA.IUIAutomationElement element,
+        CancellationToken cancellationToken)
+    {
+        int processId;
+        try
+        {
+            processId = await _staThread.ExecuteAsync(() => element.CurrentProcessId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (COMException)
+        {
+            return;
+        }
+
+        if (processId <= 0)
+        {
+            return;
+        }
+
+        Process process;
+        try
+        {
+            process = Process.GetProcessById(processId);
+        }
+        catch (ArgumentException)
+        {
+            return;
+        }
+
+        using (process)
+        {
+            try
+            {
+                _ = await DeterministicWait.UntilAsync(
+                    () => process.Responding,
+                    ElementResponsivenessTimeout,
+                    ActionVerificationPollInterval,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+                // Process exited or has no message queue to interrogate.
+            }
+        }
+    }
+
     private async Task<ElementActionOutcome> ExecuteElementActionAsync(
         UIA.IUIAutomationElement element,
         UIA.IUIAutomationElement rootElement,
         Point? fallbackClickPoint,
         CancellationToken cancellationToken)
     {
+        // Gate on the owning process being responsive. Acting while the target app is still
+        // pumping a long operation is a common source of dropped clicks and lost keystrokes.
+        // Best-effort: a still-busy process does not fail the action, it just stops us racing ahead.
+        await WaitForElementResponsiveAsync(element, cancellationToken).ConfigureAwait(false);
+
         var initial = await _staThread.ExecuteAsync(
             () => new ElementActionState(
                 element.GetControlTypeId(),

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Sbroenne.WindowsMcp.Utilities;
@@ -62,6 +63,17 @@ public sealed partial class UIAutomationService
         }
         catch (ArgumentException)
         {
+            // Process already exited.
+            return;
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+        catch (Win32Exception)
+        {
+            // Cannot open the process (for example a more privileged target). The gate is
+            // advisory, so an unqueryable process must not prevent the action.
             return;
         }
 
@@ -78,6 +90,10 @@ public sealed partial class UIAutomationService
             catch (InvalidOperationException)
             {
                 // Process exited or has no message queue to interrogate.
+            }
+            catch (Win32Exception)
+            {
+                // Access denied while probing responsiveness. Proceed with the action.
             }
         }
     }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -81,11 +81,12 @@ public sealed partial class UIAutomationService
                     referencePoint = BoundingRect.FromCoordinates(refRect.left, refRect.top, refRect.right - refRect.left, refRect.bottom - refRect.top);
                 }
 
-                // Determine if we can use fast FindAll
+                // Determine if we can use fast FindAll.
+                // ClassName is deliberately absent: it is a native UIA property, so BuildCondition
+                // pushes it into the FindAll condition instead of forcing a bulk fetch + in-process scan.
                 var hasAdvancedCriteria = !string.IsNullOrEmpty(query.NameContains) ||
                                          !string.IsNullOrEmpty(query.NamePattern) ||
                                          query.ExactDepth.HasValue ||
-                                         !string.IsNullOrEmpty(query.ClassName) ||
                                          regionFilter != null;
 
                 var elementInfos = new List<UIElementInfo>();

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -156,6 +156,14 @@ public sealed partial class UIAutomationService
             conditions.Add(Uia.CreatePropertyCondition(UIA3PropertyIds.AutomationId, query.AutomationId));
         }
 
+        if (!string.IsNullOrEmpty(query.ClassName))
+        {
+            conditions.Add(Uia.CreatePropertyConditionWithFlags(
+                UIA3PropertyIds.ClassName,
+                query.ClassName,
+                UIA.PropertyConditionFlags.PropertyConditionFlags_IgnoreCase));
+        }
+
         if (!string.IsNullOrEmpty(query.ControlType))
         {
             var controlTypeId = GetControlTypeId(query.ControlType);

--- a/src/Sbroenne.WindowsMcp/Native/NativeMethods.cs
+++ b/src/Sbroenne.WindowsMcp/Native/NativeMethods.cs
@@ -220,6 +220,17 @@ internal static partial class NativeMethods
     internal static partial bool EnumWindows(EnumWindowsProc lpEnumFunc, nint lParam);
 
     /// <summary>
+    /// Enumerates the child windows of the specified parent window.
+    /// </summary>
+    /// <param name="hWndParent">Handle to the parent window.</param>
+    /// <param name="lpEnumFunc">Callback function for each child window.</param>
+    /// <param name="lParam">Application-defined value to pass to callback.</param>
+    /// <returns>True if successful, false otherwise.</returns>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool EnumChildWindows(nint hWndParent, EnumWindowsProc lpEnumFunc, nint lParam);
+
+    /// <summary>
     /// Retrieves the name of the class to which the specified window belongs.
     /// </summary>
     /// <param name="hWnd">Handle to the window.</param>

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumContentViewTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumContentViewTests.cs
@@ -23,7 +23,7 @@ public sealed class ChromiumContentViewTests : IClassFixture<ChromiumReadOnlySes
         _readOnlySessions = readOnlySessions;
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_DefaultOnChromium_UsesContentView(ChromiumBrowserKind browser)
@@ -46,7 +46,7 @@ public sealed class ChromiumContentViewTests : IClassFixture<ChromiumReadOnlySes
         Assert.True(result.Diagnostics!.UsedContentView, "Chromium find should default to the content view.");
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_ContentView_ScansNoMoreThanControlView(ChromiumBrowserKind browser)
@@ -87,7 +87,7 @@ public sealed class ChromiumContentViewTests : IClassFixture<ChromiumReadOnlySes
             $"Content view scanned {contentScanned} elements but control view scanned {controlScanned}.");
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_ContentViewOff_StillFindsElement(ChromiumBrowserKind browser)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
@@ -21,7 +21,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         _readOnlySessions = readOnlySessions;
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_LocalChromiumPage_PrimaryNavigation_IsDiscoverable(ChromiumBrowserKind browser)
@@ -43,7 +43,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.NotEmpty(result.Items!);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_LocalChromiumPage_SearchInputByAriaLabel_ReturnsEdit(ChromiumBrowserKind browser)
@@ -67,7 +67,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.Equal("Edit", result.Items![0].Type);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_LocalChromiumPage_SignInButtonByAriaLabel_ReturnsButton(ChromiumBrowserKind browser)
@@ -91,7 +91,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.Equal("Button", result.Items![0].Type);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Type_LocalChromiumPage_SearchInput_ReadsBackTypedValue(ChromiumBrowserKind browser)
@@ -117,7 +117,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.Equal(expectedText, readResult.Text);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Click_LocalChromiumPage_SignInButton_RevealsFocusedContent(ChromiumBrowserKind browser)
@@ -139,7 +139,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.Equal(FocusedButtonMessage, readResult.Text);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Read_LocalChromiumPage_InitialStatus_ReturnsSignedOut(ChromiumBrowserKind browser)
@@ -156,7 +156,7 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.Equal(SignedOutStatus, readResult.Text);
     }
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Read_LocalChromiumPage_ArticleMode_ReturnsCleanMainContent(ChromiumBrowserKind browser)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgePublicPageTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgePublicPageTests.cs
@@ -11,7 +11,7 @@ public sealed class ChromiumPublicPageTests
 {
     private const int QueryTimeoutMs = 20000;
 
-    [Theory]
+    [SkippableTheory]
     [InlineData(ChromiumBrowserKind.Edge)]
     [InlineData(ChromiumBrowserKind.Chrome)]
     public async Task Find_PlaywrightTodoMvc_NewTodoInputByPlaceholder_ReturnsEdit(ChromiumBrowserKind browser)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/ModernTestHarnessFixture.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/ModernTestHarnessFixture.cs
@@ -62,7 +62,9 @@ public sealed class ModernTestHarnessFixture : IDisposable
         {
             throw new FileNotFoundException(
                 $"Modern test harness not found at: {HarnessPath}. " +
-                "Build the Sbroenne.WindowsMcp.ModernHarness project first.",
+                "The test project builds it automatically via ProjectReference; if you are running " +
+                "with --no-build, build it first with: " +
+                "dotnet build tests\\Sbroenne.WindowsMcp.ModernHarness -c Debug",
                 HarnessPath);
         }
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -3,6 +3,7 @@ using Sbroenne.WindowsMcp.Automation;
 using Sbroenne.WindowsMcp.Capture;
 using Sbroenne.WindowsMcp.Input;
 using Sbroenne.WindowsMcp.Models;
+using Sbroenne.WindowsMcp.Native;
 using Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
 using Sbroenne.WindowsMcp.Window;
 
@@ -477,6 +478,102 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
         Assert.NotNull(result.Items);
         Assert.True(result.Items!.Length >= 1, "Should find at least one checkbox");
         Assert.NotEqual(allCheckboxes.Items![0].Id, result.Items![0].Id);
+    }
+
+    #endregion
+
+    #region ClassName Tests
+
+    [Fact]
+    public async Task Find_WithClassName_ReturnsMatchingElements()
+    {
+        // WinForms class names carry a volatile suffix (WindowsForms10.BUTTON.app.0.3cb9f91),
+        // so discover a real one from the harness at runtime rather than hardcoding it.
+        var className = GetFirstChildClassName(_fixture.TestWindowHandle);
+        Assert.False(string.IsNullOrEmpty(className), "Could not discover a child window class name from the harness.");
+
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ClassName = className,
+        });
+
+        Assert.True(result.Success, $"Find failed: {result.ErrorMessage}");
+        Assert.NotNull(result.Items);
+        Assert.NotEmpty(result.Items!);
+    }
+
+    [Fact]
+    public async Task Find_WithClassNameDifferentCasing_StillMatches()
+    {
+        // ClassName is pushed into the native UIA condition; it must stay case-insensitive
+        // to match the previous in-process OrdinalIgnoreCase comparison.
+        var className = GetFirstChildClassName(_fixture.TestWindowHandle);
+        Assert.False(string.IsNullOrEmpty(className), "Could not discover a child window class name from the harness.");
+
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ClassName = className!.ToUpperInvariant(),
+        });
+
+        Assert.True(result.Success, $"Find failed: {result.ErrorMessage}");
+        Assert.NotNull(result.Items);
+        Assert.NotEmpty(result.Items!);
+    }
+
+    [Fact]
+    public async Task Find_WithNonMatchingClassName_ReturnsNoElements()
+    {
+        // Guards against ClassName silently ceasing to be applied as a filter.
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ControlType = "Button",
+            ClassName = "NoSuchClassName_ZZZ",
+        });
+
+        Assert.True(result.Items == null || result.Items.Length == 0,
+            $"Expected no elements for a bogus className, got {result.Items?.Length ?? 0}.");
+    }
+
+    [Fact]
+    public async Task Find_WithClassNameAndNameContains_AppliesBoth()
+    {
+        var className = GetFirstChildClassName(_fixture.TestWindowHandle);
+        Assert.False(string.IsNullOrEmpty(className), "Could not discover a child window class name from the harness.");
+
+        // Combining ClassName with an advanced criterion keeps the cached-filter path,
+        // with ClassName now pre-filtered natively.
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ClassName = className,
+            NameContains = "ThisNameDoesNotExist_ZZZ",
+        });
+
+        Assert.True(result.Items == null || result.Items.Length == 0,
+            $"Expected no elements when nameContains cannot match, got {result.Items?.Length ?? 0}.");
+    }
+
+    private static string? GetFirstChildClassName(nint parent)
+    {
+        string? found = null;
+
+        NativeMethods.EnumChildWindows(parent, (hWnd, _) =>
+        {
+            var buffer = new char[256];
+            var length = NativeMethods.GetClassName(hWnd, buffer, buffer.Length);
+            if (length > 0)
+            {
+                found = new string(buffer, 0, length);
+                return false;
+            }
+
+            return true;
+        }, nint.Zero);
+
+        return found;
     }
 
     #endregion

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -533,6 +533,11 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
             ClassName = "NoSuchClassName_ZZZ",
         });
 
+        // A zero-result find is reported as ElementNotFound rather than an empty success,
+        // so assert the specific error type: that distinguishes "the filter worked" from
+        // "the query failed for some other reason".
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.ElementNotFound, result.ErrorType);
         Assert.True(result.Items == null || result.Items.Length == 0,
             $"Expected no elements for a bogus className, got {result.Items?.Length ?? 0}.");
     }
@@ -552,6 +557,8 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
             NameContains = "ThisNameDoesNotExist_ZZZ",
         });
 
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.ElementNotFound, result.ErrorType);
         Assert.True(result.Items == null || result.Items.Length == 0,
             $"Expected no elements when nameContains cannot match, got {result.Items?.Length ?? 0}.");
     }

--- a/tests/Sbroenne.WindowsMcp.Tests/Sbroenne.WindowsMcp.Tests.csproj
+++ b/tests/Sbroenne.WindowsMcp.Tests/Sbroenne.WindowsMcp.Tests.csproj
@@ -40,6 +40,16 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Sbroenne.WindowsMcp\Sbroenne.WindowsMcp.csproj" />
     <ProjectReference Include="..\..\src\Sbroenne.WindowsMcp.Cli\Sbroenne.WindowsMcp.Cli.csproj" />
+    <!--
+      The WinUI 3 harness is launched as a separate process by ModernTestHarnessFixture, which locates
+      it by probing the harness project's own bin directory. We only need it *built*, not referenced:
+      ReferenceOutputAssembly=false keeps its assembly and Windows App SDK dependencies out of the test
+      output, while still guaranteeing it exists on a fresh clone.
+    -->
+    <ProjectReference Include="..\Sbroenne.WindowsMcp.ModernHarness\Sbroenne.WindowsMcp.ModernHarness.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      Private="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Ideas adapted from a review of [OpenRPA](https://github.com/open-rpa/openrpa) (MPL-2.0 — concepts only, no code copied), plus fixes for two test-harness defects and one CI defect found while validating.

Closes #191
Closes #192

## 1. Push `ClassName` into the native UIA condition

`ClassName` was treated as an "advanced" criterion, so it was matched only in-process after a bulk fetch of every candidate element. It is a plain string property that UIA can filter natively.

- `UIAutomationService.Helpers.cs` — `BuildCondition` now emits a `ClassName` property condition using `PropertyConditionFlags_IgnoreCase` (matching the precedent already set by `Name`).
- `UIAutomationService.Find.cs` — `ClassName` removed from `hasAdvancedCriteria`, so a `ClassName`-only query takes the fast `FindAllBuildCache` path instead of the cached-filter path.

The redundant in-process `ClassName` check is deliberately retained: `FindElementsWithTreeWalker` applies the condition per-node via `MatchesCondition`, not as a traversal filter, so narrowing the native condition cannot cause intermediate nodes to be skipped.

## 2. Gate element actions on process responsiveness

Acting on a window whose message pump is blocked produces confusing timeouts deep in a UIA pattern call. `ExecuteElementActionAsync` now waits (up to 2s) for the owning process to become responsive before dispatching.

Unlike OpenRPA's synchronous `UntilResponsive()` busy-wait, this gate is `async` so it never blocks the dedicated STA `UIAutomationThread`. It is a best-effort gate: on timeout the action proceeds anyway rather than failing.

## 3. Harness fix — WinUI 3 harness was never built (#191)

The test project had no reference to `Sbroenne.WindowsMcp.ModernHarness`, so on a fresh clone the harness executable did not exist and every `ModernTestHarnessFixture` test failed with `FileNotFoundException`.

The fixture's existing probe of the harness project's own `bin` directory turns out to work correctly — the harness was simply never built. Fixed with a `ProjectReference` carrying `ReferenceOutputAssembly="false"`, so building the tests also builds the harness without pulling its assembly or Windows App SDK dependencies into the test output. The fixture's error message now names the exact build command for `--no-build` runs.

## 4. Harness fix — `Skip.If` under plain `[Theory]` (#192)

The Chromium browser tests call `Skip.If`/`Skip.IfNot`, but `Xunit.SkippableFact` only converts a `SkipException` into a skip result when the test carries a `[SkippableFact]`/`[SkippableTheory]` attribute. Under a plain `[Theory]` the exception surfaced as a hard failure, so machines without Chrome installed reported 11 spurious failures. Converted the 11 affected attributes to `[SkippableTheory]` (attribute-only diff).

## 5. CI fix — integration gate could hang instead of failing

While validating this PR, the integration workflow sat queued for **21 hours**. `start-runner` only ran `az vm start`, which proves the VM powered on but not that a runner registered. The runner is launched by the `WindowsMcp-GitHub-Runner` scheduled task, which uses an *interactive logon* trigger so UI tests get a real desktop. Autologon had been disabled, so the VM booted to a login screen, the task never fired, and no runner ever connected.

`timeout-minutes` does not help, because it only applies once a job starts running — not while it is queued. So the job hung until GitHub's 24-hour limit, holding the repo-global `windows-ui-integration-tests` concurrency group and blocking the integration gate for every PR.

`start-runner` now polls the VM through the existing OIDC Azure login until `Runner.Listener` is running in an interactive session, and fails after 10 minutes with a message that distinguishes "nobody logged on" from "logged on but listener dead". (`GITHUB_TOKEN` cannot list self-hosted runners — `administration` is not a grantable workflow permission — so the check goes via Azure rather than the GitHub API.)

The underlying VM autologon was also repaired out-of-band, storing the credential as an LSA secret rather than a `DefaultPassword` registry value, since `HKLM\...\Winlogon` is readable by `BUILTIN\Users` and the account is a local administrator.

## Tests

`ClassName` had zero existing coverage. Added 4 integration tests to `UIAutomationAdvancedSearchTests`, covering native-path matching, case-insensitivity, combination with other criteria, and no-match behaviour. WinForms class names are volatile, so the expected value is discovered at runtime via `EnumChildWindows` + `GetClassName` (added as `[LibraryImport]` declarations in `src/.../Native/NativeMethods.cs`, since the test project disallows unsafe code and so cannot host `LibraryImport` itself).

## Verification

Full integration suite on the self-hosted Windows UI runner:

| | Failed | Passed | Skipped | Total |
|---|---|---|---|---|
| Baseline (`cf254447`, pre-change) | 0 | 805 | 8 | 813 |
| This PR (`836c628`) | **0** | **809** | 8 | **817** |

The +4 is exactly the new `ClassName` tests. Unit tests: 494 passed.

Locally, the harness fixes were confirmed independently: WinUI harness 47/47 from a clean `bin` with no manual copying (previously required copying the harness output by hand), and ChromiumBrowser 17 passed / 11 skipped / 0 failed on a machine without Chrome (previously 11 hard failures).

One intermittent failure of `Click_LocalChromiumPage_SignInButton_RevealsFocusedContent(Edge)` was observed on an earlier run of this branch. It is a pre-existing race against Chromium's accessibility-tree update — the click assertion passes and only the follow-up query fails, and that query uses only `Name`/`ControlType` so it runs an identical code path to baseline. A re-run of the `chromium` scope on the same commit passed 22/22. Tracked separately in #193.

## Follow-up

Issue #189 tracks a spike on UIA `StructureChangedEvent` subscriptions, the one remaining OpenRPA idea that looked genuinely valuable but needs measurement before committing to it — and which would also address the polling race behind #193.