### PR TITLE
spike(#189): measure event-assisted UIA waiting - recommend reject

### DIFF
--- a/src/Sbroenne.WindowsMcp/Automation/StructureChangeSignal.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/StructureChangeSignal.cs
@@ -1,0 +1,170 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using UIA = Interop.UIAutomationClient;
+
+namespace Sbroenne.WindowsMcp.Automation;
+
+/// <summary>
+/// Subscribes to UIA <c>StructureChangedEvent</c> for a subtree and exposes the changes as a
+/// signal that a waiter can block on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This deliberately makes waiting event-<em>assisted</em> rather than event-<em>driven</em>.
+/// The polling loop remains the correctness guarantee, and the signal is only used to cut a
+/// sleep short. That ordering matters, because UIA providers are not required to raise
+/// structure-changed events reliably: a purely event-driven wait would hang on providers that
+/// stay silent. With this design the worst case is exactly the previous polling behaviour, and
+/// the best case is that the waiter re-checks as soon as the tree actually changes instead of
+/// after the remainder of its backoff.
+/// </para>
+/// <para>
+/// The signal is a binary semaphore, so a burst of events coalesces into a single wake-up. That
+/// is the debounce: a churning Chromium tree cannot queue unbounded re-checks, because at most
+/// one wake-up can ever be pending.
+/// </para>
+/// <para>
+/// UIA delivers event callbacks on its own threads. Registration and unregistration are both
+/// marshalled to the automation STA thread, and unregistration is mandatory - a handler that is
+/// never removed leaks a COM callback into the target process.
+/// </para>
+/// </remarks>
+[SupportedOSPlatform("windows")]
+internal sealed class StructureChangeSignal : UIA.IUIAutomationStructureChangedEventHandler, IAsyncDisposable
+{
+    private readonly UIAutomationThread _staThread;
+    private readonly UIA.IUIAutomationElement _root;
+    private readonly SemaphoreSlim _changed = new(0, 1);
+    private int _eventCount;
+    private bool _disposed;
+
+    private StructureChangeSignal(UIAutomationThread staThread, UIA.IUIAutomationElement root)
+    {
+        _staThread = staThread;
+        _root = root;
+    }
+
+    /// <summary>
+    /// Gets the number of structure-changed events observed. Used to quantify event volume.
+    /// </summary>
+    public int EventCount => Volatile.Read(ref _eventCount);
+
+    /// <summary>
+    /// Subscribes to structure changes under <paramref name="root"/>, or returns <see langword="null"/>
+    /// if the provider refuses the subscription. A null result is not an error: the caller simply
+    /// falls back to unassisted polling.
+    /// </summary>
+    public static async Task<StructureChangeSignal?> CreateAsync(
+        UIAutomationThread staThread,
+        UIA.IUIAutomationElement root,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(staThread);
+        ArgumentNullException.ThrowIfNull(root);
+
+        var signal = new StructureChangeSignal(staThread, root);
+
+        var subscribed = await staThread.ExecuteAsync(
+            () =>
+            {
+                try
+                {
+                    UIA3Automation.Instance.Automation.AddStructureChangedEventHandler(
+                        root,
+                        UIA.TreeScope.TreeScope_Subtree,
+                        null,
+                        signal);
+                    return true;
+                }
+                catch (COMException)
+                {
+                    // Provider does not support the subscription; polling still covers us.
+                    return false;
+                }
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        return subscribed ? signal : null;
+    }
+
+    /// <summary>
+    /// Waits for the next structure change, giving up after <paramref name="timeout"/>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if a change was observed, <see langword="false"/> if the timeout
+    /// expired. Callers re-check their condition either way, so the distinction only affects how
+    /// long they waited.
+    /// </returns>
+    public async Task<bool> WaitForChangeAsync(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _changed.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Called by UIA on one of its own threads. Must stay cheap: any real work here blocks the
+    /// provider, and doing UIA calls back into the tree from a handler risks re-entrancy.
+    /// </summary>
+    public void HandleStructureChangedEvent(UIA.IUIAutomationElement sender, UIA.StructureChangeType changeType, int[] runtimeId)
+    {
+        _ = Interlocked.Increment(ref _eventCount);
+
+        try
+        {
+            _ = _changed.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // A wake-up is already pending; this event coalesces into it.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Raced with disposal; the waiter is gone.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        try
+        {
+            _ = await _staThread.ExecuteAsync(
+                () =>
+                {
+                    try
+                    {
+                        UIA3Automation.Instance.Automation.RemoveStructureChangedEventHandler(_root, this);
+                    }
+                    catch (COMException)
+                    {
+                        // The provider or its process is already gone, which unregisters us anyway.
+                    }
+
+                    return true;
+                },
+                CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // The STA thread was torn down first; the handler dies with it.
+        }
+        catch (InvalidOperationException)
+        {
+            // The STA thread stopped accepting work during shutdown.
+        }
+
+        _changed.Dispose();
+    }
+}

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -119,6 +119,72 @@ public sealed partial class UIAutomationService
         }
     }
 
+    /// <summary>
+    /// Controls whether waits are assisted by UIA structure-changed events. Polling remains the
+    /// correctness guarantee either way; this only decides whether a sleep can be cut short.
+    /// Exposed so the spike benchmark can measure both paths in a single process.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see langword="false"/>: the issue #189 spike measured only a ~5% median
+    /// latency gain, inside run-to-run noise. Even when an event woke the waiter immediately,
+    /// latency stayed near 460ms, so the cost of the UIA query itself dominates — not the sleep
+    /// this mechanism shortens. Kept, disabled, so the benchmark stays reproducible.
+    /// </remarks>
+    internal static bool EventAssistedWaitEnabled { get; set; } = false;
+
+    /// <summary>
+    /// Counts structure-changed events observed by the most recent event-assisted wait. Diagnostic
+    /// only, for the spike benchmark.
+    /// </summary>
+    internal static int LastWaitEventCount { get; private set; }
+
+    /// <summary>
+    /// Subscribes to structure changes for the query's window, when event assistance is enabled and
+    /// the provider allows it. Returns <see langword="null"/> to mean "poll unassisted".
+    /// </summary>
+    private async Task<StructureChangeSignal?> TrySubscribeToStructureChangesAsync(
+        ElementQuery query,
+        CancellationToken cancellationToken)
+    {
+        if (!EventAssistedWaitEnabled)
+        {
+            return null;
+        }
+
+        try
+        {
+            var root = await _staThread.ExecuteAsync(
+                () => GetRootElement(query.WindowHandle),
+                cancellationToken).ConfigureAwait(false);
+
+            return root is null
+                ? null
+                : await StructureChangeSignal.CreateAsync(_staThread, root, cancellationToken).ConfigureAwait(false);
+        }
+        catch (COMException)
+        {
+            // Subscription is an optimisation; never fail a wait because it could not be set up.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Sleeps for <paramref name="delay"/>, returning early if the tree changed underneath us.
+    /// </summary>
+    private static async Task DelayOrUntilStructureChangedAsync(
+        StructureChangeSignal? signal,
+        int delay,
+        CancellationToken cancellationToken)
+    {
+        if (signal is null)
+        {
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        _ = await signal.WaitForChangeAsync(TimeSpan.FromMilliseconds(delay), cancellationToken).ConfigureAwait(false);
+    }
+
     /// <inheritdoc/>
     public async Task<UIAutomationResult> WaitForElementAsync(ElementQuery query, int timeoutMs, CancellationToken cancellationToken = default)
     {
@@ -128,32 +194,47 @@ public sealed partial class UIAutomationService
         var delay = 50;
         const int MaxDelay = 500;
 
-        while (stopwatch.ElapsedMilliseconds < timeoutMs)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        // Subscribe before the first probe, so a change that lands between probing and sleeping
+        // still wakes us instead of being lost.
+        var signal = await TrySubscribeToStructureChangesAsync(query, cancellationToken).ConfigureAwait(false);
 
-            var result = await FindElementsAsync(query with { TimeoutMs = 0 }, cancellationToken);
-            if (result.Success)
+        try
+        {
+            while (stopwatch.ElapsedMilliseconds < timeoutMs)
             {
-                return result with { Action = "wait_for" };
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var result = await FindElementsAsync(query with { TimeoutMs = 0 }, cancellationToken);
+                if (result.Success)
+                {
+                    return result with { Action = "wait_for" };
+                }
+
+                await DelayOrUntilStructureChangedAsync(signal, delay, cancellationToken).ConfigureAwait(false);
+                delay = Math.Min(delay * 2, MaxDelay);
             }
 
-            await Task.Delay(delay, cancellationToken);
-            delay = Math.Min(delay * 2, MaxDelay);
+            stopwatch.Stop();
+
+            return UIAutomationResult.CreateFailure(
+                "wait_for",
+                UIAutomationErrorType.Timeout,
+                $"Element not found within {timeoutMs}ms timeout.",
+                new UIAutomationDiagnostics
+                {
+                    DurationMs = stopwatch.ElapsedMilliseconds,
+                    Query = query,
+                    ElapsedBeforeTimeout = stopwatch.ElapsedMilliseconds
+                });
         }
-
-        stopwatch.Stop();
-
-        return UIAutomationResult.CreateFailure(
-            "wait_for",
-            UIAutomationErrorType.Timeout,
-            $"Element not found within {timeoutMs}ms timeout.",
-            new UIAutomationDiagnostics
+        finally
+        {
+            if (signal is not null)
             {
-                DurationMs = stopwatch.ElapsedMilliseconds,
-                Query = query,
-                ElapsedBeforeTimeout = stopwatch.ElapsedMilliseconds
-            });
+                LastWaitEventCount = signal.EventCount;
+                await signal.DisposeAsync().ConfigureAwait(false);
+            }
+        }
     }
 
     /// <inheritdoc/>
@@ -165,40 +246,53 @@ public sealed partial class UIAutomationService
         var delay = 50;
         const int MaxDelay = 500;
 
-        while (stopwatch.ElapsedMilliseconds < timeoutMs)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
+        var signal = await TrySubscribeToStructureChangesAsync(query, cancellationToken).ConfigureAwait(false);
 
-            var result = await FindElementsAsync(query with { TimeoutMs = 0 }, cancellationToken);
-            if (!result.Success || (result.Items?.Length ?? 0) == 0)
+        try
+        {
+            while (stopwatch.ElapsedMilliseconds < timeoutMs)
             {
-                // Element no longer found - success!
-                stopwatch.Stop();
-                return UIAutomationResult.CreateSuccess(
-                    "wait_for_disappear",
-                    new UIAutomationDiagnostics
-                    {
-                        DurationMs = stopwatch.ElapsedMilliseconds,
-                        Query = query
-                    });
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var result = await FindElementsAsync(query with { TimeoutMs = 0 }, cancellationToken);
+                if (!result.Success || (result.Items?.Length ?? 0) == 0)
+                {
+                    // Element no longer found - success!
+                    stopwatch.Stop();
+                    return UIAutomationResult.CreateSuccess(
+                        "wait_for_disappear",
+                        new UIAutomationDiagnostics
+                        {
+                            DurationMs = stopwatch.ElapsedMilliseconds,
+                            Query = query
+                        });
+                }
+
+                await DelayOrUntilStructureChangedAsync(signal, delay, cancellationToken).ConfigureAwait(false);
+                delay = Math.Min(delay * 2, MaxDelay);
             }
 
-            await Task.Delay(delay, cancellationToken);
-            delay = Math.Min(delay * 2, MaxDelay);
+            stopwatch.Stop();
+
+            return UIAutomationResult.CreateFailure(
+                "wait_for_disappear",
+                UIAutomationErrorType.Timeout,
+                $"Element still present after {timeoutMs}ms timeout. Expected it to disappear.",
+                new UIAutomationDiagnostics
+                {
+                    DurationMs = stopwatch.ElapsedMilliseconds,
+                    Query = query,
+                    ElapsedBeforeTimeout = stopwatch.ElapsedMilliseconds
+                });
         }
-
-        stopwatch.Stop();
-
-        return UIAutomationResult.CreateFailure(
-            "wait_for_disappear",
-            UIAutomationErrorType.Timeout,
-            $"Element still present after {timeoutMs}ms timeout. Expected it to disappear.",
-            new UIAutomationDiagnostics
+        finally
+        {
+            if (signal is not null)
             {
-                DurationMs = stopwatch.ElapsedMilliseconds,
-                Query = query,
-                ElapsedBeforeTimeout = stopwatch.ElapsedMilliseconds
-            });
+                LastWaitEventCount = signal.EventCount;
+                await signal.DisposeAsync().ConfigureAwait(false);
+            }
+        }
     }
 
     /// <inheritdoc/>

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronEventWaitBenchmarkTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronEventWaitBenchmarkTests.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Capture;
+using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
+using Sbroenne.WindowsMcp.Tests.Integration.EventWaitSpike;
+using Sbroenne.WindowsMcp.Window;
+using Xunit.Abstractions;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.ElectronHarness;
+
+/// <summary>
+/// Spike measurements for issue #189 against the Electron harness.
+/// </summary>
+/// <remarks>
+/// Electron is the documented worst case for this idea: a Chromium accessibility tree churns, so
+/// a subtree structure-changed subscription could deliver more events than polling costs. This
+/// measures the timeout path, where a wait sits subscribed for its whole budget and finds nothing,
+/// which is where an event storm would show up as wasted re-checks and CPU.
+/// </remarks>
+[Collection("ElectronHarness")]
+[Trait("Category", "RequiresDesktop")]
+public sealed class ElectronEventWaitBenchmarkTests : IDisposable
+{
+    private const int TimeoutMs = 3000;
+
+    private readonly UIAutomationService _automationService;
+    private readonly UIAutomationThread _staThread;
+    private readonly string _windowHandle;
+    private readonly ITestOutputHelper _output;
+
+    public ElectronEventWaitBenchmarkTests(ElectronHarnessFixture fixture, ITestOutputHelper output)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        _output = output;
+        fixture.Reset();
+
+        _windowHandle = fixture.WindowHandleString;
+        _staThread = new UIAutomationThread();
+
+        _automationService = new UIAutomationService(
+            _staThread,
+            new MonitorService(),
+            new MouseInputService(),
+            new KeyboardInputService(),
+            new WindowActivator(),
+            new ElevationDetector(),
+            NullLogger<UIAutomationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        UIAutomationService.EventAssistedWaitEnabled = false;
+        _staThread.Dispose();
+        _automationService.Dispose();
+    }
+
+    [Fact]
+    public async Task EventAssistedWait_DoesNotRegressTimeoutPath_OnChromiumTree()
+    {
+        var query = new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            Name = "NoSuchElementForSpike189",
+            ControlType = "Button"
+        };
+
+        var polling = await EventWaitBenchmark.MeasureTimeoutCostAsync(
+            (elementQuery, timeoutMs) => _automationService.WaitForElementAsync(elementQuery, timeoutMs),
+            query,
+            eventAssisted: false,
+            TimeoutMs);
+
+        var assisted = await EventWaitBenchmark.MeasureTimeoutCostAsync(
+            (elementQuery, timeoutMs) => _automationService.WaitForElementAsync(elementQuery, timeoutMs),
+            query,
+            eventAssisted: true,
+            TimeoutMs);
+
+        var report = EventWaitBenchmark.FormatTimeoutReport("electron", polling, assisted, TimeoutMs);
+        _output.WriteLine(report);
+        EventWaitBenchmark.WriteReport("electron", report);
+
+        Assert.False(polling.Found, $"The spike query must not match anything.\n{report}");
+        Assert.False(assisted.Found, $"The spike query must not match anything.\n{report}");
+
+        // A wait must still honour its timeout. If an event storm were driving re-checks faster
+        // than the tree can answer them, the wall clock would overrun the requested budget.
+        Assert.True(
+            assisted.ElapsedMs < TimeoutMs * 2,
+            $"Event-assisted wait overran its timeout budget on a Chromium tree.\n{report}");
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/EventWaitBenchmark.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/EventWaitBenchmark.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Models;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.EventWaitSpike;
+
+/// <summary>
+/// Measurement helpers for the event-driven waiting spike (issue #189).
+/// </summary>
+/// <remarks>
+/// The spike's exit criterion is a measurement-backed recommendation, so these helpers exist to
+/// produce numbers rather than to assert behaviour. Results are written both to xUnit output and
+/// to a report file, because xUnit output for a passing test is not surfaced by the default CI
+/// logger and the whole point of the exercise is the numbers from a passing run.
+/// </remarks>
+internal static class EventWaitBenchmark
+{
+    /// <summary>
+    /// How long into the wait the target element is made to appear. Chosen to land in the
+    /// saturated part of the polling backoff (50, 100, 200, 400, then 500ms steps), where the
+    /// penalty for polling is largest and most consistent. Appearing early would flatter polling
+    /// by hiding it inside a short sleep.
+    /// </summary>
+    public const int AppearAfterMs = 2000;
+
+    public static string ReportDirectory =>
+        Path.Combine(Path.GetTempPath(), "mcp-windows-spike-189");
+
+    /// <summary>
+    /// Measures how long a wait takes to notice a condition that has already become true.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="trigger"/> must not return until the change is committed, so the recorded
+    /// timestamp is a lower bound on when the element became observable. Overstating that instant
+    /// would understate the measured latency for both modes equally, but understating it would not.
+    /// </remarks>
+    public static async Task<WaitLatencySample> MeasureLatencyAsync(
+        Func<ElementQuery, int, Task<UIAutomationResult>> wait,
+        ElementQuery query,
+        Func<Task> trigger,
+        bool eventAssisted,
+        int timeoutMs)
+    {
+        UIAutomationService.EventAssistedWaitEnabled = eventAssisted;
+
+        var clock = Stopwatch.StartNew();
+        long triggeredTicks = 0;
+
+        var waitTask = wait(query, timeoutMs);
+
+        var triggerTask = Task.Run(async () =>
+        {
+            await Task.Delay(AppearAfterMs);
+            await trigger();
+            Volatile.Write(ref triggeredTicks, clock.ElapsedTicks);
+        });
+
+        var result = await waitTask;
+        var observedTicks = clock.ElapsedTicks;
+
+        await triggerTask;
+
+        var triggered = Volatile.Read(ref triggeredTicks);
+        var latencyMs = (observedTicks - triggered) * 1000.0 / Stopwatch.Frequency;
+
+        return new WaitLatencySample(
+            result.Success,
+            latencyMs,
+            UIAutomationService.LastWaitEventCount);
+    }
+
+    /// <summary>
+    /// Measures the cost of a wait that never succeeds. This is the event-storm probe: on a
+    /// churning tree, an event subscription could make the timeout path more expensive than plain
+    /// polling, which is the main documented risk of the whole idea.
+    /// </summary>
+    public static async Task<WaitTimeoutSample> MeasureTimeoutCostAsync(
+        Func<ElementQuery, int, Task<UIAutomationResult>> wait,
+        ElementQuery query,
+        bool eventAssisted,
+        int timeoutMs)
+    {
+        UIAutomationService.EventAssistedWaitEnabled = eventAssisted;
+
+        var process = Process.GetCurrentProcess();
+        var cpuBefore = process.TotalProcessorTime;
+        var clock = Stopwatch.StartNew();
+
+        var result = await wait(query, timeoutMs);
+
+        clock.Stop();
+        process.Refresh();
+        var cpuMs = (process.TotalProcessorTime - cpuBefore).TotalMilliseconds;
+
+        return new WaitTimeoutSample(
+            result.Success,
+            clock.Elapsed.TotalMilliseconds,
+            cpuMs,
+            UIAutomationService.LastWaitEventCount);
+    }
+
+    public static double Median(IEnumerable<double> values)
+    {
+        var ordered = values.OrderBy(static value => value).ToArray();
+        if (ordered.Length == 0)
+        {
+            return double.NaN;
+        }
+
+        var middle = ordered.Length / 2;
+        return ordered.Length % 2 == 1
+            ? ordered[middle]
+            : (ordered[middle - 1] + ordered[middle]) / 2.0;
+    }
+
+    /// <summary>
+    /// Writes a report file so the numbers survive a passing test run in CI.
+    /// </summary>
+    public static void WriteReport(string harness, string report)
+    {
+        try
+        {
+            _ = Directory.CreateDirectory(ReportDirectory);
+            var path = Path.Combine(ReportDirectory, $"{harness}.txt");
+            File.WriteAllText(path, report, Encoding.UTF8);
+        }
+        catch (IOException)
+        {
+            // The report is a convenience; never fail a measurement because it could not be saved.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    public static string FormatLatencyReport(
+        string harness,
+        IReadOnlyList<WaitLatencySample> polling,
+        IReadOnlyList<WaitLatencySample> assisted)
+    {
+        var pollingMedian = Median(polling.Select(static sample => sample.LatencyMs));
+        var assistedMedian = Median(assisted.Select(static sample => sample.LatencyMs));
+        var improvement = pollingMedian > 0
+            ? (1.0 - (assistedMedian / pollingMedian)) * 100.0
+            : double.NaN;
+
+        var pollingRaw = string.Join(", ", polling.Select(static s => s.LatencyMs.ToString("F1", CultureInfo.InvariantCulture)));
+        var assistedRaw = string.Join(", ", assisted.Select(static s => s.LatencyMs.ToString("F1", CultureInfo.InvariantCulture)));
+        var eventCounts = string.Join(", ", assisted.Select(static s => s.EventCount.ToString(CultureInfo.InvariantCulture)));
+
+        var builder = new StringBuilder();
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"=== #189 event-assisted wait: {harness} ===");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"samples per mode        : {polling.Count}");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"element appears after   : {AppearAfterMs}ms");
+        _ = builder.AppendLine();
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"polling  median latency : {pollingMedian:F1}ms  raw: [{pollingRaw}]");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"assisted median latency : {assistedMedian:F1}ms  raw: [{assistedRaw}]");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"improvement             : {improvement:F1}%");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"events per assisted wait: [{eventCounts}]");
+        return builder.ToString();
+    }
+
+    public static string FormatTimeoutReport(
+        string harness,
+        WaitTimeoutSample polling,
+        WaitTimeoutSample assisted,
+        int timeoutMs)
+    {
+        var builder = new StringBuilder();
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"=== #189 event-assisted wait, timeout path: {harness} ===");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"requested timeout       : {timeoutMs}ms");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"polling  elapsed/cpu    : {polling.ElapsedMs:F0}ms / {polling.CpuMs:F0}ms cpu");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"assisted elapsed/cpu    : {assisted.ElapsedMs:F0}ms / {assisted.CpuMs:F0}ms cpu");
+        _ = builder.AppendLine(CultureInfo.InvariantCulture, $"events during assisted  : {assisted.EventCount}");
+        return builder.ToString();
+    }
+}
+
+internal readonly record struct WaitLatencySample(bool Found, double LatencyMs, int EventCount);
+
+internal readonly record struct WaitTimeoutSample(bool Found, double ElapsedMs, double CpuMs, int EventCount);

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinFormsEventWaitBenchmarkTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinFormsEventWaitBenchmarkTests.cs
@@ -64,7 +64,7 @@ public sealed class WinFormsEventWaitBenchmarkTests : IDisposable
     }
 
     [Fact]
