### PR TITLE
docs: promote PowerPoint MCP Server

### DIFF
--- a/gh-pages/docs/index.md
+++ b/gh-pages/docs/index.md
@@ -24,6 +24,10 @@ hide:
     Check out [Excel MCP Server](https://excelmcpserver.dev/) — the sister
     project, built the same way.
 
+!!! tip "Also building PowerPoint decks?"
+    Check out [PowerPoint MCP Server](https://powerpointmcpserver.dev/) — another
+    sister project, built the same way.
+
 ## Key features
 
 <div class="grid cards" markdown>


### PR DESCRIPTION
## Summary
- add a PowerPoint MCP Server callout beside the existing Excel promotion
- link visitors to powerpointmcpserver.dev

## Validation
- strict MkDocs build