### PR TITLE
Close leftover modal dialogs when resetting the UI test harness

### DIFF
--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/FixtureIsolationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/FixtureIsolationTests.cs
@@ -1,0 +1,78 @@
+using System.Runtime.InteropServices;
+using Sbroenne.WindowsMcp.Native;
+
+namespace Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
+
+/// <summary>
+/// Tests that the shared harness fixture isolates tests from each other.
+/// </summary>
+/// <remarks>
+/// The fixture is a collection fixture, so a single harness form is shared by every test class in
+/// the "UITestHarness" collection. A test that fails while a modal Save/Open dialog is open used to
+/// leave that dialog on screen for the rest of the run: the dialog owns the foreground and disables
+/// the harness form, so later tests clicked into a dead window. See issue #195.
+/// </remarks>
+[Collection("UITestHarness")]
+[Trait("Category", "RequiresDesktop")]
+public sealed class FixtureIsolationTests
+{
+    private readonly UITestHarnessFixture _fixture;
+
+    public FixtureIsolationTests(UITestHarnessFixture fixture)
+    {
+        _fixture = fixture;
+        _fixture.Reset();
+        _fixture.BringToFront();
+    }
+
+    [Fact]
+    public void Reset_ClosesModalDialogLeftOpenByAPreviousTest()
+    {
+        var form = _fixture.Form;
+        Assert.NotNull(form);
+
+        // Simulate a test that failed mid-interaction, leaving the Save dialog open.
+        // BeginInvoke, not Invoke: ShowDialog blocks the UI thread until dismissed.
+        form.BeginInvoke(form.ShowSaveDialogForTesting);
+
+        Assert.True(
+            TestWait.Until(() => GetOwnedDialog() != IntPtr.Zero),
+            "The Save dialog did not open, so this test could not verify anything.");
+
+        _fixture.Reset();
+
+        Assert.Equal(IntPtr.Zero, GetOwnedDialog());
+    }
+
+    [Fact]
+    public void Reset_LeavesHarnessInteractiveAfterADialogWasLeftOpen()
+    {
+        var form = _fixture.Form;
+        Assert.NotNull(form);
+
+        form.BeginInvoke(form.ShowSaveDialogForTesting);
+        Assert.True(
+            TestWait.Until(() => GetOwnedDialog() != IntPtr.Zero),
+            "The Save dialog did not open, so this test could not verify anything.");
+
+        _fixture.Reset();
+        _fixture.BringToFront();
+
+        // Win32 disables the owner window while a dialog is modal, and a disabled window silently
+        // swallows input. Control.Enabled is not the check to make here: WinForms leaves the
+        // managed property true throughout, so it stays true even while the dialog is up.
+        Assert.True(IsWindowEnabled(_fixture.TestWindowHandle));
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowEnabled(nint hWnd);
+
+    private nint GetOwnedDialog()
+    {
+        var owner = _fixture.TestWindowHandle;
+        var dialog = NativeMethods.GetWindow(owner, NativeConstants.GW_ENABLEDPOPUP);
+
+        return dialog == owner || !NativeMethods.IsWindowVisible(dialog) ? IntPtr.Zero : dialog;
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessFixture.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessFixture.cs
@@ -79,12 +79,76 @@ public sealed class UITestHarnessFixture : IDisposable
     /// <summary>
     /// Resets the form state.
     /// </summary>
+    /// <remarks>
+    /// Closes any modal dialog left open by a previous test before resetting control state.
+    /// The harness shows Save/Open common dialogs via a blocking <c>ShowDialog</c>, so a test that
+    /// fails mid-interaction leaves the dialog on screen owning the foreground, with the harness
+    /// form disabled. Resetting control values alone does not recover from that, and every
+    /// subsequent test in the collection inherits the wedged UI (issue #195).
+    /// </remarks>
     public void Reset()
     {
-        if (_form != null && !_form.IsDisposed)
+        if (_form == null || _form.IsDisposed)
         {
-            _form.Invoke(() => _form.Reset());
+            return;
         }
+
+        CloseOwnedDialogs();
+
+        // Marshalled with Invoke: safe now that any modal loop has been exited.
+        _form.Invoke(() => _form.Reset());
+    }
+
+    /// <summary>
+    /// Closes any modal dialog owned by the harness form, and waits for it to go away.
+    /// </summary>
+    /// <remarks>
+    /// Uses <c>GW_ENABLEDPOPUP</c> to find the owned popup, matching the pattern already used by
+    /// <c>WindowService</c> to detect save dialogs, and closes it with <c>WM_CLOSE</c> (equivalent
+    /// to Cancel for a common dialog). <c>WM_CLOSE</c> is posted rather than sent because the UI
+    /// thread is blocked inside the dialog's modal message loop.
+    /// </remarks>
+    public void CloseOwnedDialogs()
+    {
+        var owner = TestWindowHandle;
+        if (owner == IntPtr.Zero)
+        {
+            return;
+        }
+
+        // Bounded so a dialog that refuses to close cannot hang the whole suite. Each iteration
+        // handles one dialog, which covers a dialog stacked on top of another.
+        for (var i = 0; i < 5; i++)
+        {
+            var dialog = GetOwnedDialog(owner);
+            if (dialog == IntPtr.Zero)
+            {
+                return;
+            }
+
+            NativeMethods.PostMessage(dialog, NativeConstants.WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+
+            if (!TestWait.Until(() => GetOwnedDialog(owner) != dialog))
+            {
+                throw new InvalidOperationException(
+                    $"UI test harness has a modal dialog (handle {dialog}) that did not close in " +
+                    "response to WM_CLOSE. The harness is wedged and later tests would be unreliable.");
+            }
+        }
+
+        throw new InvalidOperationException(
+            "UI test harness still had a modal dialog open after closing 5 of them.");
+    }
+
+    /// <summary>
+    /// Gets the modal dialog owned by <paramref name="owner"/>, or zero when there is none.
+    /// </summary>
+    private static nint GetOwnedDialog(nint owner)
+    {
+        var dialog = NativeMethods.GetWindow(owner, NativeConstants.GW_ENABLEDPOPUP);
+
+        // GetWindow returns the owner itself when no owned popup is enabled.
+        return dialog == owner || !NativeMethods.IsWindowVisible(dialog) ? IntPtr.Zero : dialog;
     }
 
     /// <summary>
@@ -116,13 +180,19 @@ public sealed class UITestHarnessFixture : IDisposable
         {
             try
             {
+                // A form with an open modal dialog will not close, so clear dialogs first.
+                CloseOwnedDialogs();
                 _form.Invoke(() => _form.Close());
             }
             catch
             {
-                // Form may already be disposed
+                // Form may already be disposed, or be wedged with a dialog that will not close.
             }
         }
+
+        // Join the UI thread so its message loop and window handles are gone before the next
+        // fixture starts, rather than racing with it for foreground.
+        _uiThread?.Join(TimeSpan.FromSeconds(5));
 
         _formReady.Dispose();
     }

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
@@ -722,6 +722,14 @@ public sealed class UITestHarnessForm : Form
         UpdateStatus("UI Test Harness Reset");
     }
 
+    /// <summary>
+    /// Opens the Save dialog directly, without going through the keyboard or a click.
+    /// Exists so isolation tests can reproduce a test that failed while a modal dialog was open.
+    /// Blocks the UI thread until the dialog is dismissed, so callers must use
+    /// <see cref="Control.BeginInvoke(Delegate)"/> rather than <c>Invoke</c>.
+    /// </summary>
+    public void ShowSaveDialogForTesting() => ShowSaveDialog();
+
     private void UpdateStatus(string message)
     {
         _statusLabel.Text = message;


### PR DESCRIPTION
## What

Tests in the `UITestHarness` collection share a single harness form via a collection fixture. The harness opens Save/Open common dialogs with a blocking `ShowDialog(this)`, and nothing ever force-closed them.

So a test that failed mid-interaction left the dialog on screen for the rest of the run. That dialog owns the foreground, and Win32 disables the owner window while a dialog is modal — a disabled window silently swallows input. Every later test in the collection then clicked into a dead window.

`Reset()` only restored control values. It closed no dialogs and touched no window state, so the next test class started against a wedged UI while `Reset()` reported success.

## Changes

- `Reset()` closes any dialog owned by the harness before resetting control state.
- New `CloseOwnedDialogs()` finds the owned popup with `GW_ENABLEDPOPUP` and closes it with `WM_CLOSE`, which is Cancel for a common dialog. This reuses the pattern `WindowService` already uses to detect save dialogs. `WM_CLOSE` is *posted*, not sent, because the UI thread is blocked inside the dialog''s modal message loop. The loop is bounded, and it throws a diagnostic if a dialog refuses to close rather than hanging the suite.
- `Dispose()` clears dialogs before closing the form — a form with an open modal child will not close — and now joins the UI thread so its message loop and window handles are gone before the next fixture starts.

## Verification

Both new tests were confirmed to **fail without the fix and pass with it**:

| Test | Without fix | With fix |
|---|---|---|
| `Reset_ClosesModalDialogLeftOpenByAPreviousTest` | FAIL | PASS |
| `Reset_LeavesHarnessInteractiveAfterADialogWasLeftOpen` | FAIL | PASS |

The second test deliberately checks the **native** `IsWindowEnabled`, not `Control.Enabled`. An earlier draft asserted `Control.Enabled` and passed with *and* without the fix: WinForms leaves the managed property `true` the whole time while Win32 disables the window, so that assertion was vacuous.

Suite results, non-Electron integration selection, three consecutive runs: **440 passed / 0 failed** each time. The issue reported 2 / 0 / 2 failures across three identical runs. Unit tests 494/494.

## Scope

This fixes the leaked-dialog isolation failure. It does **not** address the desktop-level UIA degradation also noted in #195 (the Electron fixture failing to attach at all after repeated runs) — that has a different signature and is left open.

Refs #195