-    public async Task EventAssistedWait_ReactsFasterThanPolling_WhenElementAppearsMidWait()
+    public async Task EventAssistedWait_DoesNotRegressLatency_WhenElementAppearsMidWait()
     {
         var polling = new List<WaitLatencySample>(Samples);
         var assisted = new List<WaitLatencySample>(Samples);
@@ -89,8 +89,15 @@ public sealed class WinFormsEventWaitBenchmarkTests : IDisposable
         // "must be faster" threshold would be a timing assertion on a shared CI desktop, which is
         // exactly the kind of flake this whole line of work exists to remove. The magnitude of any
         // improvement is reported, not asserted.
+        //
+        // The tolerance is deliberately wider than the effect being measured. Individual waits were
+        // observed spanning 262-1046ms, so a median-of-5 can drift well past 50ms on a loaded
+        // runner. This guards against a gross regression (the mechanism deadlocking or serialising
+        // waits) without asserting on noise, which would just trade one flake for another.
+        const double RegressionToleranceMs = 150;
+
         Assert.True(
-            assistedMedian <= pollingMedian + 50,
+            assistedMedian <= pollingMedian + RegressionToleranceMs,
             $"Event assistance regressed wait latency.\n{report}");
     }
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinFormsEventWaitBenchmarkTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinFormsEventWaitBenchmarkTests.cs
@@ -1,0 +1,149 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Capture;
+using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
+using Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
+using Sbroenne.WindowsMcp.Window;
+using Xunit.Abstractions;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.EventWaitSpike;
+
+/// <summary>
+/// Spike measurements for issue #189 against the WinForms harness.
+/// </summary>
+/// <remarks>
+/// This is the decisive measurement of the spike. The WinForms harness runs in-process, so a
+/// control can be created at a precisely known instant and the wait's reaction time measured
+/// against it. The out-of-process harnesses can only be probed indirectly, so they are used to
+/// check for regressions rather than to prove the benefit.
+/// </remarks>
+[Collection("UITestHarness")]
+[Trait("Category", "RequiresDesktop")]
+public sealed class WinFormsEventWaitBenchmarkTests : IDisposable
+{
+    private const int Samples = 5;
+    private const int TimeoutMs = 10000;
+
+    private readonly UITestHarnessFixture _fixture;
+    private readonly UIAutomationService _automationService;
+    private readonly UIAutomationThread _staThread;
+    private readonly string _windowHandle;
+    private readonly ITestOutputHelper _output;
+
+    public WinFormsEventWaitBenchmarkTests(UITestHarnessFixture fixture, ITestOutputHelper output)
+    {
+        _fixture = fixture;
+        _output = output;
+        _fixture.Reset();
+        _fixture.BringToFront();
+
+        _windowHandle = _fixture.TestWindowHandleString;
+        _staThread = new UIAutomationThread();
+
+        var elevationDetector = new ElevationDetector();
+        var monitorService = new MonitorService();
+        var windowActivator = new WindowActivator();
+
+        _automationService = new UIAutomationService(
+            _staThread,
+            monitorService,
+            new MouseInputService(),
+            new KeyboardInputService(),
+            windowActivator,
+            elevationDetector,
+            NullLogger<UIAutomationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        // Leave the shared service in its shipping configuration for every other test.
+        UIAutomationService.EventAssistedWaitEnabled = false;
+        _staThread.Dispose();
+        _automationService.Dispose();
+    }
+
+    [Fact]
+    public async Task EventAssistedWait_ReactsFasterThanPolling_WhenElementAppearsMidWait()
+    {
+        var polling = new List<WaitLatencySample>(Samples);
+        var assisted = new List<WaitLatencySample>(Samples);
+
+        for (var index = 0; index < Samples; index++)
+        {
+            polling.Add(await MeasureOneAsync(eventAssisted: false));
+            assisted.Add(await MeasureOneAsync(eventAssisted: true));
+        }
+
+        var report = EventWaitBenchmark.FormatLatencyReport("winforms", polling, assisted);
+        _output.WriteLine(report);
+        EventWaitBenchmark.WriteReport("winforms", report);
+
+        Assert.All(polling, sample => Assert.True(sample.Found, $"Polling wait failed to observe the element.\n{report}"));
+        Assert.All(assisted, sample => Assert.True(sample.Found, $"Event-assisted wait failed to observe the element.\n{report}"));
+
+        var pollingMedian = EventWaitBenchmark.Median(polling.Select(static sample => sample.LatencyMs));
+        var assistedMedian = EventWaitBenchmark.Median(assisted.Select(static sample => sample.LatencyMs));
+
+        // The claim under test is only that assistance does not make things worse. A hard
+        // "must be faster" threshold would be a timing assertion on a shared CI desktop, which is
+        // exactly the kind of flake this whole line of work exists to remove. The magnitude of any
+        // improvement is reported, not asserted.
+        Assert.True(
+            assistedMedian <= pollingMedian + 50,
+            $"Event assistance regressed wait latency.\n{report}");
+    }
+
+    private async Task<WaitLatencySample> MeasureOneAsync(bool eventAssisted)
+    {
+        var form = _fixture.Form ?? throw new InvalidOperationException("Harness form is not available.");
+        var name = $"SpikeTarget{Guid.NewGuid():N}";
+        Button? target = null;
+
+        try
+        {
+            return await EventWaitBenchmark.MeasureLatencyAsync(
+                (query, timeoutMs) => _automationService.WaitForElementAsync(query, timeoutMs),
+                new ElementQuery
+                {
+                    WindowHandle = _windowHandle,
+                    Name = name,
+                    ControlType = "Button"
+                },
+                trigger: () =>
+                {
+                    _ = form.Invoke(() =>
+                    {
+                        target = new Button
+                        {
+                            Name = name,
+                            Text = name,
+                            Left = 8,
+                            Top = 8,
+                            Width = 220,
+                            Height = 24
+                        };
+                        form.Controls.Add(target);
+                        target.BringToFront();
+                        return true;
+                    });
+
+                    return Task.CompletedTask;
+                },
+                eventAssisted,
+                TimeoutMs);
+        }
+        finally
+        {
+            if (target is not null)
+            {
+                _ = form.Invoke(() =>
+                {
+                    form.Controls.Remove(target);
+                    target.Dispose();
+                    return true;
+                });
+            }
+        }
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinUIEventWaitBenchmarkTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/EventWaitSpike/WinUIEventWaitBenchmarkTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Sbroenne.WindowsMcp.Automation;
+using Sbroenne.WindowsMcp.Capture;
+using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
+using Sbroenne.WindowsMcp.Tests.Integration.EventWaitSpike;
+using Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
+using Sbroenne.WindowsMcp.Window;
+using Xunit.Abstractions;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.WinUI;
+
+/// <summary>
+/// Spike measurements for issue #189 against the WinUI 3 harness.
+/// </summary>
+/// <remarks>
+/// The WinUI harness is a separate process, so an element cannot be created at a known instant the
+/// way it can in the in-process WinForms harness. This therefore measures the timeout path only,
+/// to show that subscribing does not make waits more expensive on a modern XAML provider.
+/// </remarks>
+[Collection("ModernTestHarness")]
+[Trait("Category", "RequiresDesktop")]
+public sealed class WinUIEventWaitBenchmarkTests : IDisposable
+{
+    private const int TimeoutMs = 3000;
+
+    private readonly UIAutomationService _automationService;
+    private readonly UIAutomationThread _staThread;
+    private readonly string _windowHandle;
+    private readonly ITestOutputHelper _output;
+
+    public WinUIEventWaitBenchmarkTests(ModernTestHarnessFixture fixture, ITestOutputHelper output)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        _output = output;
+        fixture.BringToFront();
+
+        _windowHandle = fixture.TestWindowHandleString;
+        _staThread = new UIAutomationThread();
+
+        _automationService = new UIAutomationService(
+            _staThread,
+            new MonitorService(),
+            new MouseInputService(),
+            new KeyboardInputService(),
+            new WindowActivator(),
+            new ElevationDetector(),
+            NullLogger<UIAutomationService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        UIAutomationService.EventAssistedWaitEnabled = false;
+        _staThread.Dispose();
+        _automationService.Dispose();
+    }
+
+    [Fact]
+    public async Task EventAssistedWait_DoesNotRegressTimeoutPath_OnWinUiTree()
+    {
+        var query = new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            Name = "NoSuchElementForSpike189",
+            ControlType = "Button"
+        };
+
+        var polling = await EventWaitBenchmark.MeasureTimeoutCostAsync(
+            (elementQuery, timeoutMs) => _automationService.WaitForElementAsync(elementQuery, timeoutMs),
+            query,
+            eventAssisted: false,
+            TimeoutMs);
+
+        var assisted = await EventWaitBenchmark.MeasureTimeoutCostAsync(
+            (elementQuery, timeoutMs) => _automationService.WaitForElementAsync(elementQuery, timeoutMs),
+            query,
+            eventAssisted: true,
+            TimeoutMs);
+
+        var report = EventWaitBenchmark.FormatTimeoutReport("winui", polling, assisted, TimeoutMs);
+        _output.WriteLine(report);
+        EventWaitBenchmark.WriteReport("winui", report);
+
+        Assert.False(polling.Found, $"The spike query must not match anything.\n{report}");
+        Assert.False(assisted.Found, $"The spike query must not match anything.\n{report}");
+
+        Assert.True(
+            assisted.ElapsedMs < TimeoutMs * 2,
+            $"Event-assisted wait overran its timeout budget on a WinUI tree.\n{report}");
+    }
+}


### PR DESCRIPTION
Closes #189.

#189 is a spike whose exit criterion is "a measurement-backed recommendation", with explicit permission to reject the idea. This is the measurement, and the recommendation is **reject for the default path**.

## What was built

Event-***assisted*** waiting, not event-***driven*** waiting.

UIA providers are not required to raise structure-changed events reliably, so a purely event-driven wait would hang on a silent provider. Instead, events only cut a sleep short; polling remains the correctness guarantee. That makes the worst case exactly today's behaviour and directly answers risks 1 and 3 in the issue.

Two details worth noting:
- The signal subscribes **before** the first probe, so a change landing between probe and sleep cannot be missed (no lost wake-up).
- A binary `SemaphoreSlim(0,1)` coalesces bursts, so a Chromium event storm can never queue more than one pending re-check.

## Measurements

WinForms, in-process — the element is created at an exact known instant, so this is the most favourable and most trustworthy case. Four consecutive runs:

| run | polling median | assisted median | "improvement" | events fired |
|-----|---------------|-----------------|---------------|--------------|
| 1 | 482.7ms | 458.5ms | +5.0% | 3 of 5 |
| 2 | 488.0ms | 459.3ms | +5.9% | 1 of 5 |
| 3 | 421.8ms | 414.9ms | +1.6% | 5 of 5 |
| 4 | 505.2ms | 536.5ms | **−6.2%** | 4 of 5 |

WinUI timeout path — no regression:

```
polling  elapsed/cpu : 3776ms / 359ms cpu
assisted elapsed/cpu : 3217ms / 266ms cpu   (requested timeout 3000ms)
```

## Why reject

Two findings, either of which is sufficient.

**1. The effect is indistinguishable from noise.** The sign flips: run 4 measured event assistance *slower*. Individual waits span 262–1046ms, so a median-of-5 moves more than the effect being measured.

**2. The premise of #189 is false.** Run 3 is decisive — events fired on **5 of 5** waits, so the waiter was woken essentially immediately, and latency was *still* ~415ms. The cost is dominated by **the UIA query itself**, not by the polling sleep this mechanism shortens. No wake-up strategy, event-driven or event-assisted, can materially improve this. The real optimisation is a cheaper probe.

Rejecting on measured evidence, not on the speculative risks listed in the issue. (Those risks did show up — event delivery ranged from 1-of-5 to 5-of-5 waits — but they are not the reason.)

## What lands

`EventAssistedWaitEnabled` defaults to `false`, so **production behaviour is unchanged**. The mechanism and benchmark are kept so the conclusion is reproducible and can be re-checked rather than taken on trust — and so a future cheaper-probe change can re-run the same benchmark to see whether the tradeoff has shifted.

## Not adding a flake

The benchmark asserts no-regression with a 150ms tolerance, deliberately *wider* than the effect it measures. An initial 50ms bound would have been a coin flip given run 4's +31.3ms median gap — that would have traded one flake for another. 150ms still catches a gross regression such as the mechanism deadlocking or serialising waits.

## Scope limits (stated explicitly, not glossed over)

- Latency is measured directly **only on WinForms**. WinUI and Electron are out-of-process, so their element-creation instant isn't observable; they get no-regression checks on the timeout path only.
- The latency table above is from local runs. CI proves *no regression*, not the magnitude — xUnit doesn't surface `ITestOutputHelper` output for passing tests. The benchmark writes each report to `%TEMP%\mcp-windows-spike-189\` for anyone re-running it. I chose not to add a workflow step to echo those files, since the spike is being rejected and the mechanism ships disabled.
- `WaitForElementStateAsync` was deliberately left unassisted. Moot given the recommendation, but it would have been the obvious follow-up had this been adopted.

## Validation

- Build clean, 0 warnings.
- Unit tests 494/494.
- **Integration suite green: 812 passed / 0 failed / 8 skipped / 820.** That is exactly +3 over the 817 baseline — the three new benchmark tests — with no existing test disturbed.
- `TestWaitTests` / `DeterministicWaitTests` failed intermittently *locally* only when run immediately after the heavy benchmark suite, and pass 21/21 in isolation. They assert wall-clock ranges (e.g. `Assert.InRange(50-150)`) and touch none of this code — pre-existing load-sensitivity, not a regression from this PR. They passed in CI.