### PR TITLE
Scope Electron harness fixture to its own process

### DIFF
--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronHarnessFixture.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/ElectronHarnessFixture.cs
@@ -25,9 +25,6 @@ public sealed class ElectronHarnessFixture : IDisposable
     [DllImport("user32.dll")]
     private static extern nint GetForegroundWindow();
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern nint FindWindow(string? lpClassName, string lpWindowName);
-
     [DllImport("user32.dll")]
     private static extern bool PostMessage(nint hWnd, uint msg, nint wParam, nint lParam);
 
@@ -211,6 +208,10 @@ public sealed class ElectronHarnessFixture : IDisposable
             throw new InvalidOperationException($"Electron executable not found at: {electronExePath}");
         }
 
+        // Remove orphans from earlier runs before starting, so they cannot compete for the
+        // foreground or outlive this fixture.
+        KillStaleHarnessProcesses(electronExePath);
+
         // Use "." as argument and set working directory - same as `electron .` from command line
         _electronProcess = new Process
         {
@@ -232,15 +233,19 @@ public sealed class ElectronHarnessFixture : IDisposable
 
     private void WaitForWindow()
     {
+        var electronProcessId = _electronProcess?.Id
+            ?? throw new InvalidOperationException("Electron process was not started.");
+
         var appeared = TestWait.Until(
             condition: () =>
             {
-                _windowHandle = FindWindow(null, ELECTRON_HARNESS_TITLE);
                 if (_electronProcess?.HasExited == true)
                 {
                     throw new InvalidOperationException(
                         $"Electron process exited unexpectedly (exit code {_electronProcess.ExitCode})");
                 }
+
+                _windowHandle = FindHarnessWindow(electronProcessId);
 
                 return _windowHandle != nint.Zero;
             },
@@ -253,13 +258,104 @@ public sealed class ElectronHarnessFixture : IDisposable
                 $"Electron harness window did not appear within {MAX_WAIT_SECONDS} seconds");
         }
 
+        // Note: readiness is bimodal in practice - the tree is exposed within a second or two, or
+        // not at all - so a longer budget only slows failures down.
         var automationReady = TestWait.Until(
             condition: IsAutomationTreeReady,
             timeout: TimeSpan.FromSeconds(10),
             pollInterval: TimeSpan.FromMilliseconds(100));
         if (!automationReady)
         {
-            throw new TimeoutException("Electron harness UI Automation tree did not become ready.");
+            var windows = string.Join(
+                ", ",
+                GetProcessWindows(electronProcessId).Select(h => $"{h}:'{GetWindowTitle(h)}'"));
+
+            throw new TimeoutException(
+                "Electron harness UI Automation tree did not become ready. " +
+                $"Process {electronProcessId} owns window {_windowHandle}; visible windows: [{windows}].");
+        }
+    }
+
+    /// <summary>
+    /// Finds the harness window belonging to <paramref name="processId"/>.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>FindWindow(null, title)</c>. That searches every top-level window on the
+    /// desktop, so an orphaned harness left behind by an earlier run wins over the process this
+    /// fixture just started. UI Automation then runs against a window the fixture does not own and
+    /// never becomes ready, the fixture constructor throws, and xUnit fails every test in the
+    /// collection instantly (issue #195).
+    /// </remarks>
+    private static nint FindHarnessWindow(int processId) =>
+        GetProcessWindows(processId, ELECTRON_HARNESS_TITLE).FirstOrDefault();
+
+    /// <summary>
+    /// Gets the visible top-level windows owned by <paramref name="processId"/>, optionally
+    /// filtered to an exact window title.
+    /// </summary>
+    private static List<nint> GetProcessWindows(int processId, string? title = null)
+    {
+        var windows = new List<nint>();
+
+        NativeMethods.EnumWindows(
+            (hWnd, _) =>
+            {
+                NativeMethods.GetWindowThreadProcessId(hWnd, out var owningProcessId);
+                if (owningProcessId != (uint)processId || !NativeMethods.IsWindowVisible(hWnd))
+                {
+                    return true;
+                }
+
+                if (title == null || GetWindowTitle(hWnd) == title)
+                {
+                    windows.Add(hWnd);
+                }
+
+                return true;
+            },
+            nint.Zero);
+
+        return windows;
+    }
+
+    private static string GetWindowTitle(nint hWnd)
+    {
+        var buffer = new char[512];
+        var length = NativeMethods.GetWindowText(hWnd, buffer, buffer.Length);
+
+        return length > 0 ? new string(buffer, 0, length) : string.Empty;
+    }
+
+    /// <summary>
+    /// Kills harness processes left behind by an earlier run before starting a new one.
+    /// </summary>
+    /// <remarks>
+    /// Scoped to processes started from this repository's own Electron executable, so a developer's
+    /// unrelated Electron applications are never touched. Orphans accumulate because a failed run
+    /// can close the window while its process tree survives, and they then compete for the
+    /// foreground and for the harness window title.
+    /// </remarks>
+    private static void KillStaleHarnessProcesses(string electronExePath)
+    {
+        foreach (var process in Process.GetProcessesByName("electron"))
+        {
+            try
+            {
+                if (string.Equals(process.MainModule?.FileName, electronExePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(TimeSpan.FromSeconds(5));
+                }
+            }
+            catch
+            {
+                // MainModule throws for processes we cannot open, and the process may exit while
+                // we look at it. Either way there is nothing useful to do.
+            }
+            finally
+            {
+                process.Dispose();
+            }
         }
     }
 
@@ -285,23 +381,30 @@ public sealed class ElectronHarnessFixture : IDisposable
     }
 
     /// <summary>
