### PR TITLE
test: wait for observable state instead of fixed delays in integration assertion gates

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,7 +77,8 @@ jobs:
       - name: Wait for the self-hosted runner to come online
         shell: pwsh
         env:
-          RUNNER_ONLINE_TIMEOUT_MINUTES: '10'
+          RUNNER_ONLINE_TIMEOUT_MINUTES: '20'
+          PROBE_CALL_TIMEOUT_SECONDS: '180'
         run: |
           $probePath = Join-Path $env:RUNNER_TEMP 'probe-windows-ui-runner.ps1'
           @'
@@ -90,16 +91,41 @@ jobs:
 
           $deadline = (Get-Date).AddMinutes([int]$env:RUNNER_ONLINE_TIMEOUT_MINUTES)
           $lastState = 'no probe completed'
+          $agentStatus = 'unknown'
+
+          # `az vm run-command` needs a responsive Azure guest agent. Ask the control plane whether
+          # the agent is Ready first: that call reads reported status and cannot hang on the guest,
+          # so a slow-booting VM is reported accurately instead of blocking a run-command call.
+          while ((Get-Date) -lt $deadline) {
+            $agentStatus = (az vm get-instance-view `
+              --resource-group $env:AZURE_RESOURCE_GROUP `
+              --name $env:AZURE_VM_NAME `
+              --query "instanceView.vmAgent.statuses[0].displayStatus" -o tsv | Out-String).Trim()
+
+            if ($LASTEXITCODE -eq 0 -and $agentStatus -eq 'Ready') {
+              Write-Host 'Azure guest agent is Ready.'
+              break
+            }
+
+            Write-Host "Guest agent not ready yet (status: $agentStatus). Retrying in 15s."
+            Start-Sleep -Seconds 15
+          }
 
           while ((Get-Date) -lt $deadline) {
-            $probeOutput = az vm run-command invoke `
+            # Bound each call. A single `az vm run-command invoke` against an unresponsive agent has
+            # been observed to block for ~25 minutes; because the deadline is only checked between
+            # iterations, one such call silently blows the whole budget.
+            $probeOutput = timeout $env:PROBE_CALL_TIMEOUT_SECONDS az vm run-command invoke `
               --resource-group $env:AZURE_RESOURCE_GROUP `
               --name $env:AZURE_VM_NAME `
               --command-id RunPowerShellScript `
               --scripts "@$probePath" `
               --query "value[].message" -o tsv
 
-            if ($LASTEXITCODE -eq 0 -and $probeOutput) {
+            if ($LASTEXITCODE -eq 124) {
+              Write-Host "Probe call exceeded $env:PROBE_CALL_TIMEOUT_SECONDS s and was abandoned. Retrying."
+            }
+            elseif ($LASTEXITCODE -eq 0 -and $probeOutput) {
               $lastState = ($probeOutput | Out-String).Trim()
               if ($lastState -match 'RUNNER_ONLINE') {
                 Write-Host 'Runner is online and attached to an interactive desktop session.'
@@ -113,7 +139,12 @@ jobs:
 
           throw @"
           The Windows UI runner did not come online within $env:RUNNER_ONLINE_TIMEOUT_MINUTES minutes.
+          Last guest agent status: $agentStatus
           Last probe state: $lastState
+
+          A guest agent status other than Ready means the VM never finished booting far enough for
+          Azure to reach it, so no probe could run. Starting the VM has been observed taking ~25
+          minutes during Azure-side slowness; if that is the cause, re-running the job is enough.
 
           NO_INTERACTIVE_SESSION means the VM booted to a login screen and nobody logged on, so the
           WindowsMcp-GitHub-Runner logon-triggered scheduled task never fired. Verify that autologon

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -17,6 +17,16 @@ public sealed partial class UIAutomationService
     private static readonly TimeSpan SaveDialogTimeout = TimeSpan.FromSeconds(2);
 
     /// <summary>
+    /// Timeout for waiting for a dialog to close after the save has been committed. This is a
+    /// different kind of wait from locating a dialog or a control that is already on screen: the
+    /// application still has to write the file and tear the dialog down, which on a contended
+    /// desktop (or for a larger file) routinely takes longer than <see cref="SaveDialogTimeout"/>.
+    /// Reusing the short discovery budget here reported a spurious "save could not be verified"
+    /// failure even though the save had actually succeeded.
+    /// </summary>
+    private static readonly TimeSpan SaveDialogCloseTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
     /// Polling interval for dialog detection retry loop.
     /// </summary>
     private static readonly TimeSpan SaveDialogPollInterval = TimeSpan.FromMilliseconds(100);
@@ -1390,9 +1400,19 @@ public sealed partial class UIAutomationService
     /// <summary>
     /// Waits for a dialog to close (White Framework pattern: WaitWhileBusy).
     /// </summary>
-    private async Task<bool> WaitForDialogCloseAsync(UIA.IUIAutomationElement dialog, CancellationToken cancellationToken)
+    /// <param name="dialog">The dialog element to watch.</param>
+    /// <param name="cancellationToken">Token used to cancel the wait.</param>
+    /// <param name="timeout">
+    /// How long to wait. Defaults to <see cref="SaveDialogCloseTimeout"/>; callers that are merely
+    /// tidying up after an already-failed operation pass the shorter <see cref="SaveDialogTimeout"/>
+    /// so a failure is not made slower than it needs to be.
+    /// </param>
+    private async Task<bool> WaitForDialogCloseAsync(
+        UIA.IUIAutomationElement dialog,
+        CancellationToken cancellationToken,
+        TimeSpan? timeout = null)
     {
-        var deadline = DateTime.UtcNow + SaveDialogTimeout;
+        var deadline = DateTime.UtcNow + (timeout ?? SaveDialogCloseTimeout);
 
         while (DateTime.UtcNow < deadline)
         {
@@ -1527,7 +1547,9 @@ public sealed partial class UIAutomationService
                         cancellationToken);
                 }
 
-                _ = await WaitForDialogCloseAsync(errorInfo.dialog, cancellationToken);
+                // The operation has already failed; only the dialog teardown is being observed here,
+                // so keep the short budget rather than delaying the error returned to the caller.
+                _ = await WaitForDialogCloseAsync(errorInfo.dialog, cancellationToken, SaveDialogTimeout);
 
                 // Press Escape to close the Save As dialog
                 await _keyboardService.PressKeyAsync("Escape", cancellationToken: cancellationToken);

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/EdgeLocalPageTests.cs
@@ -9,6 +9,11 @@ namespace Sbroenne.WindowsMcp.Tests.Integration.ChromiumBrowser;
 public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessionFixture>
 {
     private const int QueryTimeoutMs = 5000;
+
+    // Content that only appears in response to an interaction needs a larger budget than content
+    // that is already on screen: the click has to round-trip through the page and then propagate
+    // into the accessibility tree. EdgePublicPageTests already uses this same 20s budget.
+    private const int PostInteractionTimeoutMs = 20000;
     private const string SearchInputName = "Docs Search";
     private const string SignInButtonName = "Sign in";
     private const string SignedOutStatus = "Signed out";
@@ -132,7 +137,12 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
 
         Assert.True(clickResult.Success, $"Click failed: {clickResult.ErrorMessage}");
 
-        var focusMessage = await FindSingleElementAsync(harness, session.WindowHandleString, FocusedButtonMessage, "Text");
+        var focusMessage = await FindSingleElementAsync(
+            harness,
+            session.WindowHandleString,
+            FocusedButtonMessage,
+            "Text",
+            PostInteractionTimeoutMs);
         var readResult = await harness.AutomationService.GetTextAsync(focusMessage.Id, session.WindowHandleString, includeChildren: false);
 
         Assert.True(readResult.Success, $"Read failed: {readResult.ErrorMessage}");
@@ -196,14 +206,18 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         Assert.DoesNotContain("Complementary rail link", article, StringComparison.Ordinal);
     }
 
-    private static ElementQuery CreateLocalPageQuery(string windowHandle, string name, string controlType)
+    private static ElementQuery CreateLocalPageQuery(
+        string windowHandle,
+        string name,
+        string controlType,
+        int? timeoutMs = null)
     {
         return new ElementQuery
         {
             WindowHandle = windowHandle,
             Name = name,
             ControlType = controlType,
-            TimeoutMs = QueryTimeoutMs,
+            TimeoutMs = timeoutMs ?? QueryTimeoutMs,
         };
     }
 
@@ -211,9 +225,11 @@ public sealed class ChromiumLocalPageTests : IClassFixture<ChromiumReadOnlySessi
         ChromiumAutomationHarness harness,
         string windowHandle,
         string name,
-        string controlType)
+        string controlType,
+        int? timeoutMs = null)
     {
-        var result = await harness.AutomationService.FindElementsAsync(CreateLocalPageQuery(windowHandle, name, controlType));
+        var result = await harness.AutomationService.FindElementsAsync(
+            CreateLocalPageQuery(windowHandle, name, controlType, timeoutMs));
 
         Assert.True(result.Success, $"Find failed: {result.ErrorMessage}");
         Assert.NotNull(result.Items);

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronSaveTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronSaveTests.cs
@@ -93,15 +93,28 @@ public sealed class ElectronSaveTests : IDisposable
         // Assert
         Assert.True(result.Success, $"SaveAsync failed: {result.ErrorMessage}");
 
-        // Wait for file system to settle
-        await Task.Delay(500);
+        // Wait for the harness to finish writing the file. Waiting on the content rather than on
+        // File.Exists also rules out observing a file that exists but has not been flushed yet.
+        var content = string.Empty;
+        var saved = await TestWait.UntilAsync(
+            () =>
+            {
+                try
+                {
+                    content = File.ReadAllText(testFilePath);
+                }
+                catch (IOException)
+                {
+                    return false;
+                }
 
-        // Verify the file was created
-        Assert.True(File.Exists(testFilePath),
-            $"Expected file to exist at: {testFilePath}. Duration={result.Diagnostics?.DurationMs}ms");
+                return content.Contains("Test file created at", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(10));
 
-        // Verify the file has content (the Electron harness writes a timestamp)
-        var content = File.ReadAllText(testFilePath);
+        Assert.True(
+            saved,
+            $"Expected file to exist with harness content at: {testFilePath}. Duration={result.Diagnostics?.DurationMs}ms");
         Assert.NotEmpty(content);
         Assert.Contains("Test file created at", content);
     }
@@ -146,8 +159,10 @@ public sealed class ElectronSaveTests : IDisposable
         // Assert
         Assert.True(result.Success, $"Save failed: {result.ErrorMessage}");
 
-        await Task.Delay(300);
-        Assert.True(File.Exists(testFilePath), $"File was not created at: {testFilePath}");
+        var created = await TestWait.UntilAsync(
+            () => File.Exists(testFilePath),
+            TimeSpan.FromSeconds(10));
+        Assert.True(created, $"File was not created at: {testFilePath}");
     }
 
     [Fact]

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
@@ -76,14 +76,17 @@ public sealed class OpenFileTests : IDisposable
             Assert.True(result.Success, $"Open handling failed: {result.ErrorMessage}");
 
             // Wait for the harness to record the opened path instead of assuming it has done so.
+            string? lastOpened = null;
             await TestWait.UntilAsync(
-                () => string.Equals(
-                    testFilePath,
-                    _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form!.LastOpenPath)),
-                    StringComparison.OrdinalIgnoreCase),
+                () =>
+                {
+                    lastOpened = _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form!.LastOpenPath));
+                    return string.Equals(testFilePath, lastOpened, StringComparison.OrdinalIgnoreCase);
+                },
                 TimeSpan.FromSeconds(10));
 
-            var lastOpened = _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form!.LastOpenPath));
+            // Assert on the observed value rather than on the wait result: if the wait times out this
+            // reports the expected and actual paths, which is more actionable than "the wait expired".
             Assert.Equal(testFilePath, lastOpened, ignoreCase: true);
         });
     }

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
@@ -75,7 +75,13 @@ public sealed class OpenFileTests : IDisposable
 
             Assert.True(result.Success, $"Open handling failed: {result.ErrorMessage}");
 
-            await Task.Delay(300);
+            // Wait for the harness to record the opened path instead of assuming it has done so.
+            await TestWait.UntilAsync(
+                () => string.Equals(
+                    testFilePath,
+                    _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form!.LastOpenPath)),
+                    StringComparison.OrdinalIgnoreCase),
+                TimeSpan.FromSeconds(10));
 
             var lastOpened = _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form!.LastOpenPath));
             Assert.Equal(testFilePath, lastOpened, ignoreCase: true);

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/SaveTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/SaveTests.cs
@@ -93,14 +93,26 @@ public sealed class SaveTests : IDisposable
         // Assert
         Assert.True(result.Success, $"Save handling failed: {result.ErrorMessage}");
 
-        // Wait for file system to settle
-        await Task.Delay(500);
+        // Wait for the harness to finish writing the file. Waiting on the content rather than on
+        // File.Exists also rules out observing a file that exists but has not been flushed yet.
+        var content = string.Empty;
+        var saved = await TestWait.UntilAsync(
+            () =>
+            {
+                try
+                {
+                    content = File.ReadAllText(testFilePath);
+                }
+                catch (IOException)
+                {
+                    return false;
+                }
 
-        // Verify the file was created
-        Assert.True(File.Exists(testFilePath), $"Expected file to exist at: {testFilePath}");
+                return content.Contains("Test file created at", StringComparison.Ordinal);
+            },
+            TimeSpan.FromSeconds(10));
 
-        // Verify the file has content (the test harness writes a timestamp)
-        var content = File.ReadAllText(testFilePath);
+        Assert.True(saved, $"Expected file to exist with harness content at: {testFilePath}");
         Assert.NotEmpty(content);
         Assert.Contains("Test file created at", content);
     }
@@ -145,8 +157,10 @@ public sealed class SaveTests : IDisposable
         // Assert
         Assert.True(result.Success, $"Save failed: {result.ErrorMessage}");
 
-        await Task.Delay(300);
-        Assert.True(File.Exists(testFilePath), $"File was not created at: {testFilePath}");
+        var created = await TestWait.UntilAsync(
+            () => File.Exists(testFilePath),
+            TimeSpan.FromSeconds(10));
+        Assert.True(created, $"File was not created at: {testFilePath}");
     }
 
     [Fact]

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUISaveTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUISaveTests.cs
@@ -95,14 +95,26 @@ public sealed class WinUISaveTests : IDisposable
             // Assert
             Assert.True(result.Success, $"Save handling failed: {result.ErrorMessage}");
 
-            // Wait for file system to settle
-            await Task.Delay(500);
+            // Wait for the harness to finish writing the file. Waiting on the content rather than
+            // on File.Exists also rules out observing a file that has not been flushed yet.
+            var content = string.Empty;
+            var saved = await TestWait.UntilAsync(
+                () =>
+                {
+                    try
+                    {
+                        content = File.ReadAllText(testFilePath);
+                    }
+                    catch (IOException)
+                    {
+                        return false;
+                    }
 
-            // Verify the file was created
-            Assert.True(File.Exists(testFilePath), $"Expected file to exist at: {testFilePath}");
+                    return content.Contains("Test file created at", StringComparison.Ordinal);
+                },
+                TimeSpan.FromSeconds(10));
 
-            // Verify the file has content (the test harness writes a timestamp)
-            var content = File.ReadAllText(testFilePath);
+            Assert.True(saved, $"Expected file to exist with harness content at: {testFilePath}");
             Assert.NotEmpty(content);
             Assert.Contains("Test file created at", content);
         });
@@ -149,8 +161,10 @@ public sealed class WinUISaveTests : IDisposable
             // Assert
             Assert.True(result.Success, $"Save failed: {result.ErrorMessage}");
 
-            await Task.Delay(300);
-            Assert.True(File.Exists(testFilePath), $"File was not created at: {testFilePath}");
+            var created = await TestWait.UntilAsync(
+                () => File.Exists(testFilePath),
+                TimeSpan.FromSeconds(10));
+            Assert.True(created, $"File was not created at: {testFilePath}");
         });
     }
 


### PR DESCRIPTION
Fixes #193.

## Problem

Two of the three full integration runs on the previous branch flaked, on **different** tests that shared one shape: act, then check with a fixed short wait.

| Test | Shape |
|---|---|
| `Click_LocalChromiumPage_SignInButton_RevealsFocusedContent` | click → find with the 5s already-rendered-content budget |
| `ElectronSaveTests.Save_WithFilePath_...` | save → `Task.Delay(300)` → `File.Exists` |

This matters more now that the integration gate actually runs on every PR: a ~2-in-3 spurious failure rate blocks PRs and trains people to ignore red.

A corroborating detail: `SaveTests`, `WinUISaveTests` and `ElectronSaveTests` are near-identical clones (same delays, same line numbers). `WinUISaveTests` and `OpenFileTests` are wrapped in `TestRetry.RunAsync`; `SaveTests` and `ElectronSaveTests` are not. `ElectronSaveTests` is exactly the variant that flaked in CI.

## Change 1: test assertion gates

This is a **conformance fix, not a new pattern**. The repo already has `TestWait`, whose doc comment states the convention:

> Bounded polling helpers for integration tests. Tests wait for observable state rather than sleeping for an assumed amount of time.

These tests simply didn't follow it.

- Save/open assertion gates now poll for the observable result instead of sleeping.
- The save tests wait on file **content**, not `File.Exists`. That closes a second latent race the old code had even with a longer sleep: the file can exist before it is flushed, so `File.Exists` + immediate `ReadAllText` could observe a partial write.
- Post-interaction Chromium lookups get their own `PostInteractionTimeoutMs = 20000`, matching the budget `EdgePublicPageTests` already uses. Content that appears *because of* a click needs to round-trip through the page and propagate into the a11y tree; reusing the already-rendered-content budget conflated two different things.

## Change 2: a production bug the first change uncovered

After the test fixes, CI still failed `ElectronSaveTests.Save_Electron_SavesFile` — but **upstream of the wait I'd touched**, at the `result.Success` assertion, with *"Save could not be verified because the Save dialog remained open."* So this was never a test-code problem.

`WaitForDialogCloseAsync` reused `SaveDialogTimeout` (2s), the budget intended for *locating* a dialog or control that is already on screen. Closing is a different kind of wait: the application still has to write the file and tear the dialog down. On a loaded machine that overruns 2s, and `SaveAsync` then reports failure for a save that actually succeeded.

Split out `SaveDialogCloseTimeout` (10s) used only by that wait, leaving element discovery on the short budget. This mirrors `OpenDialogEditFieldTimeout`, which the codebase had already carved out of `SaveDialogTimeout` for the same reason. The error-dialog teardown path explicitly keeps the short budget, so a genuine failure is not made slower.

Worth calling out as **scope beyond "fix the test flakes"**: it's a real robustness bug. An MCP client saving a large file, or driving a slow app, would get a spurious "save could not be verified" error for a successful save. The same reasoning applies to the "Open dialog remained open" path, which shares the helper and so also picks up the longer budget.

## Change 3: CI runner probe

The `Start Windows UI runner` step ran 51m48s against a 10-minute budget: the deadline was only checked *between* iterations, so one `az vm run-command invoke` that blocked for ~25 minutes blew through it. Each probe call is now individually bounded, and gated on guest-agent readiness via `az vm get-instance-view` (a control-plane read, which cannot hang on the guest). Subsequent run: 1m17s.

## Deliberately not changed

- **Input-pacing delays** (double-click intervals, key repeat, cursor settle) — ~245 `Task.Delay` calls exist in the suite, but most are genuinely time-based semantics, not assertion gates. Blanket-replacing them would risk breaking working tests.
- **`Task.Delay` after `BringToFront()`** — redundant, since `BringToFront()` already blocks on `GetForegroundWindow() == handle` via `TestWait.RetryUntil`. Removing delays could *introduce* flakes, which is the opposite of the goal here, so they're left for a separate change.

## Validation

- Build clean; unit tests 494/494 (unchanged from baseline).
- Full integration suite green in CI: 809 passed / 0 failed / 8 skipped.

## Note on local validation

I could not use local runs to validate this cluster, and confirmed why rather than assuming. Baseline (changes stashed) failed `OpenFileTests` *in isolation*, and the same combined selection variously produced 2 failures, 0 failures, and 2 failures across three consecutive runs **with** the change. `SaveTests` passes alone but fails in combination, so there is additional pre-existing shared-fixture contamination in the `UITestHarness` collection locally, present with and without this change.

That contamination is real but out of scope here; worth a follow-up issue. CI is the authoritative signal for this suite.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>