-    /// Dismisses any open modal dialogs (Save As, etc.) by sending WM_CLOSE
-    /// to known dialog titles. Uses FindWindow + PostMessage which is targeted
-    /// and doesn't interfere with the main Electron window (unlike keybd_event Escape).
+    /// Dismisses any open modal dialogs (Save As, etc.) by sending WM_CLOSE.
     /// </summary>
-#pragma warning disable CA1822 // Mark members as static — called as instance method from tests for readability
+    /// <remarks>
+    /// Scoped to windows owned by the harness process. A global <c>FindWindow(null, "Save")</c>
+    /// would match any window on the desktop with that title, including one belonging to an
+    /// unrelated application.
+    /// </remarks>
     public void DismissDialogs()
-#pragma warning restore CA1822
     {
+        if (_electronProcess is not { HasExited: false })
+        {
+            return;
+        }
+
+        var processId = _electronProcess.Id;
         string[] dialogTitles = ["Save As", "Save as", "Save"];
+
         foreach (var title in dialogTitles)
         {
-            var dialogHwnd = FindWindow(null, title);
-            if (dialogHwnd != nint.Zero)
+            foreach (var dialogHwnd in GetProcessWindows(processId, title))
             {
                 PostMessage(dialogHwnd, WM_CLOSE, nint.Zero, nint.Zero);
                 TestWait.Until(
-                    () => FindWindow(null, title) == nint.Zero,
+                    () => !NativeMethods.IsWindow(dialogHwnd) || !NativeMethods.IsWindowVisible(dialogHwnd),
                     timeout: TimeSpan.FromSeconds(2));
             }
         }


### PR DESCRIPTION
## Problem

`ElectronHarnessFixture` located its window with `FindWindow(null, "MCP Electron Test Harness")`, a **global** desktop search that never checks the window belongs to the process the fixture just started.

When an orphaned harness from an earlier run was alive, it won. UI Automation then ran against a window the fixture did not own, never became ready, the constructor threw, and xUnit failed **every test in the collection at once** — the signature reported in #195.

Reproduced locally: with one orphan alive, the collection went from passing to `5 failed in 35 ms`, all with `System.TimeoutException : Electron harness UI Automation tree did not become ready.`

Orphans accumulated for a related reason: `CloseElectronApp` posted `WM_CLOSE` to whatever handle was found — possibly the orphan's — and killed only its own process, leaving **windowless Electron processes alive**. Four were routinely still running after a completed run.

## Fix

- Find the window by enumerating visible top-level windows **owned by the process we started**.
- Kill leftover harness processes before launching, scoped to this repo's own `electron.exe` so a developer's unrelated Electron apps are untouched.
- Scope `DismissDialogs` the same way. It previously used a global `FindWindow(null, "Save")` and could `WM_CLOSE` an **unrelated application's** window.
- Report the process, chosen window, and all visible windows it owns on readiness timeout.

## Validation

- Unit: **494/494**. Non-Electron integration: **441/441**.
- Electron collection, 6 runs: 50/50, 49/50, 50/50, 49/50, 50/50, 49/50 — and **0 leftover Electron processes after every run** (previously 4).
- Orphan scenario: previously 5/5 failed instantly; now attaches correctly.
- The occasional 49/50 is the pre-existing `ElectronSaveTests` flake. I verified it is **not** caused by this change by running the unmodified baseline three times: 49/50, 50/50, 49/50 — identical.

## Known remaining issue (not fixed here)

#195 has a second, deeper cause that this PR does not address. Chromium intermittently fails to expose the harness's **web content** in the UIA tree at all. Confirmed with an independent UIA client, outside the fixture entirely: the window is present with 14 descendants, but they are only Chromium's own chrome (`MenuBar`, `File`/`Edit`/`View`/`Window`, empty `Pane`s) — the document is absent, so `Navigate Home` cannot be found.

This reproduces on the **unmodified baseline** as well, so it is pre-existing. The harness already sets `force-renderer-accessibility complete`, so the cause is elsewhere and needs separate investigation. Because readiness is bimodal — the tree appears within a second or two, or never — I left the readiness timeout at 10s; raising it to 30s changed nothing except making failures slower.
