### PR TITLE
Improve UI automation reliability across browser and native dialogs

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -205,6 +205,9 @@ Click buttons, tabs, checkboxes, and other interactive elements.
 | `automationId` | Automation ID | No* |
 | `controlType` | Control type filter | No |
 | `foundIndex` | Click the Nth match (1-based) | No |
+| `scope` | `window` (default) or `active_dialog` | No |
+| `parentElementId` | Restrict search to a known subtree | No |
+| `requireUnique` | Fail with match details when more than one control matches | No |
 | `doubleClick` | Double-click instead of single-click | No |
 
 *Selectors are optional; without one, the first actionable match in the target window is used.
@@ -215,6 +218,9 @@ Click buttons, tabs, checkboxes, and other interactive elements.
 - Toggle checkboxes and toggle buttons
 - Handles various control patterns automatically
 - Falls back to coordinate-based click if pattern fails
+- Filters selector-based actions to visible, enabled controls and revalidates stale element IDs before acting
+- Scope duplicate labels to the currently active modal/native dialog with `scope='active_dialog'`
+- Use `requireUnique=true` to get `multiple_matches` plus diagnostic match details instead of silently choosing
 - `doubleClick=true` double-clicks an element by name/id - no coordinates needed for list/grid items that open on double-click. UI Automation has no double-click pattern, so this is always a physical double-click at the element's clickable point.
 
 ---
@@ -234,6 +240,10 @@ Type text into edit controls and text fields.
 | `automationId` | Automation ID | No* |
 | `controlType` | Control type (default: Edit) | No |
 | `clearFirst` | Clear existing text before typing | No (default: false) |
+| `inputMode` | `auto`, `keyboard`, or `value` | No (default: auto) |
+| `scope` | `window` (default) or `active_dialog` | No |
+| `parentElementId` | Restrict search to a known subtree | No |
+| `requireUnique` | Fail when more than one field matches | No |
 
 ### Capabilities
 
@@ -241,6 +251,9 @@ Type text into edit controls and text fields.
 - Clear existing content before typing with `clearFirst=true`
 - Append text to existing content
 - Unicode support for any language
+- `auto` uses normal focus and keyboard input for Chromium/Electron so React-style input handlers observe the change
+- `keyboard` forces the normal focus/key event path; `value` forces UIA ValuePattern
+- The tool verifies the requested value became observable and fails instead of reporting an unobserved change
 
 ---
 
@@ -425,6 +438,9 @@ Wait until a UI condition is met before continuing - no blind sleeps or screensh
 | `elementId` | Element id for `mode='state'` | No |
 | `desiredState` | Target state for `mode='state'` (enabled, disabled, on, off, indeterminate, visible, offscreen) | No |
 | `timeoutMs` | Max wait in milliseconds | No (default: 5000) |
+| `scope` | `window` (default) or `active_dialog` | No |
+| `parentElementId` | Restrict appear/disappear to a known subtree | No |
+| `requireUnique` | Require exactly one matching element for appear | No |
 
 ### Capabilities
 
@@ -454,7 +470,7 @@ Each step is a JSON object with an `action` plus the fields that action needs:
 
 - `find` - selectors; resolves an element and exposes its id to the next step as `$prev`
 - `click` - selectors or `elementId`, optional `doubleClick`
-- `type` - selectors or `elementId`, plus `text` (optional `clearFirst`)
+- `type` - selectors or `elementId`, plus `text` (optional `clearFirst`, `inputMode`)
 - `select` - selectors, plus `value` (visible option text)
 - `wait` - `mode` (`appear`/`disappear`/`state`), selectors or `elementId`+`desiredState`, optional `timeoutMs`
 - `read` - selectors or `elementId` (or neither, to read the whole window), optional `includeChildren`
@@ -482,6 +498,9 @@ The target window is activated before each mouse step, so a batch cannot fail wi
 - One round-trip for multi-step workflows (fill username + password + submit) and for multi-stroke drawing
 - Per-step results: `{ index, action, success, summary, error?, elementId?, text? }`
 - Chain steps by referencing the prior step's element with `elementId: "$prev"`
+- Add a `wait` step immediately after an action to verify consequences such as a button enabling,
+  a dialog closing, or confirmation text appearing
+- Selector steps accept `scope`, `parentElementId`, `requireUnique`, `visibleOnly`, and `enabledOnly`
 - `stopOnError=false` runs every step and reports each outcome
 - Mouse steps delegate to the same engine as `mouse_control`, so monitor resolution, foreground guards, secure-desktop and elevation checks behave identically
 
@@ -525,11 +544,15 @@ Open an existing file via the standard Windows Open dialog — the counterpart t
 | `windowHandle` | Target window handle (the app window, not a dialog) | Yes |
 | `filePath` | Absolute path of an existing file to open (forward/back slashes both work) | Yes |
 | `includeDiagnostics` | Include timing/diagnostic details in the response (default: false) | No |
+| `triggerMode` | `shortcut` sends Ctrl+O; `wait` waits for a dialog opened by a prior click | No (default: shortcut) |
+| `timeoutMs` | Maximum wait for the native dialog | No (default: 5000) |
 
 ### Capabilities
 
 - Trigger Ctrl+O to open
 - Auto-detect Open dialog appearance (shares the Save-As dialog engine)
+- `triggerMode='wait'` supports browser-to-native-dialog handoff after `ui_click`
+- Dialog selection prefers the enabled popup owned by the requested app and reports observed candidate windows on timeout
 - Fill in the file path and click Open
 - Validates the file exists up front for deterministic behavior
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -440,7 +440,7 @@ Wait until a UI condition is met before continuing - no blind sleeps or screensh
 | `timeoutMs` | Max wait in milliseconds | No (default: 5000) |
 | `scope` | `window` (default) or `active_dialog` | No |
 | `parentElementId` | Restrict appear/disappear to a known subtree | No |
-| `requireUnique` | Require exactly one matching element for appear | No |
+| `requireUnique` | Require exactly one matching element for appear or disappear | No |
 
 ### Capabilities
 
@@ -657,7 +657,7 @@ Control mouse input on Windows with full multi-monitor and DPI awareness.
 | `modifiers` | `ctrl`, `shift`, `alt` (comma-separated) | No |
 | `direction` / `amount` | Scroll direction and click count | For `scroll` |
 | `target` / `monitorIndex` | Monitor targeting | With coordinates |
-| `windowHandle` | Window-relative coordinate mode | No |
+| `windowHandle` | Window-relative coordinate mode and foreground guard | No |
 | `expectedWindowTitle` / `expectedProcessName` | Abort unless the foreground window matches | No |
 
 ### Capabilities
@@ -670,7 +670,7 @@ Control mouse input on Windows with full multi-monitor and DPI awareness.
 - Multi-monitor support with DPI awareness
 - Easy targeting with `target='primary_screen'` or `'secondary_screen'`
 - Modifier key support (Ctrl+click, Shift+click, etc.)
-- Wrong window detection with `expectedWindowTitle` / `expectedProcessName`
+- Wrong window detection with `windowHandle`, `expectedWindowTitle`, or `expectedProcessName`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ ui_click(windowHandle='123456', nameContains='Save')
 # 3. Type into fields
 ui_type(windowHandle='123456', controlType='Edit', text='Hello World')
 
+# Browser/React field: force normal focus and keyboard events when needed
+ui_type(windowHandle='123456', name='Title', text='New title', inputMode='keyboard')
+
+# Modal with duplicate labels: scope the action and require one match
+ui_click(windowHandle='123456', name='Save', scope='active_dialog', requireUnique=true)
+
 # 4. Fallback for games/canvas — screenshot + mouse
 screenshot_control(target='window', windowHandle='123456') → element coordinates
 mouse_control(action='click', x=450, y=300)
@@ -34,6 +40,9 @@ mouse_control(action='click', x=450, y=300)
 Same command works every time. Any machine. Any DPI. Any theme.
 
 Browsers follow the same semantic flow: launch `msedge.exe` or `chrome.exe`, then use `ui_find`, `ui_click`, and `ui_type` on links, buttons, and fields exposed through UIA names and ARIA labels.
+For controls that open a native file picker, click the browser control first, then call
+`file_open(..., triggerMode='wait')`. Use `window_management(action='maximize')` when the page's
+responsive layout hides or replaces the intended control in a small viewport.
 
 ## Key Features
 

--- a/src/Sbroenne.WindowsMcp.Cli/Cli/CommandDispatcher.cs
+++ b/src/Sbroenne.WindowsMcp.Cli/Cli/CommandDispatcher.cs
@@ -198,6 +198,8 @@ internal static class CommandDispatcher
             Window(a) ?? string.Empty,
             a.GetString("path", "file-path", "file") ?? string.Empty,
             a.GetFlag("include-diagnostics", "diagnostics"),
+            a.GetString("trigger-mode", "trigger") ?? "shortcut",
+            a.GetInt("timeout-ms", "timeout") ?? 5000,
             ct);
         return Emit.Result(result);
     }
@@ -314,6 +316,10 @@ internal static class CommandDispatcher
                         a.GetString("near-element", "near"),
                         a.GetNullableBool("visible-only"),
                         a.GetNullableBool("content-view-only"),
+                        a.GetString("parent-element-id", "parent"),
+                        a.GetString("scope") ?? "window",
+                        a.GetFlag("require-unique", "unique"),
+                        a.GetNullableBool("enabled-only"),
                         a.GetInt("timeout-ms", "timeout") ?? 5000,
                         diag,
                         ct);
@@ -336,6 +342,9 @@ internal static class CommandDispatcher
                         a.GetString("snapshot-mode") ?? "full",
                         diag,
                         a.GetFlag("double-click", "dblclick"),
+                        a.GetString("parent-element-id", "parent"),
+                        a.GetString("scope") ?? "window",
+                        a.GetFlag("require-unique", "unique"),
                         ct);
                     return Emit.Result(result);
                 }
@@ -363,6 +372,10 @@ internal static class CommandDispatcher
                         a.GetFlag("with-snapshot", "snapshot"),
                         a.GetString("snapshot-mode") ?? "full",
                         diag,
+                        a.GetString("input-mode") ?? "auto",
+                        a.GetString("parent-element-id", "parent"),
+                        a.GetString("scope") ?? "window",
+                        a.GetFlag("require-unique", "unique"),
                         ct);
                     return Emit.Result(result);
                 }
@@ -444,6 +457,10 @@ internal static class CommandDispatcher
                         a.GetString("control-type"),
                         a.GetString("automation-id"),
                         a.GetString("class-name"),
+                        a.GetString("parent-element-id", "parent"),
+                        a.GetString("scope") ?? "window",
+                        a.GetFlag("require-unique", "unique"),
+                        a.GetNullableBool("enabled-only"),
                         a.GetInt("timeout-ms", "timeout") ?? 5000,
                         diag,
                         ct);

--- a/src/Sbroenne.WindowsMcp.Cli/Cli/HelpText.cs
+++ b/src/Sbroenne.WindowsMcp.Cli/Cli/HelpText.cs
@@ -75,9 +75,16 @@ internal static class HelpText
         ui find     --window <h> [--name|--name-contains|--name-pattern|--control-type|
                      --automation-id|--class-name ...] [--found-index <n>] [--include-children]
                      [--sort-by-prominence] [--in-region x,y,w,h] [--near-element <id>]
-                     [--visible-only] [--content-view-only] [--timeout-ms <n>]
-        ui click    --window <h> [selectors|--element-id <id>] [--found-index <n>] [--double-click] [--with-snapshot] [--snapshot-mode full|auto|reset]
-        ui type     --window <h> --text <s> [selectors|--element-id <id>] [--clear-first] [--with-snapshot] [--snapshot-mode full|auto|reset]
+                     [--visible-only] [--enabled-only] [--content-view-only]
+                     [--scope window|active_dialog] [--parent <id>] [--require-unique]
+                     [--timeout-ms <n>]
+        ui click    --window <h> [selectors|--element-id <id>] [--found-index <n>]
+                     [--scope window|active_dialog] [--parent <id>] [--require-unique]
+                     [--double-click] [--with-snapshot] [--snapshot-mode full|auto|reset]
+        ui type     --window <h> --text <s> [selectors|--element-id <id>] [--clear-first]
+                     [--input-mode auto|keyboard|value] [--scope window|active_dialog]
+                     [--parent <id>] [--require-unique] [--with-snapshot]
+                     [--snapshot-mode full|auto|reset]
         ui select   --window <h> --value <s> [selectors] [--with-snapshot] [--snapshot-mode full|auto|reset]
         ui read     --window <h> [selectors|--element-id <id>] [--include-children] [--language <c>] [--format raw|article]
         ui read-table --window <h> [selectors|--element-id <id>] [--max-rows <n>] [--max-columns <n>]
@@ -107,8 +114,9 @@ internal static class HelpText
         file-save --window <h> [--path <file>]
             Save the active document; drives the Save As dialog when needed.
 
-        file-open --window <h> --path <file>
-            Open an existing file; drives the Open dialog (Ctrl+O, types the path, clicks Open).
+        file-open --window <h> --path <file> [--trigger-mode shortcut|wait] [--timeout-ms <n>]
+            Open an existing file. shortcut sends Ctrl+O; wait handles a native dialog opened by
+            a prior semantic click in a browser or desktop app.
 
         clipboard <action> [--text <s>]
             actions: get (read clipboard text), set (write --text), clear

--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -115,8 +115,12 @@ public static class ElementIdGenerator
                 element = FindByRuntimeId(parts.WindowHandle, runtimeId);
             }
 
-            // Fall back to tree path if runtime ID didn't work
-            if (element == null && !string.IsNullOrEmpty(parts.TreePath) && parts.TreePath != "stale")
+            // A tree path is positional and may now identify a replacement control. Strict
+            // state-changing resolution may use it only when the original element had no runtime ID.
+            if (element == null &&
+                (allowSelectorFallback || string.IsNullOrEmpty(parts.RuntimeId) || parts.RuntimeId == "0") &&
+                !string.IsNullOrEmpty(parts.TreePath) &&
+                parts.TreePath != "stale")
             {
                 element = FindByTreePath(parts.WindowHandle, parts.TreePath);
             }

--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -77,7 +77,21 @@ public static class ElementIdGenerator
     /// </summary>
     /// <param name="elementId">The short element ID (e.g., "1", "2").</param>
     /// <returns>The UI Automation element, or null if resolution fails.</returns>
-    public static UIA.IUIAutomationElement? ResolveToAutomationElement(string elementId)
+    public static UIA.IUIAutomationElement? ResolveToAutomationElement(string elementId) =>
+        ResolveToAutomationElement(elementId, allowSelectorFallback: true);
+
+    /// <summary>
+    /// Resolves a short element ID to the actual UI Automation element.
+    /// </summary>
+    /// <param name="elementId">The short element ID (e.g., "1", "2").</param>
+    /// <param name="allowSelectorFallback">
+    /// Whether a stale runtime ID may fall back to an exact name/control-type search.
+    /// State-changing actions should pass <see langword="false"/>.
+    /// </param>
+    /// <returns>The UI Automation element, or null if resolution fails.</returns>
+    public static UIA.IUIAutomationElement? ResolveToAutomationElement(
+        string elementId,
+        bool allowSelectorFallback)
     {
         ArgumentNullException.ThrowIfNull(elementId);
 
@@ -110,7 +124,7 @@ public static class ElementIdGenerator
             // Last-resort: Locator-style re-resolution by name + control type. Chromium/Electron churn
             // runtime IDs and tree indices on re-render, so re-find the element by its stable semantic
             // selector when both the runtime ID and tree path have gone stale.
-            if (element == null && !string.IsNullOrEmpty(parts.Name))
+            if (allowSelectorFallback && element == null && !string.IsNullOrEmpty(parts.Name))
             {
                 element = FindBySelector(parts.WindowHandle, parts.ControlType, parts.Name!);
             }

--- a/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/ElementIdGenerator.cs
@@ -85,7 +85,7 @@ public static class ElementIdGenerator
     /// </summary>
     /// <param name="elementId">The short element ID (e.g., "1", "2").</param>
     /// <param name="allowSelectorFallback">
-    /// Whether a stale runtime ID may fall back to an exact name/control-type search.
+    /// Whether resolution may fall back to positional tree paths or an exact name/control-type search.
     /// State-changing actions should pass <see langword="false"/>.
     /// </param>
     /// <returns>The UI Automation element, or null if resolution fails.</returns>
@@ -115,10 +115,10 @@ public static class ElementIdGenerator
                 element = FindByRuntimeId(parts.WindowHandle, runtimeId);
             }
 
-            // A tree path is positional and may now identify a replacement control. Strict
-            // state-changing resolution may use it only when the original element had no runtime ID.
+            // A tree path is positional and may now identify a replacement control.
+            // Strict state-changing resolution must fail closed without a stable runtime identity.
             if (element == null &&
-                (allowSelectorFallback || string.IsNullOrEmpty(parts.RuntimeId) || parts.RuntimeId == "0") &&
+                allowSelectorFallback &&
                 !string.IsNullOrEmpty(parts.TreePath) &&
                 parts.TreePath != "stale")
             {

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIBatchTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIBatchTool.cs
@@ -34,7 +34,7 @@ public static partial class UIBatchTool
     /// Each step is a JSON object with an "action" plus the fields that action needs:
     /// - find:     selectors (name/controlType/automationId/...). Resolves an element; its id is exposed to the next step as "$prev".
     /// - click:    selectors OR elementId, optional doubleClick.
-    /// - type:     selectors OR elementId, plus text (and optional clearFirst).
+    /// - type:     selectors OR elementId, plus text; optional clearFirst and inputMode (auto/keyboard/value).
     /// - select:   selectors, plus value (visible option text).
     /// - wait:     mode (appear/disappear/state), selectors or elementId+desiredState, optional timeoutMs.
     /// - read:     selectors or elementId (or neither, to read the whole window), optional includeChildren.
@@ -47,8 +47,12 @@ public static partial class UIBatchTool
     /// Mouse coordinates are window-relative by default; set target ('primary_screen'/'secondary_screen') or
     /// monitorIndex on a step for screen-relative coordinates. The target window is activated before each mouse
     /// step unless expectedProcessName/expectedWindowTitle is set (those verify the foreground window instead).
+    /// Selector steps also accept scope="active_dialog", parentElementId, requireUnique,
+    /// visibleOnly, and enabledOnly for reliable modal workflows.
     /// Example steps: [{"action":"type","automationId":"UsernameInput","text":"admin"},
-    /// {"action":"type","automationId":"PasswordInput","text":"secret"},{"action":"click","name":"Submit"}]
+    /// {"action":"type","automationId":"PasswordInput","text":"secret"},
+    /// {"action":"click","name":"Submit","requireUnique":true},
+    /// {"action":"wait","name":"Saved","mode":"appear"}]
     /// Drawing example: [{"action":"polyline","points":[[100,100],[300,100],[300,250],[100,100]]}]
     /// </remarks>
     /// <param name="windowHandle">Window handle as decimal string (from window_management 'find'/'list' or app). Used for every step unless a step overrides it. REQUIRED.</param>
@@ -269,8 +273,19 @@ public static partial class UIBatchTool
                     }
 
                     var result = !string.IsNullOrWhiteSpace(elementId)
-                        ? await service.TypeIntoElementAsync(elementId, step.Text, step.ClearFirst, windowHandle, cancellationToken)
-                        : await service.FindAndTypeAsync(BuildQuery(step, windowHandle), step.Text, step.ClearFirst, cancellationToken);
+                        ? await service.TypeIntoElementAsync(
+                            elementId,
+                            step.Text,
+                            step.ClearFirst,
+                            windowHandle,
+                            step.InputMode ?? "auto",
+                            cancellationToken)
+                        : await service.FindAndTypeAsync(
+                            BuildQuery(step, windowHandle),
+                            step.Text,
+                            step.ClearFirst,
+                            step.InputMode ?? "auto",
+                            cancellationToken);
                     return Step(index, action, result.Success, result.Success ? "typed" : null,
                         result.ErrorMessage, elementId ?? FirstElementId(result));
                 }
@@ -522,6 +537,11 @@ public static partial class UIBatchTool
         ControlType = step.ControlType,
         AutomationId = step.AutomationId,
         ClassName = step.ClassName,
+        ParentElementId = step.ParentElementId,
+        Scope = step.Scope,
+        RequireUnique = step.RequireUnique,
+        EnabledOnly = step.EnabledOnly,
+        VisibleOnly = step.VisibleOnly,
         FoundIndex = Math.Max(1, step.FoundIndex)
     };
 

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIClickTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIClickTool.cs
@@ -36,6 +36,9 @@ public static partial class UIClickTool
     /// <param name="snapshotMode">Post-action snapshot mode when withSnapshot=true: full for one verification (default), auto for repeated checks of the same window, or reset when this action starts a new comparison.</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="doubleClick">Double-click the element instead of single-clicking. Use for list/grid items that open on double-click - no coordinates needed. Default: false.</param>
+    /// <param name="parentElementId">Limit selector search to a known parent element.</param>
+    /// <param name="scope">Search root: window (default) or active_dialog. Use active_dialog for duplicate labels in a modal/native dialog.</param>
+    /// <param name="requireUnique">Fail with ambiguity details instead of choosing the first match. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A call result containing a text content block with the JSON payload describing the click operation's success status and element information. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_click", Title = "Click UI Element", Destructive = true, OpenWorld = false)]
@@ -53,6 +56,9 @@ public static partial class UIClickTool
         [DefaultValue("full")] string snapshotMode,
         [DefaultValue(false)] bool includeDiagnostics,
         [DefaultValue(false)] bool doubleClick,
+        [DefaultValue(null)] string? parentElementId,
+        [DefaultValue("window")] string? scope,
+        [DefaultValue(false)] bool requireUnique,
         CancellationToken cancellationToken)
     {
         const string actionName = "click";
@@ -96,6 +102,9 @@ public static partial class UIClickTool
                 ControlType = controlType,
                 AutomationId = automationId,
                 ClassName = className,
+                ParentElementId = parentElementId,
+                Scope = scope,
+                RequireUnique = requireUnique,
                 FoundIndex = Math.Max(1, foundIndex)
             };
 
@@ -130,5 +139,27 @@ public static partial class UIClickTool
         ExecuteAsync(
             windowHandle, name, nameContains, namePattern, controlType, automationId, className,
             elementId, foundIndex, withSnapshot, "full", includeDiagnostics, doubleClick,
+            null, "window", false,
             cancellationToken);
+
+    /// <summary>Compatibility overload preserving explicit snapshotMode.</summary>
+    public static Task<CallToolResult> ExecuteAsync(
+        string windowHandle,
+        string? name,
+        string? nameContains,
+        string? namePattern,
+        string? controlType,
+        string? automationId,
+        string? className,
+        string? elementId,
+        int foundIndex,
+        bool withSnapshot,
+        string snapshotMode,
+        bool includeDiagnostics,
+        bool doubleClick,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(
+            windowHandle, name, nameContains, namePattern, controlType, automationId, className,
+            elementId, foundIndex, withSnapshot, snapshotMode, includeDiagnostics, doubleClick,
+            null, "window", false, cancellationToken);
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIFindTool.cs
@@ -40,6 +40,10 @@ public static partial class UIFindTool
     /// <param name="nearElement">Find elements near this elementId (results sorted by distance).</param>
     /// <param name="visibleOnly">Exclude off-screen elements. Default (unset): excluded for Chromium/Edge/Electron (which expose many hidden nodes), included elsewhere. Set false to include hidden nodes.</param>
     /// <param name="contentViewOnly">Scan only the leaner UI Automation content view (meaningful, user-facing elements) instead of the full control view. Default (unset): content view for Chromium/Edge/Electron (whose control view is bloated with structural nodes), control view elsewhere; automatically falls back to the control view if nothing is found. Set false to force the full control view.</param>
+    /// <param name="parentElementId">Limit the search to a known parent element from ui_find/ui_snapshot.</param>
+    /// <param name="scope">Search root: window (default) or active_dialog. Use active_dialog after opening a modal or native file dialog.</param>
+    /// <param name="requireUnique">Fail with ambiguity details when more than one element matches. Default: false.</param>
+    /// <param name="enabledOnly">Exclude disabled elements when true.</param>
     /// <param name="timeoutMs">Timeout in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -61,6 +65,10 @@ public static partial class UIFindTool
         [DefaultValue(null)] string? nearElement,
         [DefaultValue(null)] bool? visibleOnly,
         [DefaultValue(null)] bool? contentViewOnly,
+        [DefaultValue(null)] string? parentElementId,
+        [DefaultValue("window")] string? scope,
+        [DefaultValue(false)] bool requireUnique,
+        [DefaultValue(null)] bool? enabledOnly,
         [DefaultValue(5000)] int timeoutMs,
         [DefaultValue(false)] bool includeDiagnostics,
         CancellationToken cancellationToken)
@@ -98,6 +106,10 @@ public static partial class UIFindTool
                 NearElement = nearElement,
                 VisibleOnly = visibleOnly,
                 ContentViewOnly = contentViewOnly,
+                ParentElementId = parentElementId,
+                Scope = scope,
+                RequireUnique = requireUnique,
+                EnabledOnly = enabledOnly,
                 TimeoutMs = Math.Clamp(timeoutMs, 0, 60000)
             };
 
@@ -109,4 +121,48 @@ public static partial class UIFindTool
             return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
+
+    /// <summary>Compatibility overload for the original window-scoped find surface.</summary>
+    public static Task<CallToolResult> ExecuteAsync(
+        string windowHandle,
+        string? name,
+        string? nameContains,
+        string? namePattern,
+        string? controlType,
+        string? automationId,
+        string? className,
+        int? exactDepth,
+        int foundIndex,
+        bool includeChildren,
+        bool sortByProminence,
+        string? inRegion,
+        string? nearElement,
+        bool? visibleOnly,
+        bool? contentViewOnly,
+        int timeoutMs,
+        bool includeDiagnostics,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(
+            windowHandle,
+            name,
+            nameContains,
+            namePattern,
+            controlType,
+            automationId,
+            className,
+            exactDepth,
+            foundIndex,
+            includeChildren,
+            sortByProminence,
+            inRegion,
+            nearElement,
+            visibleOnly,
+            contentViewOnly,
+            null,
+            "window",
+            false,
+            null,
+            timeoutMs,
+            includeDiagnostics,
+            cancellationToken);
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIOpenFileTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIOpenFileTool.cs
@@ -28,6 +28,8 @@ public static partial class UIOpenFileTool
     /// <param name="windowHandle">Application window handle (from app or window_management 'find'). REQUIRED. Pass the APPLICATION window, not a dialog.</param>
     /// <param name="filePath">Absolute path of an existing file to open (e.g., C:/Users/User/doc.txt). Forward/back slashes both work. REQUIRED.</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
+    /// <param name="triggerMode">shortcut (default) sends Ctrl+O; wait only waits for a native Open dialog already triggered by a prior ui_click.</param>
+    /// <param name="timeoutMs">Maximum time to wait for the native dialog (default: 5000).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A call result containing a text content block with the JSON payload describing the open operation's success status. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "file_open", Title = "📂 OPEN FILE (handles Open dialogs)", Destructive = false, OpenWorld = false)]
@@ -35,6 +37,8 @@ public static partial class UIOpenFileTool
         string windowHandle,
         string filePath,
         [DefaultValue(false)] bool includeDiagnostics,
+        [DefaultValue("shortcut")] string triggerMode,
+        [DefaultValue(5000)] int timeoutMs,
         CancellationToken cancellationToken)
     {
         const string actionName = "open";
@@ -53,7 +57,12 @@ public static partial class UIOpenFileTool
 
         try
         {
-            var result = await WindowsToolsBase.UIAutomationService.OpenFileAsync(windowHandle, filePath, cancellationToken);
+            var result = await WindowsToolsBase.UIAutomationService.OpenFileAsync(
+                windowHandle,
+                filePath,
+                triggerMode,
+                timeoutMs,
+                cancellationToken);
             return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
         }
         catch (Exception ex)
@@ -61,4 +70,18 @@ public static partial class UIOpenFileTool
             return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
+
+    /// <summary>Compatibility overload using the Ctrl+O shortcut and default timeout.</summary>
+    public static Task<CallToolResult> ExecuteAsync(
+        string windowHandle,
+        string filePath,
+        bool includeDiagnostics,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(
+            windowHandle,
+            filePath,
+            includeDiagnostics,
+            "shortcut",
+            5000,
+            cancellationToken);
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UITypeTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UITypeTool.cs
@@ -39,6 +39,10 @@ public static partial class UITypeTool
     /// <param name="withSnapshot">When true, attach a post-action snapshot so you can verify the new state without another tool call. Default: false.</param>
     /// <param name="snapshotMode">Post-action snapshot mode when withSnapshot=true: full for one verification (default), auto for repeated checks of the same window, or reset when this action starts a new comparison.</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query, elements scanned) in response. Default: false.</param>
+    /// <param name="inputMode">Input path: auto (keyboard for Chromium/Electron, ValuePattern elsewhere), keyboard (normal focus/key events), or value (direct ValuePattern only).</param>
+    /// <param name="parentElementId">Limit selector search to a known parent element.</param>
+    /// <param name="scope">Search root: window (default) or active_dialog.</param>
+    /// <param name="requireUnique">Fail with ambiguity details instead of choosing the first match. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A call result containing a text content block with the JSON payload describing the type operation's success status and element information. <c>IsError</c> reflects operation success.</returns>
     [McpServerTool(Name = "ui_type", Title = "Type Text into Element", Destructive = true, OpenWorld = false)]
@@ -57,6 +61,10 @@ public static partial class UITypeTool
         [DefaultValue(false)] bool withSnapshot,
         [DefaultValue("full")] string snapshotMode,
         [DefaultValue(false)] bool includeDiagnostics,
+        [DefaultValue("auto")] string inputMode,
+        [DefaultValue(null)] string? parentElementId,
+        [DefaultValue("window")] string? scope,
+        [DefaultValue(false)] bool requireUnique,
         CancellationToken cancellationToken)
     {
         const string actionName = "type";
@@ -88,7 +96,8 @@ public static partial class UITypeTool
         {
             if (!string.IsNullOrWhiteSpace(elementId))
             {
-                var byIdResult = await WindowsToolsBase.UIAutomationService.TypeIntoElementAsync(elementId, text, clearFirst, windowHandle, cancellationToken);
+                var byIdResult = await WindowsToolsBase.UIAutomationService.TypeIntoElementAsync(
+                    elementId, text, clearFirst, windowHandle, inputMode, cancellationToken);
                 byIdResult = await WindowsToolsBase.WithPostActionSnapshotAsync(
                     byIdResult, windowHandle, withSnapshot, parsedSnapshotMode, cancellationToken);
                 return WindowsToolsBase.ToCallToolResult(byIdResult, includeDiagnostics);
@@ -103,10 +112,14 @@ public static partial class UITypeTool
                 ControlType = controlType,
                 AutomationId = automationId,
                 ClassName = className,
+                ParentElementId = parentElementId,
+                Scope = scope,
+                RequireUnique = requireUnique,
                 FoundIndex = Math.Max(1, foundIndex)
             };
 
-            var result = await WindowsToolsBase.UIAutomationService.FindAndTypeAsync(query, text, clearFirst, cancellationToken);
+            var result = await WindowsToolsBase.UIAutomationService.FindAndTypeAsync(
+                query, text, clearFirst, inputMode, cancellationToken);
             result = await WindowsToolsBase.WithPostActionSnapshotAsync(
                 result, windowHandle, withSnapshot, parsedSnapshotMode, cancellationToken);
             return WindowsToolsBase.ToCallToolResult(result, includeDiagnostics);
@@ -136,5 +149,28 @@ public static partial class UITypeTool
         ExecuteAsync(
             windowHandle, text, name, nameContains, namePattern, controlType, automationId, className,
             elementId, foundIndex, clearFirst, withSnapshot, "full", includeDiagnostics,
+            "auto", null, "window", false,
             cancellationToken);
+
+    /// <summary>Compatibility overload preserving explicit snapshotMode.</summary>
+    public static Task<CallToolResult> ExecuteAsync(
+        string windowHandle,
+        string text,
+        string? name,
+        string? nameContains,
+        string? namePattern,
+        string? controlType,
+        string? automationId,
+        string? className,
+        string? elementId,
+        int foundIndex,
+        bool clearFirst,
+        bool withSnapshot,
+        string snapshotMode,
+        bool includeDiagnostics,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(
+            windowHandle, text, name, nameContains, namePattern, controlType, automationId, className,
+            elementId, foundIndex, clearFirst, withSnapshot, snapshotMode, includeDiagnostics,
+            "auto", null, "window", false, cancellationToken);
 }

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIWaitTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIWaitTool.cs
@@ -40,7 +40,7 @@ public static partial class UIWaitTool
     /// <param name="className">Element class name.</param>
     /// <param name="parentElementId">Limit appear/disappear search to a known parent element.</param>
     /// <param name="scope">Search root: window (default) or active_dialog.</param>
-    /// <param name="requireUnique">For appear, fail if more than one element matches.</param>
+    /// <param name="requireUnique">For appear or disappear, fail if more than one element matches.</param>
     /// <param name="enabledOnly">Exclude disabled elements when true.</param>
     /// <param name="timeoutMs">Maximum time to wait in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query) in response. Default: false.</param>

--- a/src/Sbroenne.WindowsMcp/Automation/Tools/UIWaitTool.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/Tools/UIWaitTool.cs
@@ -38,6 +38,10 @@ public static partial class UIWaitTool
     /// <param name="controlType">Control type (Button, Edit, Window, etc.)</param>
     /// <param name="automationId">AutomationId for precise matching.</param>
     /// <param name="className">Element class name.</param>
+    /// <param name="parentElementId">Limit appear/disappear search to a known parent element.</param>
+    /// <param name="scope">Search root: window (default) or active_dialog.</param>
+    /// <param name="requireUnique">For appear, fail if more than one element matches.</param>
+    /// <param name="enabledOnly">Exclude disabled elements when true.</param>
     /// <param name="timeoutMs">Maximum time to wait in milliseconds (default: 5000).</param>
     /// <param name="includeDiagnostics">Include diagnostics (timing, query) in response. Default: false.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -54,6 +58,10 @@ public static partial class UIWaitTool
         [DefaultValue(null)] string? controlType,
         [DefaultValue(null)] string? automationId,
         [DefaultValue(null)] string? className,
+        [DefaultValue(null)] string? parentElementId,
+        [DefaultValue("window")] string? scope,
+        [DefaultValue(false)] bool requireUnique,
+        [DefaultValue(null)] bool? enabledOnly,
         [DefaultValue(5000)] int timeoutMs,
         [DefaultValue(false)] bool includeDiagnostics,
         CancellationToken cancellationToken)
@@ -111,7 +119,11 @@ public static partial class UIWaitTool
                 NamePattern = namePattern,
                 ControlType = controlType,
                 AutomationId = automationId,
-                ClassName = className
+                ClassName = className,
+                ParentElementId = parentElementId,
+                Scope = scope,
+                RequireUnique = requireUnique,
+                EnabledOnly = enabledOnly
             };
 
             var result = normalizedMode == "appear"
@@ -125,4 +137,24 @@ public static partial class UIWaitTool
             return WindowsToolsBase.ErrorCallToolResult(actionName, ex);
         }
     }
+
+    /// <summary>Compatibility overload for callers using the original wait signature.</summary>
+    public static Task<CallToolResult> ExecuteAsync(
+        string? windowHandle,
+        string? mode,
+        string? elementId,
+        string? desiredState,
+        string? name,
+        string? nameContains,
+        string? namePattern,
+        string? controlType,
+        string? automationId,
+        string? className,
+        int timeoutMs,
+        bool includeDiagnostics,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(
+            windowHandle, mode, elementId, desiredState, name, nameContains, namePattern,
+            controlType, automationId, className, null, "window", false, null, timeoutMs,
+            includeDiagnostics, cancellationToken);
 }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.ActionExecution.cs
@@ -15,7 +15,8 @@ public sealed partial class UIAutomationService
     private readonly record struct ElementActionOutcome(
         bool Success,
         bool ElementUnavailable = false,
-        string? ErrorMessage = null);
+        string? ErrorMessage = null,
+        string? ActionPath = null);
 
     private readonly record struct ElementActionState(
         int ControlType,
@@ -131,7 +132,7 @@ public sealed partial class UIAutomationService
                     cancellationToken);
                 if (verified.Observed)
                 {
-                    return new ElementActionOutcome(true, verified.ElementUnavailable);
+                    return new ElementActionOutcome(true, verified.ElementUnavailable, ActionPath: "semantic_toggle");
                 }
 
                 return new ElementActionOutcome(
@@ -147,7 +148,7 @@ public sealed partial class UIAutomationService
                     cancellationToken);
                 if (verified.Observed)
                 {
-                    return new ElementActionOutcome(true, verified.ElementUnavailable);
+                    return new ElementActionOutcome(true, verified.ElementUnavailable, ActionPath: "semantic_select");
                 }
 
                 if (initial.ControlType == UIA3ControlTypeIds.RadioButton)
@@ -175,26 +176,40 @@ public sealed partial class UIAutomationService
 
             // Invoke has no universal state postcondition. A successful provider call is the
             // observable completion signal; do not fabricate a state that the provider lacks.
-            return new ElementActionOutcome(true);
+            return new ElementActionOutcome(true, ActionPath: "semantic_invoke");
         }
 
-        var clickablePoint = await _staThread.ExecuteAsync(
+        var physicalTarget = await _staThread.ExecuteAsync(
             () =>
             {
-                TryActivateWindowForElement(element, windowHandle: null);
-                return GetClickablePointForClick(element) ?? fallbackClickPoint;
+                var activated = ActivateWindowForElement(element, windowHandle: null);
+                return (
+                    Point: GetClickablePointForClick(element) ?? fallbackClickPoint,
+                    WindowHandle: ResolveElementWindowHandle(element),
+                    Activated: activated);
             },
             cancellationToken);
-        if (!clickablePoint.HasValue)
+        if (!physicalTarget.Point.HasValue)
         {
             return new ElementActionOutcome(
                 false,
                 ErrorMessage: $"Element (ControlType={UIA3ControlTypeIds.ToName(initial.ControlType)}) cannot be clicked: semantic pattern unavailable and no clickable point is available.");
         }
 
+        if (!physicalTarget.Activated ||
+            !IsExpectedForegroundWindow(physicalTarget.WindowHandle))
+        {
+            return new ElementActionOutcome(
+                false,
+                ErrorMessage: "The element's window could not be confirmed as foreground, so the physical click was not sent.",
+                ActionPath: "physical_click");
+        }
+
         var clickResult = await _mouseService.ClickAsync(
-            clickablePoint.Value.X,
-            clickablePoint.Value.Y,
+            physicalTarget.Point.Value.X,
+            physicalTarget.Point.Value.Y,
+            ModifierKey.None,
+            physicalTarget.WindowHandle,
             cancellationToken: cancellationToken);
         if (!clickResult.Success)
         {
@@ -210,7 +225,7 @@ public sealed partial class UIAutomationService
             cancellationToken);
 
         return physicalOutcome.Observed
-            ? new ElementActionOutcome(true, physicalOutcome.ElementUnavailable)
+            ? new ElementActionOutcome(true, physicalOutcome.ElementUnavailable, ActionPath: "physical_click")
             : new ElementActionOutcome(
                 false,
                 ErrorMessage: semanticAttempted

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -1372,7 +1372,17 @@ public sealed partial class UIAutomationService
                     "double_click",
                     UIAutomationErrorType.ElementStale,
                     $"Element with ID '{elementId}' is stale. Refresh UI state before double-clicking.",
-                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, Initial: default(ElementActionState));
+                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, WindowHandle: IntPtr.Zero, Initial: default(ElementActionState));
+            }
+
+            var elementWindowHandle = ResolveElementWindowHandle(element);
+            if (!IsRequestedWindowHandleCompatible(elementWindowHandle, activationHandle))
+            {
+                return (Failure: UIAutomationResult.CreateFailure(
+                    "double_click",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The resolved element no longer belongs to the requested window.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, WindowHandle: IntPtr.Zero, Initial: default(ElementActionState));
             }
 
             // A double-click is always physical input, so a window that could not be brought to the foreground
@@ -1384,7 +1394,7 @@ public sealed partial class UIAutomationService
                     UIAutomationErrorType.WindowNotFound,
                     "The element's window could not be activated and confirmed as the foreground window, so the double-click was not sent. " +
                     "Activate the window first with window_management(action='activate') and retry.",
-                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, Initial: default(ElementActionState));
+                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, WindowHandle: IntPtr.Zero, Initial: default(ElementActionState));
             }
 
             if (!element.IsEnabled())
@@ -1394,7 +1404,17 @@ public sealed partial class UIAutomationService
                     UIAutomationErrorType.InvalidParameter,
                     $"Element with ID '{elementId}' is disabled and cannot be double-clicked. " +
                     "Wait for it to become enabled (e.g., after filling required fields) or target a different element.",
-                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, Initial: default(ElementActionState));
+                    CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, WindowHandle: IntPtr.Zero, Initial: default(ElementActionState));
+            }
+
+            if (element.IsOffscreen())
+            {
+                return (Failure: UIAutomationResult.CreateFailure(
+                    "double_click",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Element with ID '{elementId}' is off-screen and cannot be safely double-clicked. " +
+                    "Refresh the UI state, scroll it into view, or target the active dialog.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, WindowHandle: IntPtr.Zero, Initial: default(ElementActionState));
             }
 
             var root = GetRootElementForScroll(element);
@@ -1405,7 +1425,7 @@ public sealed partial class UIAutomationService
                 GetElementState(element),
                 GetObservableFingerprint(root));
 
-            return (Failure: (UIAutomationResult?)null, Element: element, Root: root, Point: GetPhysicalClickPoint(element) ?? fallbackClickPoint, Initial: initial);
+            return (Failure: (UIAutomationResult?)null, Element: element, Root: root, Point: GetPhysicalClickPoint(element) ?? fallbackClickPoint, WindowHandle: elementWindowHandle, Initial: initial);
         }, cancellationToken);
 
         if (prepared.Failure != null)
@@ -1425,7 +1445,9 @@ public sealed partial class UIAutomationService
         var clickResult = await _mouseService.DoubleClickAsync(
             prepared.Point.Value.X,
             prepared.Point.Value.Y,
-            cancellationToken: cancellationToken);
+            ModifierKey.None,
+            prepared.WindowHandle,
+            cancellationToken);
         if (!clickResult.Success)
         {
             return UIAutomationResult.CreateFailure(

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -38,14 +38,19 @@ public sealed partial class UIAutomationService
 
         try
         {
-            var findResult = await FindElementsAsync(query, cancellationToken);
+            var actionQuery = query with
+            {
+                VisibleOnly = query.VisibleOnly ?? true,
+                EnabledOnly = query.EnabledOnly ?? true
+            };
+            var findResult = await FindElementsAsync(actionQuery, cancellationToken);
             if (!findResult.Success || findResult.Items == null || findResult.Items.Length == 0)
             {
                 return UIAutomationResult.CreateFailure(
                     "click",
-                    UIAutomationErrorType.ElementNotFound,
+                    findResult.ErrorType ?? UIAutomationErrorType.ElementNotFound,
                     findResult.ErrorMessage ?? "Element not found.",
-                    CreateDiagnostics(stopwatch));
+                    findResult.Diagnostics ?? CreateDiagnostics(stopwatch, actionQuery));
             }
 
             var targetElement = findResult.Items[0];
@@ -106,14 +111,24 @@ public sealed partial class UIAutomationService
 
         var prepared = await _staThread.ExecuteAsync(() =>
         {
-            var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+            var element = ElementIdGenerator.ResolveToAutomationElement(elementId, allowSelectorFallback: false);
             if (element == null)
             {
                 return (Failure: UIAutomationResult.CreateFailure(
                     "click",
-                    UIAutomationErrorType.ElementNotFound,
-                    $"Element with ID '{elementId}' could not be resolved.",
+                    UIAutomationErrorType.ElementStale,
+                    $"Element with ID '{elementId}' is stale and was not retargeted by name.",
                     CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null);
+            }
+
+            var elementWindowHandle = ResolveElementWindowHandle(element);
+            if (!IsRequestedWindowHandleCompatible(elementWindowHandle, activationHandle))
+            {
+                return (Failure: UIAutomationResult.CreateFailure(
+                    "click",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The resolved element no longer belongs to the requested window.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null);
             }
 
             TryActivateWindowForElement(element, activationHandle);
@@ -125,6 +140,16 @@ public sealed partial class UIAutomationService
                     $"Element with ID '{elementId}' is disabled and cannot be clicked. " +
                     "Wait for it to become enabled (e.g., after filling required fields) or target a different element.",
                     CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null);
+            }
+
+            if (element.IsOffscreen())
+            {
+                return (Failure: UIAutomationResult.CreateFailure(
+                    "click",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Element with ID '{elementId}' is off-screen and cannot be safely clicked. " +
+                    "Refresh the UI state, scroll it into view, or target the active dialog.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null);
             }
 
             return (Failure: (UIAutomationResult?)null, Element: element, Root: GetRootElementForScroll(element));
@@ -146,7 +171,10 @@ public sealed partial class UIAutomationService
                 "click",
                 UIAutomationErrorType.PatternNotSupported,
                 outcome.ErrorMessage ?? "The element action could not be completed.",
-                CreateDiagnostics(stopwatch));
+                CreateActionDiagnostics(
+                    stopwatch,
+                    prepared.Element,
+                    outcome.ActionPath ?? "unverified"));
         }
 
         return await _staThread.ExecuteAsync(() =>
@@ -158,16 +186,44 @@ public sealed partial class UIAutomationService
                 ? UIAutomationResult.CreateSuccessWithHint(
                     "click",
                     "Click succeeded. Element closed or changed its parent window or dialog.",
-                    CreateDiagnostics(stopwatch))
-                : UIAutomationResult.CreateSuccessCompact("click", [info], CreateDiagnostics(stopwatch));
+                    CreateActionDiagnostics(stopwatch, prepared.Element, outcome.ActionPath ?? "unknown"))
+                : UIAutomationResult.CreateSuccessCompact(
+                    "click",
+                    [info],
+                    CreateActionDiagnostics(stopwatch, prepared.Element, outcome.ActionPath ?? "unknown"));
         }, cancellationToken);
     }
 
     /// <inheritdoc/>
-    public async Task<UIAutomationResult> FindAndTypeAsync(ElementQuery query, string text, bool clearFirst, CancellationToken cancellationToken = default)
+    public Task<UIAutomationResult> FindAndTypeAsync(
+        ElementQuery query,
+        string text,
+        bool clearFirst,
+        CancellationToken cancellationToken = default) =>
+        FindAndTypeAsync(query, text, clearFirst, "auto", cancellationToken);
+
+    /// <summary>
+    /// Finds a text control and enters text using auto, value, or keyboard input.
+    /// Auto prefers keyboard input for Chromium/Electron so web frameworks receive normal events.
+    /// </summary>
+    public async Task<UIAutomationResult> FindAndTypeAsync(
+        ElementQuery query,
+        string text,
+        bool clearFirst,
+        string inputMode,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
         var stopwatch = Stopwatch.StartNew();
+
+        if (!TryNormalizeInputMode(inputMode, out var normalizedInputMode))
+        {
+            return UIAutomationResult.CreateFailure(
+                "type",
+                UIAutomationErrorType.InvalidParameter,
+                $"Invalid inputMode '{inputMode}'. Valid values: auto, keyboard, value.",
+                CreateDiagnostics(stopwatch, query));
+        }
 
         // Normalize Windows file paths: convert forward slashes to backslashes
         // This handles paths like "D:/folder/file.txt" → "D:\folder\file.txt"
@@ -181,7 +237,12 @@ public sealed partial class UIAutomationService
 
             foreach (var searchQuery in searchQueries)
             {
-                var findResult = await FindElementsAsync(searchQuery, cancellationToken);
+                var actionQuery = searchQuery with
+                {
+                    VisibleOnly = searchQuery.VisibleOnly ?? true,
+                    EnabledOnly = searchQuery.EnabledOnly ?? true
+                };
+                var findResult = await FindElementsAsync(actionQuery, cancellationToken);
                 lastResult = findResult;
 
                 if (findResult.Success && findResult.Items is { Length: > 0 })
@@ -189,7 +250,19 @@ public sealed partial class UIAutomationService
                     var targetElement = findResult.Items[0];
                     var elementId = targetElement.Id;
 
-                    return await PerformTypeAsync(elementId, text, clearFirst, searchQuery.WindowHandle, stopwatch, cancellationToken);
+                    return await PerformTypeAsync(
+                        elementId,
+                        text,
+                        clearFirst,
+                        normalizedInputMode,
+                        actionQuery.WindowHandle,
+                        stopwatch,
+                        cancellationToken);
+                }
+
+                if (findResult.ErrorType is not null and not UIAutomationErrorType.ElementNotFound)
+                {
+                    return findResult with { Action = "type" };
                 }
             }
 
@@ -230,17 +303,50 @@ public sealed partial class UIAutomationService
     /// (from ui_find/ui_snapshot), skipping the find step. Useful for reusing a known element
     /// across multiple actions without re-querying.
     /// </summary>
-    public async Task<UIAutomationResult> TypeIntoElementAsync(string elementId, string text, bool clearFirst, string? windowHandle, CancellationToken cancellationToken = default)
+    public Task<UIAutomationResult> TypeIntoElementAsync(
+        string elementId,
+        string text,
+        bool clearFirst,
+        string? windowHandle,
+        CancellationToken cancellationToken = default) =>
+        TypeIntoElementAsync(elementId, text, clearFirst, windowHandle, "auto", cancellationToken);
+
+    /// <summary>
+    /// Types into a previously discovered element using auto, value, or keyboard input.
+    /// </summary>
+    public async Task<UIAutomationResult> TypeIntoElementAsync(
+        string elementId,
+        string text,
+        bool clearFirst,
+        string? windowHandle,
+        string inputMode,
+        CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(elementId);
         var stopwatch = Stopwatch.StartNew();
+
+        if (!TryNormalizeInputMode(inputMode, out var normalizedInputMode))
+        {
+            return UIAutomationResult.CreateFailure(
+                "type",
+                UIAutomationErrorType.InvalidParameter,
+                $"Invalid inputMode '{inputMode}'. Valid values: auto, keyboard, value.",
+                CreateDiagnostics(stopwatch));
+        }
 
         // Normalize Windows file paths for consistency with FindAndTypeAsync.
         text = PathNormalizer.NormalizeWindowsPath(text);
 
         try
         {
-            return await PerformTypeAsync(elementId, text, clearFirst, windowHandle, stopwatch, cancellationToken);
+            return await PerformTypeAsync(
+                elementId,
+                text,
+                clearFirst,
+                normalizedInputMode,
+                windowHandle,
+                stopwatch,
+                cancellationToken);
         }
         catch (COMException ex)
         {
@@ -286,19 +392,27 @@ public sealed partial class UIAutomationService
         return queries;
     }
 
-    private async Task<UIAutomationResult> PerformTypeAsync(string elementId, string text, bool clearFirst, string? windowHandle, Stopwatch stopwatch, CancellationToken cancellationToken)
+    private async Task<UIAutomationResult> PerformTypeAsync(
+        string elementId,
+        string text,
+        bool clearFirst,
+        string inputMode,
+        string? windowHandle,
+        Stopwatch stopwatch,
+        CancellationToken cancellationToken)
     {
-        // First phase: resolve element and try ValuePattern (on STA thread)
         var staResult = await _staThread.ExecuteAsync(() =>
         {
-            var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+            var element = ElementIdGenerator.ResolveToAutomationElement(
+                elementId,
+                allowSelectorFallback: false);
             if (element == null)
             {
                 return (Success: false, Result: UIAutomationResult.CreateFailure(
                     "type",
-                    UIAutomationErrorType.ElementNotFound,
-                    $"Element with ID '{elementId}' could not be resolved.",
-                    CreateDiagnostics(stopwatch)), ValuePatternSucceeded: false, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    UIAutomationErrorType.ElementStale,
+                    $"Element with ID '{elementId}' is stale and was not retargeted by name.",
+                    CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
             nint? activationHandle = null;
@@ -310,16 +424,22 @@ public sealed partial class UIAutomationService
                         "type",
                         UIAutomationErrorType.InvalidParameter,
                         $"Invalid windowHandle '{windowHandle}'. Expected decimal string from window_management(handle).",
-                        CreateDiagnostics(stopwatch)), ValuePatternSucceeded: false, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                        CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                 }
 
                 activationHandle = parsedHandle;
             }
 
-            // Ensure window is activated before typing
-            TryActivateWindowForElement(element, activationHandle);
+            var elementWindowHandle = ResolveElementWindowHandle(element);
+            if (!IsRequestedWindowHandleCompatible(elementWindowHandle, activationHandle))
+            {
+                return (Success: false, Result: UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The resolved element no longer belongs to the requested window.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+            }
 
-            // Actionability gate: a disabled field cannot receive text. Fail fast with guidance.
             if (!element.IsEnabled())
             {
                 return (Success: false, Result: UIAutomationResult.CreateFailure(
@@ -327,79 +447,94 @@ public sealed partial class UIAutomationService
                     UIAutomationErrorType.InvalidParameter,
                     $"Element with ID '{elementId}' is disabled and cannot receive text. " +
                     "Wait for it to become enabled or target a different field.",
-                    CreateDiagnostics(stopwatch)), ValuePatternSucceeded: false, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
-            // Try to set focus
-            element.TrySetFocus();
+            if (element.IsOffscreen())
+            {
+                return (Success: false, Result: UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Element with ID '{elementId}' is off-screen and cannot safely receive input. " +
+                    "Refresh the UI state, scroll it into view, or target the active dialog.",
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+            }
 
             var rootElement = GetRootElementForScroll(element);
+            var isPassword = element.CurrentIsPassword != 0;
+            var initialValue = ReadEditableValue(element);
+            var detectedFramework = DetectFramework(rootElement);
+            var useKeyboard = inputMode == "keyboard" ||
+                (inputMode == "auto" &&
+                 string.Equals(detectedFramework, "Chromium/Electron", StringComparison.Ordinal));
 
-            // Try ValuePattern first - need to clear manually if clearFirst
-            if (clearFirst)
+            if (!useKeyboard)
             {
-                // Try to clear via ValuePattern
-                if (element.TrySetValue(""))
+                if (clearFirst && !element.TrySetValue(""))
                 {
-                    // Then set new value
-                    if (element.TrySetValue(text))
-                    {
-                        var info = ConvertToElementInfo(element, rootElement, _coordinateConverter);
-                        if (info == null)
-                        {
-                            // Type succeeded but element became unavailable (e.g., dialog closed).
-                            // This is expected behavior for text fields that close their parent window.
-                            return (Success: true, Result: UIAutomationResult.CreateSuccessWithHint("type", "Type succeeded. Element closed its parent window.", CreateDiagnostics(stopwatch)), ValuePatternSucceeded: true, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
-                        }
-                        return (Success: true, Result: UIAutomationResult.CreateSuccessCompact("type", [info], CreateDiagnostics(stopwatch)), ValuePatternSucceeded: true, Element: element, RootElement: rootElement);
-                    }
+                    useKeyboard = inputMode == "auto";
                 }
-            }
-            else
-            {
-                if (element.TrySetValue(text))
+
+                if (!useKeyboard && element.TrySetValue(text))
                 {
                     var info = ConvertToElementInfo(element, rootElement, _coordinateConverter);
                     if (info == null)
                     {
-                        // Type succeeded but element became unavailable (e.g., dialog closed).
-                        // This is expected behavior for text fields that close their parent window.
-                        return (Success: true, Result: UIAutomationResult.CreateSuccessWithHint("type", "Type succeeded. Element closed its parent window.", CreateDiagnostics(stopwatch)), ValuePatternSucceeded: true, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                        return (Success: true, Result: UIAutomationResult.CreateSuccessWithHint(
+                            "type",
+                            "Type succeeded. Element closed its parent window.",
+                            CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                     }
-                    return (Success: true, Result: UIAutomationResult.CreateSuccessCompact("type", [info], CreateDiagnostics(stopwatch)), ValuePatternSucceeded: true, Element: element, RootElement: rootElement);
+
+                    return (Success: true, Result: UIAutomationResult.CreateSuccessCompact(
+                        "type",
+                        [info],
+                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: element, RootElement: rootElement);
+                }
+
+                if (!useKeyboard && inputMode == "auto")
+                {
+                    useKeyboard = true;
+                }
+
+                if (!useKeyboard)
+                {
+                    return (Success: false, Result: UIAutomationResult.CreateFailure(
+                        "type",
+                        UIAutomationErrorType.PatternNotSupported,
+                        "The element did not accept ValuePattern input. Use inputMode='keyboard' to emit normal focus and keyboard events.",
+                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                 }
             }
 
-            // Need to fall back to keyboard input
-            return (Success: true, Result: (UIAutomationResult?)null, ValuePatternSucceeded: false, Element: element, RootElement: rootElement);
+            // Request foreground activation, but use the target element's actual keyboard-focus
+            // state below as the final safety gate. Some UI providers can focus correctly even when
+            // GetForegroundWindow is unavailable to the automation process.
+            _ = ActivateWindowForElement(element, activationHandle);
+            element.TrySetFocus();
+            return (Success: true, Result: (UIAutomationResult?)null, UseKeyboard: true, IsPassword: isPassword, InitialValue: initialValue, Element: element, RootElement: rootElement);
         }, cancellationToken);
 
-        // Check if we already have a result (success or element not found)
         if (!staResult.Success)
         {
             return staResult.Result!;
         }
 
-        if (staResult.ValuePatternSucceeded)
+        if (!staResult.UseKeyboard)
         {
             if (staResult.Element == null)
             {
                 return staResult.Result!;
             }
 
-            var isPassword = await _staThread.ExecuteAsync(
-                () => staResult.Element.CurrentIsPassword != 0,
-                cancellationToken);
-            if (isPassword)
+            if (staResult.IsPassword)
             {
-                // UIA intentionally does not expose password values. The successful provider
-                // SetValue call is the strongest observable completion signal available.
                 return staResult.Result!;
             }
 
             var verified = await WaitForElementConditionAsync(
                 staResult.Element,
-                () => string.Equals(staResult.Element.TryGetValue(), text, StringComparison.Ordinal),
+                () => string.Equals(ReadEditableValue(staResult.Element), text, StringComparison.Ordinal),
                 cancellationToken);
             if (verified.Observed)
             {
@@ -410,31 +545,182 @@ public sealed partial class UIAutomationService
                 "type",
                 UIAutomationErrorType.PatternNotSupported,
                 "ValuePattern accepted the text, but the requested value was not observable before the bounded timeout.",
-                CreateDiagnostics(stopwatch));
+                CreateActionDiagnostics(stopwatch, staResult.Element, "value_pattern"));
         }
 
-        // Fall back to keyboard input (outside STA thread)
+        var expectedWindowHandle = await _staThread.ExecuteAsync(
+            () => ResolveElementWindowHandle(staResult.Element!),
+            cancellationToken);
+        if (!IsExpectedForegroundWindow(expectedWindowHandle))
+        {
+            return UIAutomationResult.CreateFailure(
+                "type",
+                UIAutomationErrorType.WrongTargetWindow,
+                "The target window is not foreground, so no keyboard input was sent.",
+                CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+        }
+
+        var focusReady = await WaitForElementConditionAsync(
+            staResult.Element!,
+            () => staResult.Element!.CurrentHasKeyboardFocus != 0,
+            cancellationToken,
+            TimeSpan.FromMilliseconds(750));
+        if (!focusReady.Observed)
+        {
+            var clickPoint = await _staThread.ExecuteAsync(
+                () => GetPhysicalClickPoint(staResult.Element!),
+                cancellationToken);
+            if (clickPoint.HasValue)
+            {
+                if (!IsExpectedForegroundWindow(expectedWindowHandle))
+                {
+                    return UIAutomationResult.CreateFailure(
+                        "type",
+                        UIAutomationErrorType.WrongTargetWindow,
+                        "The target window lost foreground ownership before the focus click.",
+                        CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+                }
+
+                var click = await _mouseService.ClickAsync(
+                    clickPoint.Value.X,
+                    clickPoint.Value.Y,
+                    ModifierKey.None,
+                    expectedWindowHandle,
+                    cancellationToken: cancellationToken);
+                if (!click.Success)
+                {
+                    return UIAutomationResult.CreateFailure(
+                        "type",
+                        UIAutomationErrorType.WrongTargetWindow,
+                        "The text field could not be focused before keyboard input.",
+                        CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+                }
+            }
+
+            focusReady = await WaitForElementConditionAsync(
+                staResult.Element!,
+                () => staResult.Element!.CurrentHasKeyboardFocus != 0,
+                cancellationToken,
+                TimeSpan.FromMilliseconds(750));
+            if (!focusReady.Observed)
+            {
+                return UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The text field did not obtain keyboard focus, so no text was sent.",
+                    CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+            }
+        }
+
         if (clearFirst)
         {
-            await _keyboardService.PressKeyAsync("a", ModifierKey.Ctrl, 1, cancellationToken);
+            if (!IsExpectedForegroundWindow(expectedWindowHandle))
+            {
+                return UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The target window lost foreground ownership before clearing the field.",
+                    CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+            }
+
+            await _keyboardService.PressKeyAsync(
+                "a",
+                ModifierKey.Ctrl,
+                1,
+                expectedWindowHandle,
+                cancellationToken);
+            _ = await _keyboardService.WaitForIdleAsync(cancellationToken);
+            if (!IsExpectedForegroundWindow(expectedWindowHandle))
+            {
+                return UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The target window lost foreground ownership while clearing the field.",
+                    CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+            }
+
+            await _keyboardService.PressKeyAsync(
+                "Delete",
+                ModifierKey.None,
+                1,
+                expectedWindowHandle,
+                cancellationToken);
             _ = await _keyboardService.WaitForIdleAsync(cancellationToken);
         }
 
-        await _keyboardService.TypeTextAsync(text, cancellationToken);
+        if (!IsExpectedForegroundWindow(expectedWindowHandle))
+        {
+            return UIAutomationResult.CreateFailure(
+                "type",
+                UIAutomationErrorType.WrongTargetWindow,
+                "The target window lost foreground ownership before text input.",
+                CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+        }
 
-        // Get final element info (on STA thread)
+        var keyboardResult = await _keyboardService.TypeTextAsync(
+            text,
+            expectedWindowHandle,
+            cancellationToken);
+        if (!keyboardResult.Success)
+        {
+            return UIAutomationResult.CreateFailure(
+                "type",
+                UIAutomationErrorType.InternalError,
+                keyboardResult.Error ?? "Keyboard input failed.",
+                CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+        }
+
+        if (!staResult.IsPassword)
+        {
+            var observed = await WaitForElementConditionAsync(
+                staResult.Element!,
+                () =>
+                {
+                    var current = ReadEditableValue(staResult.Element!);
+                    return clearFirst
+                        ? string.Equals(current, text, StringComparison.Ordinal)
+                        : !string.Equals(current, staResult.InitialValue, StringComparison.Ordinal) &&
+                          (current?.Contains(text, StringComparison.Ordinal) == true);
+                },
+                cancellationToken);
+            if (!observed.Observed)
+            {
+                return UIAutomationResult.CreateFailure(
+                    "type",
+                    UIAutomationErrorType.PatternNotSupported,
+                    "Keyboard input was sent, but the requested text change was not observable. " +
+                    "Refresh the UI state and verify the field still has focus.",
+                    CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
+            }
+        }
+
         return await _staThread.ExecuteAsync(() =>
         {
             var info = ConvertToElementInfo(staResult.Element!, staResult.RootElement!, _coordinateConverter);
             if (info == null)
             {
-                // Type succeeded but element became unavailable (e.g., dialog closed).
-                // This is expected behavior for text fields that close their parent window.
-                return UIAutomationResult.CreateSuccessWithHint("type", "Type succeeded. Element closed its parent window.", CreateDiagnostics(stopwatch));
+                return UIAutomationResult.CreateSuccessWithHint(
+                    "type",
+                    "Type succeeded. Element closed its parent window.",
+                    CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
             }
-            return UIAutomationResult.CreateSuccessCompact("type", [info], CreateDiagnostics(stopwatch));
+            return UIAutomationResult.CreateSuccessCompact(
+                "type",
+                [info],
+                CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
         }, cancellationToken);
     }
+
+    private static bool TryNormalizeInputMode(string? inputMode, out string normalized)
+    {
+        normalized = string.IsNullOrWhiteSpace(inputMode)
+            ? "auto"
+            : inputMode.Trim().ToLowerInvariant();
+        return normalized is "auto" or "keyboard" or "value";
+    }
+
+    private static string? ReadEditableValue(UIA.IUIAutomationElement element) =>
+        element.TryGetValue() ?? element.GetText();
 
     /// <inheritdoc/>
     public async Task<UIAutomationResult> FindAndSelectAsync(ElementQuery query, string value, CancellationToken cancellationToken = default)
@@ -483,13 +769,15 @@ public sealed partial class UIAutomationService
     {
         return await _staThread.ExecuteAsync(() =>
         {
-            var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+            var element = ElementIdGenerator.ResolveToAutomationElement(
+                elementId,
+                allowSelectorFallback: false);
             if (element == null)
             {
                 return UIAutomationResult.CreateFailure(
                     "select",
-                    UIAutomationErrorType.ElementNotFound,
-                    $"Element with ID '{elementId}' could not be resolved.",
+                    UIAutomationErrorType.ElementStale,
+                    $"Element with ID '{elementId}' is stale. Refresh UI state before selecting.",
                     CreateDiagnostics(stopwatch));
             }
 
@@ -508,7 +796,27 @@ public sealed partial class UIAutomationService
                 activationHandle = parsedHandle;
             }
 
-            // Ensure window is activated
+            var elementWindowHandle = ResolveElementWindowHandle(element);
+            if (!IsRequestedWindowHandleCompatible(elementWindowHandle, activationHandle))
+            {
+                return UIAutomationResult.CreateFailure(
+                    "select",
+                    UIAutomationErrorType.WrongTargetWindow,
+                    "The resolved element does not belong to the requested window or one of its owned dialogs.",
+                    CreateActionDiagnostics(stopwatch, element, "selection_pattern"));
+            }
+
+            if (!element.IsEnabled() || element.CurrentIsOffscreen != 0)
+            {
+                return UIAutomationResult.CreateFailure(
+                    "select",
+                    UIAutomationErrorType.ElementStale,
+                    "The resolved element is no longer visible and enabled. Refresh UI state before selecting.",
+                    CreateActionDiagnostics(stopwatch, element, "selection_pattern"));
+            }
+
+            // Selection patterns are semantic UIA actions, so foreground activation is best effort.
+            // Only physical keyboard or mouse injection must require foreground confirmation.
             TryActivateWindowForElement(element, activationHandle);
 
             var rootElement = GetRootElementForScroll(element);
@@ -647,7 +955,20 @@ public sealed partial class UIAutomationService
         var requestedRoot = NativeMethods.GetAncestor(requestedWindowHandle.Value, NativeConstants.GA_ROOT);
         if (elementRoot != IntPtr.Zero && requestedRoot != IntPtr.Zero)
         {
-            return elementRoot == requestedRoot;
+            if (elementRoot == requestedRoot)
+            {
+                return true;
+            }
+
+            var elementRootOwner = NativeMethods.GetAncestor(
+                elementWindowHandle,
+                NativeConstants.GA_ROOTOWNER);
+            var requestedRootOwner = NativeMethods.GetAncestor(
+                requestedWindowHandle.Value,
+                NativeConstants.GA_ROOTOWNER);
+            return elementRootOwner != IntPtr.Zero &&
+                requestedRootOwner != IntPtr.Zero &&
+                elementRootOwner == requestedRootOwner;
         }
 
         return false;
@@ -671,7 +992,7 @@ public sealed partial class UIAutomationService
                 var hwnd = TryGetNativeWindowHandle(current);
                 if (hwnd != IntPtr.Zero)
                 {
-                    return hwnd;
+                    return NormalizeTopLevelWindowHandle(hwnd);
                 }
 
                 current = walker.GetParentElement(current);
@@ -688,7 +1009,7 @@ public sealed partial class UIAutomationService
             var rootHandle = TryGetNativeWindowHandle(root);
             if (rootHandle != IntPtr.Zero)
             {
-                return rootHandle;
+                return NormalizeTopLevelWindowHandle(rootHandle);
             }
         }
         catch
@@ -724,6 +1045,25 @@ public sealed partial class UIAutomationService
 
     private static bool TryParseElementWindowHandle(string elementId, out nint windowHandle) =>
         ElementIdGenerator.TryResolveWindowHandle(elementId, out windowHandle);
+
+    private static nint NormalizeTopLevelWindowHandle(nint windowHandle)
+    {
+        var root = NativeMethods.GetAncestor(windowHandle, NativeConstants.GA_ROOT);
+        return root != IntPtr.Zero ? root : windowHandle;
+    }
+
+    private static bool IsExpectedForegroundWindow(nint expectedWindowHandle)
+    {
+        if (expectedWindowHandle == IntPtr.Zero)
+        {
+            return false;
+        }
+
+        var foreground = NativeMethods.GetForegroundWindow();
+        return foreground != IntPtr.Zero &&
+            NormalizeTopLevelWindowHandle(foreground) ==
+            NormalizeTopLevelWindowHandle(expectedWindowHandle);
+    }
 
     private static nint TryGetNativeWindowHandle(UIA.IUIAutomationElement? element)
     {
@@ -783,11 +1123,14 @@ public sealed partial class UIAutomationService
                     return false;
                 }
 
-                _windowActivator.ActivateWindowAsync(windowHandle.Value, cancellationToken: CancellationToken.None)
+                var handleToActivate = elementWindowHandle != IntPtr.Zero
+                    ? elementWindowHandle
+                    : windowHandle.Value;
+                _windowActivator.ActivateWindowAsync(handleToActivate, cancellationToken: CancellationToken.None)
                     .GetAwaiter()
                     .GetResult();
                 return DeterministicWait.Until(
-                    () => _windowActivator.IsForegroundWindow(windowHandle.Value),
+                    () => _windowActivator.IsForegroundWindow(handleToActivate),
                     TimeSpan.FromMilliseconds(500),
                     ActionVerificationPollInterval);
             }
@@ -943,14 +1286,19 @@ public sealed partial class UIAutomationService
 
         try
         {
-            var findResult = await FindElementsAsync(query, cancellationToken);
+            var actionQuery = query with
+            {
+                VisibleOnly = query.VisibleOnly ?? true,
+                EnabledOnly = query.EnabledOnly ?? true
+            };
+            var findResult = await FindElementsAsync(actionQuery, cancellationToken);
             if (!findResult.Success || findResult.Items == null || findResult.Items.Length == 0)
             {
                 return UIAutomationResult.CreateFailure(
                     "double_click",
-                    UIAutomationErrorType.ElementNotFound,
+                    findResult.ErrorType ?? UIAutomationErrorType.ElementNotFound,
                     findResult.ErrorMessage ?? "Element not found.",
-                    CreateDiagnostics(stopwatch));
+                    findResult.Diagnostics ?? CreateDiagnostics(stopwatch, actionQuery));
             }
 
             var targetElement = findResult.Items[0];
@@ -1017,13 +1365,15 @@ public sealed partial class UIAutomationService
 
         var prepared = await _staThread.ExecuteAsync(() =>
         {
-            var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+            var element = ElementIdGenerator.ResolveToAutomationElement(
+                elementId,
+                allowSelectorFallback: false);
             if (element == null)
             {
                 return (Failure: UIAutomationResult.CreateFailure(
                     "double_click",
-                    UIAutomationErrorType.ElementNotFound,
-                    $"Element with ID '{elementId}' could not be resolved.",
+                    UIAutomationErrorType.ElementStale,
+                    $"Element with ID '{elementId}' is stale. Refresh UI state before double-clicking.",
                     CreateDiagnostics(stopwatch)), Element: (UIA.IUIAutomationElement?)null, Root: (UIA.IUIAutomationElement?)null, Point: (Point?)null, Initial: default(ElementActionState));
             }
 
@@ -1423,7 +1773,12 @@ public sealed partial class UIAutomationService
     /// </summary>
     private async Task<bool> FocusWindowAsync(nint hwnd, CancellationToken cancellationToken)
     {
-        return await _staThread.ExecuteAsync(() =>
+        var activated = _windowActivator is not null &&
+            await _windowActivator.ActivateWindowAsync(
+                hwnd,
+                cancellationToken: cancellationToken);
+
+        var focused = await _staThread.ExecuteAsync(() =>
         {
             var element = Uia.ElementFromHandle(hwnd);
             if (element == null)
@@ -1441,6 +1796,8 @@ public sealed partial class UIAutomationService
                 return false;
             }
         }, cancellationToken);
+
+        return activated || focused;
     }
 
     /// <summary>

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -412,7 +412,7 @@ public sealed partial class UIAutomationService
                     "type",
                     UIAutomationErrorType.ElementStale,
                     $"Element with ID '{elementId}' is stale and was not retargeted by name.",
-                    CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, TargetWindowHandle: IntPtr.Zero, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
             nint? activationHandle = null;
@@ -424,7 +424,7 @@ public sealed partial class UIAutomationService
                         "type",
                         UIAutomationErrorType.InvalidParameter,
                         $"Invalid windowHandle '{windowHandle}'. Expected decimal string from window_management(handle).",
-                        CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                        CreateDiagnostics(stopwatch)), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, TargetWindowHandle: IntPtr.Zero, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                 }
 
                 activationHandle = parsedHandle;
@@ -437,7 +437,7 @@ public sealed partial class UIAutomationService
                     "type",
                     UIAutomationErrorType.WrongTargetWindow,
                     "The resolved element no longer belongs to the requested window.",
-                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, TargetWindowHandle: IntPtr.Zero, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
             if (!element.IsEnabled())
@@ -447,7 +447,7 @@ public sealed partial class UIAutomationService
                     UIAutomationErrorType.InvalidParameter,
                     $"Element with ID '{elementId}' is disabled and cannot receive text. " +
                     "Wait for it to become enabled or target a different field.",
-                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, TargetWindowHandle: IntPtr.Zero, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
             if (element.IsOffscreen())
@@ -457,7 +457,7 @@ public sealed partial class UIAutomationService
                     UIAutomationErrorType.InvalidParameter,
                     $"Element with ID '{elementId}' is off-screen and cannot safely receive input. " +
                     "Refresh the UI state, scroll it into view, or target the active dialog.",
-                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                    CreateActionDiagnostics(stopwatch, element, "target_validation")), UseKeyboard: false, IsPassword: false, InitialValue: (string?)null, TargetWindowHandle: IntPtr.Zero, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
             }
 
             var rootElement = GetRootElementForScroll(element);
@@ -483,13 +483,13 @@ public sealed partial class UIAutomationService
                         return (Success: true, Result: UIAutomationResult.CreateSuccessWithHint(
                             "type",
                             "Type succeeded. Element closed its parent window.",
-                            CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                            CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, TargetWindowHandle: elementWindowHandle, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                     }
 
                     return (Success: true, Result: UIAutomationResult.CreateSuccessCompact(
                         "type",
                         [info],
-                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: element, RootElement: rootElement);
+                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, TargetWindowHandle: elementWindowHandle, Element: element, RootElement: rootElement);
                 }
 
                 if (!useKeyboard && inputMode == "auto")
@@ -503,7 +503,7 @@ public sealed partial class UIAutomationService
                         "type",
                         UIAutomationErrorType.PatternNotSupported,
                         "The element did not accept ValuePattern input. Use inputMode='keyboard' to emit normal focus and keyboard events.",
-                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
+                        CreateActionDiagnostics(stopwatch, element, "value_pattern")), UseKeyboard: false, IsPassword: isPassword, InitialValue: initialValue, TargetWindowHandle: elementWindowHandle, Element: (UIA.IUIAutomationElement?)null, RootElement: (UIA.IUIAutomationElement?)null);
                 }
             }
 
@@ -512,7 +512,7 @@ public sealed partial class UIAutomationService
             // GetForegroundWindow is unavailable to the automation process.
             _ = ActivateWindowForElement(element, activationHandle);
             element.TrySetFocus();
-            return (Success: true, Result: (UIAutomationResult?)null, UseKeyboard: true, IsPassword: isPassword, InitialValue: initialValue, Element: element, RootElement: rootElement);
+            return (Success: true, Result: (UIAutomationResult?)null, UseKeyboard: true, IsPassword: isPassword, InitialValue: initialValue, TargetWindowHandle: elementWindowHandle, Element: element, RootElement: rootElement);
         }, cancellationToken);
 
         if (!staResult.Success)
@@ -548,9 +548,7 @@ public sealed partial class UIAutomationService
                 CreateActionDiagnostics(stopwatch, staResult.Element, "value_pattern"));
         }
 
-        var expectedWindowHandle = await _staThread.ExecuteAsync(
-            () => ResolveElementWindowHandle(staResult.Element!),
-            cancellationToken);
+        var expectedWindowHandle = staResult.TargetWindowHandle;
         if (!IsExpectedForegroundWindow(expectedWindowHandle))
         {
             return UIAutomationResult.CreateFailure(

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Actions.cs
@@ -663,7 +663,9 @@ public sealed partial class UIAutomationService
         {
             return UIAutomationResult.CreateFailure(
                 "type",
-                UIAutomationErrorType.InternalError,
+                keyboardResult.ErrorCode == KeyboardControlErrorCode.WrongTargetWindow
+                    ? UIAutomationErrorType.WrongTargetWindow
+                    : UIAutomationErrorType.InternalError,
                 keyboardResult.Error ?? "Keyboard input failed.",
                 CreateActionDiagnostics(stopwatch, staResult.Element, "keyboard"));
         }
@@ -733,9 +735,9 @@ public sealed partial class UIAutomationService
             {
                 return UIAutomationResult.CreateFailure(
                     "select",
-                    UIAutomationErrorType.ElementNotFound,
+                    findResult.ErrorType ?? UIAutomationErrorType.ElementNotFound,
                     findResult.ErrorMessage ?? "Element not found.",
-                    CreateDiagnostics(stopwatch));
+                    findResult.Diagnostics ?? CreateDiagnostics(stopwatch));
             }
 
             var targetElement = findResult.Items[0];

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -14,6 +14,31 @@ public sealed partial class UIAutomationService
     /// <inheritdoc/>
     public async Task<UIAutomationResult> FindElementsAsync(ElementQuery query, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(query);
+
+        if (query.TimeoutMs <= 0)
+        {
+            return await FindElementsOnceAsync(query, cancellationToken).ConfigureAwait(false);
+        }
+
+        var result = await WaitForElementAsync(
+            query with { TimeoutMs = 0 },
+            query.TimeoutMs,
+            cancellationToken).ConfigureAwait(false);
+
+        return result with
+        {
+            Action = "find",
+            Diagnostics = result.Diagnostics is null
+                ? null
+                : result.Diagnostics with { Query = query }
+        };
+    }
+
+    private async Task<UIAutomationResult> FindElementsOnceAsync(
+        ElementQuery query,
+        CancellationToken cancellationToken)
+    {
         var stopwatch = Stopwatch.StartNew();
 
         try

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -16,6 +16,15 @@ public sealed partial class UIAutomationService
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        if (query.RequireUnique && query.FoundIndex != 1)
+        {
+            return UIAutomationResult.CreateFailure(
+                "find",
+                UIAutomationErrorType.InvalidParameter,
+                "requireUnique cannot be combined with foundIndex other than 1. Refine the selector instead.",
+                CreateDiagnostics(Stopwatch.StartNew(), query));
+        }
+
         if (query.TimeoutMs <= 0)
         {
             return await FindElementsOnceAsync(query, cancellationToken).ConfigureAwait(false);

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Find.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using Sbroenne.WindowsMcp.Native;
 using UIA = Interop.UIAutomationClient;
 
 namespace Sbroenne.WindowsMcp.Automation;
@@ -23,27 +24,49 @@ public sealed partial class UIAutomationService
                 UIA.IUIAutomationElement? rootElement;
                 if (!string.IsNullOrEmpty(query.ParentElementId))
                 {
-                    rootElement = ElementIdGenerator.ResolveToAutomationElement(query.ParentElementId);
+                    rootElement = ElementIdGenerator.ResolveToAutomationElement(
+                        query.ParentElementId,
+                        allowSelectorFallback: false);
                     if (rootElement == null)
                     {
                         return UIAutomationResult.CreateFailure(
                             "find",
-                            UIAutomationErrorType.ElementNotFound,
-                            $"Parent element not found or stale: {query.ParentElementId}",
+                            UIAutomationErrorType.ElementStale,
+                            $"Parent element is stale: {query.ParentElementId}. Refresh UI state before searching within it.",
                             CreateDiagnostics(stopwatch, query));
                     }
                 }
                 else
                 {
-                    rootElement = GetRootElement(query.WindowHandle);
+                    var normalizedScope = string.IsNullOrWhiteSpace(query.Scope)
+                        ? "window"
+                        : query.Scope.Trim().ToLowerInvariant();
+                    if (normalizedScope is not ("window" or "active_dialog"))
+                    {
+                        return UIAutomationResult.CreateFailure(
+                            "find",
+                            UIAutomationErrorType.InvalidParameter,
+                            $"Invalid scope '{query.Scope}'. Valid values: window, active_dialog.",
+                            CreateDiagnostics(stopwatch, query));
+                    }
+
+                    rootElement = normalizedScope == "active_dialog"
+                        ? GetActiveDialogRoot(query.WindowHandle)
+                        : GetRootElement(query.WindowHandle);
                 }
 
                 if (rootElement == null)
                 {
+                    var requestedActiveDialog = string.Equals(
+                        query.Scope,
+                        "active_dialog",
+                        StringComparison.OrdinalIgnoreCase);
                     return UIAutomationResult.CreateFailure(
                         "find",
                         UIAutomationErrorType.WindowNotFound,
-                        "Could not find the specified window or foreground window.",
+                        requestedActiveDialog
+                            ? "No visible enabled dialog is currently owned by the requested window."
+                            : "Could not find the specified window or foreground window.",
                         CreateDiagnostics(stopwatch, query));
                 }
 
@@ -145,6 +168,11 @@ public sealed partial class UIAutomationService
                     {
                         elementInfos.RemoveAll(e => e.IsOffscreen);
                     }
+
+                    if (query.EnabledOnly == true && elementInfos.Count > 0)
+                    {
+                        elementInfos.RemoveAll(e => !e.IsEnabled);
+                    }
                 }
 
                 // AND the caller's condition with the predefined content-view condition so FindAll
@@ -190,6 +218,11 @@ public sealed partial class UIAutomationService
                         elementInfos.RemoveAll(e => e.IsOffscreen);
                     }
 
+                    if (query.EnabledOnly == true && elementInfos.Count > 0)
+                    {
+                        elementInfos.RemoveAll(e => !e.IsEnabled);
+                    }
+
                     if (elementInfos.Count > 0)
                     {
                         LogSearchPerformance(_logger, "find (auto-relaxed to partial match)", elementsScanned, stopwatch.ElapsedMilliseconds, elementInfos.Count);
@@ -232,6 +265,37 @@ public sealed partial class UIAutomationService
                         var areaB = b.BoundingRect.Width * b.BoundingRect.Height;
                         return areaB.CompareTo(areaA); // Descending order (largest first)
                     });
+                }
+
+                if (query.RequireUnique && elementInfos.Count > 1)
+                {
+                    return UIAutomationResult.CreateFailure(
+                        "find",
+                        UIAutomationErrorType.MultipleMatches,
+                        $"{elementInfos.Count} visible matching elements were found. Add automationId, " +
+                        "use scope='active_dialog' or parentElementId, or set foundIndex explicitly.",
+                        CreateDiagnosticsWithContext(
+                            stopwatch,
+                            rootElement,
+                            query,
+                            elementsScanned,
+                            windowTitle,
+                            query.WindowHandle,
+                            usedContentView) with
+                        {
+                            MultipleMatches = elementInfos
+                                .Take(10)
+                                .Select(info => new UIAutomationTargetDiagnostics
+                                {
+                                    ElementId = info.ElementId,
+                                    Name = info.Name,
+                                    AutomationId = info.AutomationId,
+                                    ControlType = info.ControlType,
+                                    IsEnabled = info.IsEnabled,
+                                    IsOffscreen = info.IsOffscreen
+                                })
+                                .ToArray()
+                        });
                 }
 
                 // Always use compact format for Find to reduce token count by ~70%
@@ -615,6 +679,43 @@ public sealed partial class UIAutomationService
         }
 
         return $"No element found matching: {string.Join(", ", criteria)}";
+    }
+
+    private UIA.IUIAutomationElement? GetActiveDialogRoot(string? windowHandle)
+    {
+        if (!WindowHandleParser.TryParse(windowHandle, out var parentHandle))
+        {
+            return null;
+        }
+
+        var popupHandle = NativeMethods.GetWindow(parentHandle, NativeConstants.GW_ENABLEDPOPUP);
+        if (popupHandle != IntPtr.Zero &&
+            popupHandle != parentHandle &&
+            NativeMethods.IsWindowVisible(popupHandle))
+        {
+            return Uia.ElementFromHandle(popupHandle);
+        }
+
+        var parent = Uia.ElementFromHandle(parentHandle);
+        if (parent == null)
+        {
+            return null;
+        }
+
+        var windows = parent.FindAll(
+            UIA.TreeScope.TreeScope_Children,
+            Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Window));
+        for (var index = 0; index < (windows?.Length ?? 0); index++)
+        {
+            var candidate = windows!.GetElement(index);
+            var pattern = candidate.GetPattern<UIA.IUIAutomationWindowPattern>(UIA3PatternIds.Window);
+            if (pattern?.CurrentIsModal != 0)
+            {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Focus.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Focus.cs
@@ -17,13 +17,15 @@ public sealed partial class UIAutomationService
         {
             return await _staThread.ExecuteAsync(() =>
             {
-                var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+                var element = ElementIdGenerator.ResolveToAutomationElement(
+                    elementId,
+                    allowSelectorFallback: false);
                 if (element == null)
                 {
                     return UIAutomationResult.CreateFailure(
                         "focus",
-                        UIAutomationErrorType.ElementNotFound,
-                        $"Element not found or stale: {elementId}",
+                        UIAutomationErrorType.ElementStale,
+                        $"Element is stale: {elementId}. Refresh UI state before focusing.",
                         CreateDiagnostics(stopwatch));
                 }
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Helpers.cs
@@ -396,6 +396,39 @@ public sealed partial class UIAutomationService
         };
     }
 
+    private static UIAutomationDiagnostics CreateActionDiagnostics(
+        Stopwatch stopwatch,
+        UIA.IUIAutomationElement? element,
+        string actionPath)
+    {
+        UIAutomationTargetDiagnostics? target = null;
+        if (element != null)
+        {
+            try
+            {
+                target = new UIAutomationTargetDiagnostics
+                {
+                    Name = element.GetName(),
+                    AutomationId = element.GetAutomationId(),
+                    ControlType = element.GetControlTypeName(),
+                    IsEnabled = element.CurrentIsEnabled != 0,
+                    IsOffscreen = element.CurrentIsOffscreen != 0
+                };
+            }
+            catch (Exception ex) when (COMExceptionHelper.IsExpectedElementFailure(ex))
+            {
+                target = null;
+            }
+        }
+
+        return new UIAutomationDiagnostics
+        {
+            DurationMs = stopwatch.ElapsedMilliseconds,
+            ActionPath = actionPath,
+            TargetElement = target
+        };
+    }
+
     private static UIAutomationDiagnostics CreateDiagnosticsWithContext(
         Stopwatch stopwatch,
         UIA.IUIAutomationElement rootElement,

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
@@ -130,10 +130,22 @@ public sealed partial class UIAutomationService
                         CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
                 }
 
-                await _keyboardService.PressKeyAsync(
+                var shortcutResult = await _keyboardService.PressKeyAsync(
                     "o",
                     ModifierKey.Ctrl,
-                    cancellationToken: cancellationToken);
+                    1,
+                    hwnd,
+                    cancellationToken);
+                if (!shortcutResult.Success)
+                {
+                    return UIAutomationResult.CreateFailure(
+                        "open",
+                        shortcutResult.ErrorCode == KeyboardControlErrorCode.WrongTargetWindow
+                            ? UIAutomationErrorType.WrongTargetWindow
+                            : UIAutomationErrorType.InternalError,
+                        shortcutResult.Error ?? "Ctrl+O could not be sent.",
+                        CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
+                }
             }
 
             var dialog = await WaitForOpenDialogAsync(

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.OpenDialog.cs
@@ -33,18 +33,56 @@ public sealed partial class UIAutomationService
     /// <returns>A result describing whether the Open dialog was driven successfully.</returns>
     public async Task<UIAutomationResult> OpenFileAsync(
         string windowHandle, string filePath, CancellationToken cancellationToken = default)
+        => await OpenFileAsync(
+            windowHandle,
+            filePath,
+            triggerMode: "shortcut",
+            timeoutMs: (int)SaveDialogTimeout.TotalMilliseconds,
+            cancellationToken);
+
+    /// <summary>
+    /// Opens a file through a standard Open dialog. Use triggerMode "shortcut" to send Ctrl+O,
+    /// or "wait" when a prior semantic browser/app click is expected to open the native dialog.
+    /// </summary>
+    public async Task<UIAutomationResult> OpenFileAsync(
+        string windowHandle,
+        string filePath,
+        string triggerMode,
+        int timeoutMs,
+        CancellationToken cancellationToken = default)
     {
         var stopwatch = Stopwatch.StartNew();
+        var normalizedTrigger = string.IsNullOrWhiteSpace(triggerMode)
+            ? "shortcut"
+            : triggerMode.Trim().ToLowerInvariant();
 
         try
         {
+            if (normalizedTrigger is not ("shortcut" or "wait"))
+            {
+                return UIAutomationResult.CreateFailure(
+                    "open",
+                    UIAutomationErrorType.InvalidParameter,
+                    $"Invalid triggerMode '{triggerMode}'. Valid values: shortcut, wait.",
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
+            }
+
+            if (timeoutMs <= 0 || timeoutMs > 60000)
+            {
+                return UIAutomationResult.CreateFailure(
+                    "open",
+                    UIAutomationErrorType.InvalidParameter,
+                    "timeoutMs must be between 1 and 60000.",
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
+            }
+
             if (!nint.TryParse(windowHandle, out var hwnd) || hwnd == nint.Zero)
             {
                 return UIAutomationResult.CreateFailure(
                     "open",
                     UIAutomationErrorType.InvalidParameter,
                     $"Invalid window handle format: '{windowHandle}'",
-                    CreateDiagnostics(stopwatch));
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
             }
 
             if (string.IsNullOrWhiteSpace(filePath))
@@ -53,7 +91,7 @@ public sealed partial class UIAutomationService
                     "open",
                     UIAutomationErrorType.InvalidParameter,
                     "filePath is required for open. Provide the absolute path of an existing file.",
-                    CreateDiagnostics(stopwatch));
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
             }
 
             filePath = Path.GetFullPath(filePath);
@@ -63,42 +101,68 @@ public sealed partial class UIAutomationService
                     "open",
                     UIAutomationErrorType.PathError,
                     $"Open failed: file '{filePath}' does not exist. Provide the path of an existing file.",
-                    CreateDiagnostics(stopwatch));
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
             }
 
-            // Step 1: focus the target window.
-            if (!await FocusWindowAsync(hwnd, cancellationToken))
+            if (normalizedTrigger == "shortcut" &&
+                !await FocusWindowAsync(hwnd, cancellationToken))
             {
                 return UIAutomationResult.CreateFailure(
                     "open",
                     UIAutomationErrorType.ElementNotFound,
                     "Could not focus the target window.",
-                    CreateDiagnostics(stopwatch));
+                    CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
             }
 
-            _ = await DeterministicWait.UntilAsync(
-                () => NativeMethods.GetForegroundWindow() == hwnd,
-                TimeSpan.FromMilliseconds(500),
-                TimeSpan.FromMilliseconds(25),
-                cancellationToken: cancellationToken);
+            if (normalizedTrigger == "shortcut")
+            {
+                var foregroundReady = await DeterministicWait.UntilAsync(
+                    () => NativeMethods.GetForegroundWindow() == hwnd,
+                    TimeSpan.FromMilliseconds(500),
+                    TimeSpan.FromMilliseconds(25),
+                    cancellationToken: cancellationToken);
+                if (!foregroundReady)
+                {
+                    return UIAutomationResult.CreateFailure(
+                        "open",
+                        UIAutomationErrorType.WrongTargetWindow,
+                        "The target window could not be confirmed as foreground, so Ctrl+O was not sent.",
+                        CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
+                }
 
-            // Step 2: invoke the Open command (universal Ctrl+O).
-            await _keyboardService.PressKeyAsync("o", ModifierKey.Ctrl, cancellationToken: cancellationToken);
+                await _keyboardService.PressKeyAsync(
+                    "o",
+                    ModifierKey.Ctrl,
+                    cancellationToken: cancellationToken);
+            }
 
-            // Step 3: wait for the Open dialog.
-            var dialog = await WaitForOpenDialogAsync(hwnd, cancellationToken);
+            var dialog = await WaitForOpenDialogAsync(
+                hwnd,
+                TimeSpan.FromMilliseconds(timeoutMs),
+                allowStructuralMatch: normalizedTrigger == "shortcut",
+                cancellationToken);
             if (dialog == null)
             {
+                var candidates = await DescribeOpenDialogCandidatesAsync(hwnd, cancellationToken);
                 return UIAutomationResult.CreateFailure(
                     "open",
                     UIAutomationErrorType.Timeout,
-                    "No Open dialog appeared after Ctrl+O. The app may use a different shortcut or menu; " +
-                    "open the dialog manually with ui_click, then type the path with ui_type.",
-                    CreateDiagnostics(stopwatch));
+                    normalizedTrigger == "wait"
+                        ? "The expected native Open dialog did not appear after the prior UI action."
+                        : "No native Open dialog appeared after Ctrl+O.",
+                    CreateDiagnostics(stopwatch) with
+                    {
+                        ActionPath = normalizedTrigger,
+                        Warnings = [$"Observed candidate windows: {candidates}"]
+                    });
             }
 
-            // Step 4: fill the File name field and confirm.
-            return await FillOpenDialogAsync(dialog, filePath, stopwatch, cancellationToken);
+            return await FillOpenDialogAsync(
+                dialog,
+                filePath,
+                stopwatch,
+                normalizedTrigger,
+                cancellationToken);
         }
         catch (COMException ex)
         {
@@ -106,7 +170,7 @@ public sealed partial class UIAutomationService
                 "open",
                 COMExceptionHelper.GetErrorType(ex),
                 COMExceptionHelper.GetErrorMessage(ex, "Open"),
-                CreateDiagnostics(stopwatch));
+                CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -114,7 +178,7 @@ public sealed partial class UIAutomationService
                 "open",
                 UIAutomationErrorType.InternalError,
                 $"Open failed: {ex.Message}",
-                CreateDiagnostics(stopwatch));
+                CreateDiagnostics(stopwatch) with { ActionPath = normalizedTrigger });
         }
     }
 
@@ -123,11 +187,14 @@ public sealed partial class UIAutomationService
     /// Mirrors <see cref="WaitForSaveDialogAsync"/> but matches Open dialog titles.
     /// </summary>
     private async Task<UIA.IUIAutomationElement?> WaitForOpenDialogAsync(
-        nint parentHwnd, CancellationToken cancellationToken)
+        nint parentHwnd,
+        TimeSpan timeout,
+        bool allowStructuralMatch,
+        CancellationToken cancellationToken)
     {
         string[] dialogPatterns = ["Open", "Select a file", "Choose File", "Browse"];
 
-        var deadline = DateTime.UtcNow + SaveDialogTimeout;
+        var deadline = DateTime.UtcNow + timeout;
 
         while (DateTime.UtcNow < deadline)
         {
@@ -138,6 +205,21 @@ public sealed partial class UIAutomationService
             {
                 result = await _staThread.ExecuteAsync(() =>
                 {
+                    var enabledPopup = NativeMethods.GetWindow(
+                        parentHwnd,
+                        NativeConstants.GW_ENABLEDPOPUP);
+                    if (enabledPopup != IntPtr.Zero &&
+                        enabledPopup != parentHwnd &&
+                        NativeMethods.IsWindowVisible(enabledPopup))
+                    {
+                        var popup = Uia.ElementFromHandle(enabledPopup);
+                        if (popup != null &&
+                            MatchesExpectedFileDialog(popup, dialogPatterns, allowStructuralMatch))
+                        {
+                            return popup;
+                        }
+                    }
+
                     var parentElement = Uia.ElementFromHandle(parentHwnd);
                     if (parentElement != null)
                     {
@@ -162,8 +244,10 @@ public sealed partial class UIAutomationService
                                         continue;
                                     }
 
-                                    var name = child.CurrentName ?? string.Empty;
-                                    if (MatchesOpenDialog(name, dialogPatterns))
+                                    if (MatchesExpectedFileDialog(
+                                        child,
+                                        dialogPatterns,
+                                        allowStructuralMatch))
                                     {
                                         return child;
                                     }
@@ -176,7 +260,7 @@ public sealed partial class UIAutomationService
                         }
                     }
 
-                    // Fallback: top-level shell dialog windows.
+                    // Fallback: only accept a visible top-level window owned by the requested app.
                     var topWindowCondition = Uia.CreatePropertyCondition(
                         UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Window);
                     var topWindows = Uia.RootElement.FindAll(UIA.TreeScope.TreeScope_Children, topWindowCondition);
@@ -185,8 +269,25 @@ public sealed partial class UIAutomationService
                         for (int i = 0; i < topWindows.Length; i++)
                         {
                             var window = topWindows.GetElement(i);
-                            var name = window.CurrentName ?? string.Empty;
-                            if (MatchesOpenDialog(name, dialogPatterns))
+                            var candidateHandle = new IntPtr(window.CurrentNativeWindowHandle);
+                            var rootOwner = NativeMethods.GetAncestor(
+                                candidateHandle,
+                                NativeConstants.GA_ROOTOWNER);
+                            var parentRootOwner = NativeMethods.GetAncestor(
+                                parentHwnd,
+                                NativeConstants.GA_ROOTOWNER);
+                            var owner = NativeMethods.GetWindow(
+                                candidateHandle,
+                                NativeConstants.GW_OWNER);
+                            if (candidateHandle != parentHwnd &&
+                                owner != IntPtr.Zero &&
+                                MatchesExpectedFileDialog(
+                                    window,
+                                    dialogPatterns,
+                                    allowStructuralMatch) &&
+                                NativeMethods.IsWindowVisible(candidateHandle) &&
+                                (rootOwner == parentRootOwner ||
+                                 owner == parentHwnd))
                             {
                                 return window;
                             }
@@ -223,6 +324,36 @@ public sealed partial class UIAutomationService
         }
 
         return false;
+    }
+
+    private static bool MatchesExpectedFileDialog(
+        UIA.IUIAutomationElement dialog,
+        string[] titlePatterns,
+        bool allowStructuralMatch)
+    {
+        if (MatchesOpenDialog(dialog.CurrentName ?? string.Empty, titlePatterns))
+        {
+            return true;
+        }
+
+        if (!allowStructuralMatch)
+        {
+            return false;
+        }
+
+        // Localized Windows installations do not use English dialog titles. Standard shell file
+        // dialogs can still be identified by their file-name field and default confirmation button.
+        if (FindSaveDialogEditField(dialog) is null)
+        {
+            return false;
+        }
+
+        var defaultButtonCondition = Uia.CreateAndCondition(
+            Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Button),
+            Uia.CreatePropertyCondition(UIA3PropertyIds.AutomationId, "1"));
+        return dialog.FindFirst(
+            UIA.TreeScope.TreeScope_Descendants,
+            defaultButtonCondition) is not null;
     }
 
     /// <summary>
@@ -271,20 +402,16 @@ public sealed partial class UIAutomationService
     /// Save and Open shell dialogs) and <see cref="WaitForDialogCloseAsync"/>.
     /// </summary>
     private async Task<UIAutomationResult> FillOpenDialogAsync(
-        UIA.IUIAutomationElement dialog, string filePath, Stopwatch stopwatch, CancellationToken cancellationToken)
+        UIA.IUIAutomationElement dialog,
+        string filePath,
+        Stopwatch stopwatch,
+        string actionPath,
+        CancellationToken cancellationToken)
     {
-        await _staThread.ExecuteAsync(() =>
-        {
-            try
-            {
-                dialog.SetFocus();
-            }
-            catch
-            {
-                // Best effort.
-            }
-            return true;
-        }, cancellationToken);
+        var dialogHwnd = await _staThread.ExecuteAsync(
+            () => NormalizeTopLevelWindowHandle(
+                new IntPtr(dialog.CurrentNativeWindowHandle)),
+            cancellationToken);
 
         UIA.IUIAutomationElement? editField = null;
         var editFieldFound = await DeterministicWait.UntilAsync(
@@ -308,12 +435,11 @@ public sealed partial class UIAutomationService
                 UIAutomationErrorType.ElementNotFound,
                 "Could not find the File name field in the Open dialog. Edit/ComboBox descendants: " +
                 controlDump,
-                CreateDiagnostics(stopwatch));
+                CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
         }
 
         int[]? editFieldCenter = await _staThread.ExecuteAsync<int[]?>(() =>
         {
-            editField.TrySetFocus();
             var rect = editField.GetBoundingRectangle();
             if (rect.Width <= 0 || rect.Height <= 0)
             {
@@ -323,15 +449,7 @@ public sealed partial class UIAutomationService
             return [(int)Math.Round(rect.X + (rect.Width / 2)), (int)Math.Round(rect.Y + (rect.Height / 2))];
         }, cancellationToken);
 
-        if (editFieldCenter is { Length: 2 })
-        {
-            await _mouseService.ClickAsync(editFieldCenter[0], editFieldCenter[1], cancellationToken: cancellationToken);
-        }
-
-        await _keyboardService.ReleaseAllKeysAsync(cancellationToken);
-
         var normalizedPath = filePath.Replace('/', '\\');
-        var expectedFileName = Path.GetFileName(normalizedPath);
 
         // Enter the path robustly, verify it actually landed in the File name field, and only then
         // confirm. A loaded, shared CI desktop can drop the first keystrokes right after the field
@@ -343,91 +461,254 @@ public sealed partial class UIAutomationService
         // writes are ignored), and retype until the field holds the full path before clicking Open. We
         // click the Open button rather than pressing Enter, which can commit an autocomplete suggestion.
         string? lastObservedValue = null;
+        ElementActionOutcome? lastOpenButtonOutcome = null;
+
+        // Prefer semantic assignment and invocation. This path is background-safe and avoids exposing
+        // the local path through global keyboard input when another application owns the foreground.
+        await _staThread.ExecuteAsync(
+            () =>
+            {
+                editField.TrySetValue(normalizedPath);
+                return true;
+            },
+            cancellationToken);
+        lastObservedValue = await _staThread.ExecuteAsync(
+            () => editField.GetText(),
+            cancellationToken);
+        if (PathMatches(lastObservedValue, normalizedPath))
+        {
+            lastOpenButtonOutcome = await ClickOpenButtonAsync(
+                dialog,
+                allowPhysicalFallback: false,
+                cancellationToken);
+            if (lastOpenButtonOutcome.Value.Success &&
+                await WaitForDialogCloseAsync(dialog, cancellationToken))
+            {
+                return UIAutomationResult.CreateSuccess(
+                    "open",
+                    CreateDiagnostics(stopwatch) with { ActionPath = actionPath + "+semantic" });
+            }
+        }
+
+        if (dialogHwnd == IntPtr.Zero || _windowActivator == null)
+        {
+            return UIAutomationResult.CreateFailure(
+                "open",
+                UIAutomationErrorType.WrongTargetWindow,
+                "The native Open dialog could not be activated before keyboard input.",
+                CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
+        }
+
+        var activated = await _windowActivator.ActivateWindowAsync(
+            dialogHwnd,
+            cancellationToken: cancellationToken);
+        if (!activated || !_windowActivator.IsForegroundWindow(dialogHwnd))
+        {
+            return UIAutomationResult.CreateFailure(
+                "open",
+                UIAutomationErrorType.WrongTargetWindow,
+                "The native Open dialog was found but could not be confirmed as foreground, so the file path was not typed.",
+                CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
+        }
+
+        await _keyboardService.ReleaseAllKeysAsync(cancellationToken);
 
         for (var attempt = 0; attempt < 3; attempt++)
         {
+            if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+            {
+                return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+            }
+
             await _staThread.ExecuteAsync(() => { editField.TrySetFocus(); return true; }, cancellationToken);
             if (editFieldCenter is { Length: 2 })
             {
-                await _mouseService.ClickAsync(editFieldCenter[0], editFieldCenter[1], cancellationToken: cancellationToken);
-            }
+                if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+                {
+                    return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+                }
 
-            // Wait for the edit field to actually own keyboard focus so the typed path lands in it.
-            _ = await DeterministicWait.UntilAsync(
-                async () => await _staThread.ExecuteAsync(
-                    () =>
-                    {
-                        try
-                        {
-                            return editField.CurrentHasKeyboardFocus != 0;
-                        }
-                        catch (COMException)
-                        {
-                            return false;
-                        }
-                    },
-                    cancellationToken),
-                TimeSpan.FromMilliseconds(500),
-                TimeSpan.FromMilliseconds(25),
-                cancellationToken: cancellationToken);
+                await _mouseService.ClickAsync(
+                    editFieldCenter[0],
+                    editFieldCenter[1],
+                    ModifierKey.None,
+                    dialogHwnd,
+                    cancellationToken);
+            }
 
             // Clear then type, verifying the field reads back the full path. Retype on mismatch so a
             // dropped leading character (a contended-desktop hazard) is corrected before we confirm.
             var matched = false;
             for (var typeAttempt = 0; typeAttempt < 4 && !matched; typeAttempt++)
             {
-                await _keyboardService.PressKeyAsync("a", ModifierKey.Ctrl, cancellationToken: cancellationToken);
+                if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+                {
+                    return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+                }
+
+                await _keyboardService.PressKeyAsync(
+                    "a",
+                    ModifierKey.Ctrl,
+                    1,
+                    dialogHwnd,
+                    cancellationToken);
                 _ = await _keyboardService.WaitForIdleAsync(cancellationToken);
-                await _keyboardService.PressKeyAsync("Delete", cancellationToken: cancellationToken);
+                if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+                {
+                    return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+                }
+
+                await _keyboardService.PressKeyAsync(
+                    "Delete",
+                    ModifierKey.None,
+                    1,
+                    dialogHwnd,
+                    cancellationToken);
                 _ = await _keyboardService.WaitForIdleAsync(cancellationToken);
-                await _keyboardService.TypeTextAsync(normalizedPath, cancellationToken);
+                if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+                {
+                    return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+                }
+
+                await _keyboardService.TypeTextAsync(
+                    normalizedPath,
+                    dialogHwnd,
+                    cancellationToken);
                 _ = await _keyboardService.WaitForIdleAsync(cancellationToken);
 
                 lastObservedValue = await _staThread.ExecuteAsync(
                     () => editField.GetText(), cancellationToken);
-                matched = PathMatches(lastObservedValue, normalizedPath, expectedFileName);
+                matched = PathMatches(lastObservedValue, normalizedPath);
             }
 
             if (!matched)
             {
-                // Best-effort populate for dialogs that honor ValuePattern (the classic Win32 edit does
-                // not, but the Vista-style one does); harmless when ignored.
+                // Best-effort populate for dialogs that honor ValuePattern, then verify before any
+                // confirmation action.
                 await _staThread.ExecuteAsync(() => { editField.TrySetValue(normalizedPath); return true; }, cancellationToken);
+                lastObservedValue = await _staThread.ExecuteAsync(
+                    () => editField.GetText(), cancellationToken);
+                matched = PathMatches(lastObservedValue, normalizedPath);
             }
 
-            // Confirm. The edit has keyboard focus and holds the verified path, so press Enter first -
-            // the canonical confirm for the classic Win32 dialog, which does not always commit when its
-            // Open button is invoked through UIA. Fall back to clicking the Open button for dialogs that
-            // swallow Enter (e.g. when an autocomplete popup is showing). Either commit closes the dialog.
-            await _keyboardService.PressKeyAsync("Return", cancellationToken: cancellationToken);
-            if (await WaitForDialogCloseAsync(dialog, cancellationToken))
+            if (!matched)
             {
-                return UIAutomationResult.CreateSuccess("open", CreateDiagnostics(stopwatch));
+                continue;
             }
 
-            await ClickOpenButtonAsync(dialog, cancellationToken);
+            // Confirm through the dialog's default Open button first. This avoids sending another
+            // global key when the shell exposes a reliable semantic action.
+            lastOpenButtonOutcome = await ClickOpenButtonAsync(
+                dialog,
+                allowPhysicalFallback: true,
+                cancellationToken);
+            if (lastOpenButtonOutcome.Value.Success &&
+                await WaitForDialogCloseAsync(dialog, cancellationToken))
+            {
+                return UIAutomationResult.CreateSuccess(
+                    "open",
+                    CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
+            }
+
+            // Some classic dialogs expose Invoke but do not commit it. The field still contains the
+            // verified absolute path, so Enter is a bounded fallback.
+            if (!_windowActivator.IsForegroundWindow(dialogHwnd))
+            {
+                return CreateOpenDialogForegroundFailure(stopwatch, actionPath);
+            }
+
+            await _keyboardService.PressKeyAsync(
+                "Return",
+                ModifierKey.None,
+                1,
+                dialogHwnd,
+                cancellationToken);
             if (await WaitForDialogCloseAsync(dialog, cancellationToken))
             {
-                return UIAutomationResult.CreateSuccess("open", CreateDiagnostics(stopwatch));
+                return UIAutomationResult.CreateSuccess(
+                    "open",
+                    CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
             }
         }
 
         return UIAutomationResult.CreateFailure(
             "open",
             UIAutomationErrorType.Timeout,
-            "Open could not be verified because the Open dialog remained open after entering " +
-            $"'{normalizedPath}'. Last File name value observed: '{lastObservedValue ?? "<null>"}'. " +
-            "The path may be invalid or the app rejected the file; open the dialog manually with " +
-            "ui_click, type the path with ui_type, then confirm.",
-            CreateDiagnostics(stopwatch));
+            "Open could not be verified because the native dialog remained open after the path " +
+            "was entered and confirmed. The app may have rejected the file.",
+            CreateDiagnostics(stopwatch) with
+            {
+                ActionPath = actionPath,
+                Warnings =
+                [
+                    $"File name field matched requested path: {PathMatches(lastObservedValue, normalizedPath)}",
+                    $"Open button outcome: {lastOpenButtonOutcome?.Success}; " +
+                    $"path={lastOpenButtonOutcome?.ActionPath ?? "<none>"}; " +
+                    $"error={lastOpenButtonOutcome?.ErrorMessage ?? "<none>"}"
+                ]
+            });
+    }
+
+    private static UIAutomationResult CreateOpenDialogForegroundFailure(
+        Stopwatch stopwatch,
+        string actionPath) =>
+        UIAutomationResult.CreateFailure(
+            "open",
+            UIAutomationErrorType.WrongTargetWindow,
+            "The native Open dialog lost foreground ownership, so no further file-path input was sent.",
+            CreateDiagnostics(stopwatch) with { ActionPath = actionPath });
+
+    private async Task<string> DescribeOpenDialogCandidatesAsync(
+        nint parentHwnd,
+        CancellationToken cancellationToken)
+    {
+        return await _staThread.ExecuteAsync(() =>
+        {
+            var descriptions = new List<string>();
+            var popup = NativeMethods.GetWindow(parentHwnd, NativeConstants.GW_ENABLEDPOPUP);
+            if (popup != IntPtr.Zero && popup != parentHwnd)
+            {
+                var popupElement = Uia.ElementFromHandle(popup);
+                descriptions.Add(
+                    $"enabledPopup(handle={popup}, name='{popupElement?.CurrentName ?? string.Empty}')");
+            }
+
+            var windows = Uia.RootElement.FindAll(
+                UIA.TreeScope.TreeScope_Children,
+                Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Window));
+            var parentRootOwner = NativeMethods.GetAncestor(
+                parentHwnd,
+                NativeConstants.GA_ROOTOWNER);
+            for (var index = 0; index < Math.Min(windows?.Length ?? 0, 12); index++)
+            {
+                var window = windows!.GetElement(index);
+                var handle = new IntPtr(window.CurrentNativeWindowHandle);
+                var rootOwner = NativeMethods.GetAncestor(
+                    handle,
+                    NativeConstants.GA_ROOTOWNER);
+                var owner = NativeMethods.GetWindow(handle, NativeConstants.GW_OWNER);
+                if (handle != parentHwnd &&
+                    rootOwner != parentRootOwner &&
+                    owner != parentHwnd)
+                {
+                    continue;
+                }
+
+                descriptions.Add(
+                    $"window(handle={handle}, name='{window.CurrentName ?? string.Empty}', visible={NativeMethods.IsWindowVisible(handle)})");
+            }
+
+            return descriptions.Count == 0 ? "<none>" : string.Join("; ", descriptions);
+        }, cancellationToken);
     }
 
     /// <summary>
     /// Whether the File name field's observed text corresponds to the requested path. The shell may
-    /// show just the file name, the full path, or a value with surrounding quotes, so accept any of
-    /// those rather than requiring an exact match.
+    /// show the full path with surrounding quotes, so normalize those quotes before comparison.
+    /// Require the complete absolute path: accepting only a matching file-name suffix can hide
+    /// dropped leading keystrokes and cause the dialog to open an unintended file.
     /// </summary>
-    private static bool PathMatches(string? observed, string normalizedPath, string expectedFileName)
+    private static bool PathMatches(string? observed, string normalizedPath)
     {
         if (string.IsNullOrEmpty(observed))
         {
@@ -435,15 +716,16 @@ public sealed partial class UIAutomationService
         }
 
         var trimmed = observed.Trim().Trim('"');
-        return trimmed.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase)
-            || trimmed.Equals(expectedFileName, StringComparison.OrdinalIgnoreCase)
-            || trimmed.EndsWith(expectedFileName, StringComparison.OrdinalIgnoreCase);
+        return trimmed.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
     /// Finds and clicks the Open button in an Open dialog. Mirrors <see cref="ClickSaveButtonAsync"/>.
     /// </summary>
-    private async Task<bool> ClickOpenButtonAsync(UIA.IUIAutomationElement dialog, CancellationToken cancellationToken)
+    private async Task<ElementActionOutcome> ClickOpenButtonAsync(
+        UIA.IUIAutomationElement dialog,
+        bool allowPhysicalFallback,
+        CancellationToken cancellationToken)
     {
         UIA.IUIAutomationElement? openButton = null;
         var found = await DeterministicWait.UntilAsync(
@@ -451,6 +733,22 @@ public sealed partial class UIAutomationService
             {
                 openButton = await _staThread.ExecuteAsync(() =>
                 {
+                    // AutomationId "1" is the default confirmation button in standard shell
+                    // dialogs. Prefer it over accessible name because the dialog can contain
+                    // another visible "Open" command in its navigation surface.
+                    var idCondition = Uia.CreateAndCondition(
+                        Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Button),
+                        Uia.CreatePropertyCondition(UIA3PropertyIds.AutomationId, "1"));
+                    var defaultButton = dialog.FindFirst(
+                        UIA.TreeScope.TreeScope_Descendants,
+                        idCondition);
+                    if (defaultButton is not null &&
+                        defaultButton.IsEnabled() &&
+                        !defaultButton.IsOffscreen())
+                    {
+                        return defaultButton;
+                    }
+
                     string[] openButtonNames = ["Open", "&Open"];
                     foreach (var name in openButtonNames)
                     {
@@ -458,17 +756,15 @@ public sealed partial class UIAutomationService
                             Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Button),
                             Uia.CreatePropertyCondition(UIA3PropertyIds.Name, name));
                         var button = dialog.FindFirst(UIA.TreeScope.TreeScope_Descendants, condition);
-                        if (button != null)
+                        if (button is not null &&
+                            button.IsEnabled() &&
+                            !button.IsOffscreen())
                         {
                             return button;
                         }
                     }
 
-                    // AutomationId "1" is the default OK/Open button in shell file dialogs.
-                    var idCondition = Uia.CreateAndCondition(
-                        Uia.CreatePropertyCondition(UIA3PropertyIds.ControlType, UIA3ControlTypeIds.Button),
-                        Uia.CreatePropertyCondition(UIA3PropertyIds.AutomationId, "1"));
-                    return dialog.FindFirst(UIA.TreeScope.TreeScope_Descendants, idCondition);
+                    return null;
                 }, cancellationToken);
                 return openButton != null;
             },
@@ -481,10 +777,29 @@ public sealed partial class UIAutomationService
 
         if (!found || openButton == null)
         {
-            return false;
+            return new ElementActionOutcome(
+                false,
+                ErrorMessage: "No visible Open button was found in the native dialog.",
+                ActionPath: "open_button_find");
         }
 
-        var outcome = await ExecuteElementActionAsync(openButton, dialog, fallbackClickPoint: null, cancellationToken);
-        return outcome.Success;
+        if (!allowPhysicalFallback)
+        {
+            var invoked = await _staThread.ExecuteAsync(
+                () => openButton.TryInvoke(),
+                cancellationToken);
+            return invoked
+                ? new ElementActionOutcome(true, ActionPath: "semantic_invoke")
+                : new ElementActionOutcome(
+                    false,
+                    ErrorMessage: "The native dialog's default Open button did not support semantic invocation.",
+                    ActionPath: "semantic_invoke");
+        }
+
+        return await ExecuteElementActionAsync(
+            openButton,
+            dialog,
+            fallbackClickPoint: null,
+            cancellationToken);
     }
 }

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Patterns.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Patterns.cs
@@ -18,13 +18,15 @@ public sealed partial class UIAutomationService
         {
             return await _staThread.ExecuteAsync(() =>
             {
-                var element = ElementIdGenerator.ResolveToAutomationElement(elementId);
+                var element = ElementIdGenerator.ResolveToAutomationElement(
+                    elementId,
+                    allowSelectorFallback: false);
                 if (element == null)
                 {
                     return UIAutomationResult.CreateFailure(
                         "invoke",
-                        UIAutomationErrorType.ElementNotFound,
-                        $"Element not found or stale: {elementId}",
+                        UIAutomationErrorType.ElementStale,
+                        $"Element is stale: {elementId}. Refresh UI state before invoking a pattern.",
                         CreateDiagnostics(stopwatch));
                 }
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Scroll.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Scroll.cs
@@ -21,14 +21,16 @@ public sealed partial class UIAutomationService
             if (!string.IsNullOrEmpty(elementId))
             {
                 element = await _staThread.ExecuteAsync(() =>
-                    ElementIdGenerator.ResolveToAutomationElement(elementId), cancellationToken);
+                    ElementIdGenerator.ResolveToAutomationElement(
+                        elementId,
+                        allowSelectorFallback: false), cancellationToken);
 
                 if (element == null)
                 {
                     return UIAutomationResult.CreateFailure(
                         "scroll_into_view",
-                        UIAutomationErrorType.ElementNotFound,
-                        $"Element with ID '{elementId}' not found.",
+                        UIAutomationErrorType.ElementStale,
+                        $"Element with ID '{elementId}' is stale. Refresh UI state before scrolling.",
                         CreateDiagnostics(stopwatch));
                 }
             }
@@ -46,7 +48,9 @@ public sealed partial class UIAutomationService
                 }
 
                 element = await _staThread.ExecuteAsync(() =>
-                    ElementIdGenerator.ResolveToAutomationElement(foundElement.ElementId), cancellationToken);
+                    ElementIdGenerator.ResolveToAutomationElement(
+                        foundElement.ElementId,
+                        allowSelectorFallback: false), cancellationToken);
             }
             else
             {

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -210,7 +210,7 @@ public sealed partial class UIAutomationService
 
         try
         {
-            while (stopwatch.ElapsedMilliseconds < timeoutMs)
+            while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -225,7 +225,14 @@ public sealed partial class UIAutomationService
                     return result with { Action = "wait_for" };
                 }
 
-                await DelayOrUntilStructureChangedAsync(signal, delay, cancellationToken).ConfigureAwait(false);
+                var remainingMs = timeoutMs - stopwatch.ElapsedMilliseconds;
+                if (remainingMs <= 0)
+                {
+                    break;
+                }
+
+                var boundedDelay = (int)Math.Min(delay, remainingMs);
+                await DelayOrUntilStructureChangedAsync(signal, boundedDelay, cancellationToken).ConfigureAwait(false);
                 delay = Math.Min(delay * 2, MaxDelay);
             }
 

--- a/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
+++ b/src/Sbroenne.WindowsMcp/Automation/UIAutomationService.Tree.cs
@@ -220,6 +220,11 @@ public sealed partial class UIAutomationService
                     return result with { Action = "wait_for" };
                 }
 
+                if (!IsRetryableWaitAbsence(result.ErrorType))
+                {
+                    return result with { Action = "wait_for" };
+                }
+
                 await DelayOrUntilStructureChangedAsync(signal, delay, cancellationToken).ConfigureAwait(false);
                 delay = Math.Min(delay * 2, MaxDelay);
             }
@@ -265,9 +270,25 @@ public sealed partial class UIAutomationService
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var result = await FindElementsAsync(query with { TimeoutMs = 0 }, cancellationToken);
-                if (!result.Success || (result.Items?.Length ?? 0) == 0)
+                if (!result.Success)
                 {
-                    // Element no longer found - success!
+                    if (IsSatisfiedDisappearAbsence(result.ErrorType))
+                    {
+                        stopwatch.Stop();
+                        return UIAutomationResult.CreateSuccess(
+                            "wait_for_disappear",
+                            new UIAutomationDiagnostics
+                            {
+                                DurationMs = stopwatch.ElapsedMilliseconds,
+                                Query = query
+                            });
+                    }
+
+                    return result with { Action = "wait_for_disappear" };
+                }
+
+                if ((result.Items?.Length ?? 0) == 0)
+                {
                     stopwatch.Stop();
                     return UIAutomationResult.CreateSuccess(
                         "wait_for_disappear",
@@ -304,6 +325,14 @@ public sealed partial class UIAutomationService
             }
         }
     }
+
+    private static bool IsRetryableWaitAbsence(string? errorType) =>
+        errorType is UIAutomationErrorType.ElementNotFound or UIAutomationErrorType.WindowNotFound;
+
+    private static bool IsSatisfiedDisappearAbsence(string? errorType) =>
+        errorType is UIAutomationErrorType.ElementNotFound or
+            UIAutomationErrorType.ElementStale or
+            UIAutomationErrorType.WindowNotFound;
 
     /// <inheritdoc/>
     public async Task<UIAutomationResult> WaitForElementStateAsync(string elementId, string desiredState, int timeoutMs, CancellationToken cancellationToken = default)

--- a/src/Sbroenne.WindowsMcp/Input/KeyboardInputService.cs
+++ b/src/Sbroenne.WindowsMcp/Input/KeyboardInputService.cs
@@ -424,6 +424,13 @@ public sealed class KeyboardInputService : IDisposable
             INPUT.Size);
         if (result != inputArray.Length)
         {
+            var insertedModifierCount = Math.Min((int)result, pressedModifiers.Count);
+            if (insertedModifierCount > 0)
+            {
+                _modifierKeyManager.ReleaseModifiers(
+                    pressedModifiers.Take(insertedModifierCount).ToArray());
+            }
+
             var error = Marshal.GetLastWin32Error();
             var (errorCode, errorMessage) = MapSendInputError(error);
             return KeyboardControlResult.CreateFailure(errorCode, errorMessage);
@@ -473,7 +480,21 @@ public sealed class KeyboardInputService : IDisposable
     }
 
     /// <inheritdoc />
-    public Task<KeyboardControlResult> KeyDownAsync(string keyName, CancellationToken cancellationToken = default)
+    public Task<KeyboardControlResult> KeyDownAsync(
+        string keyName,
+        CancellationToken cancellationToken = default) =>
+        KeyDownCoreAsync(keyName, expectedForegroundWindow: null, cancellationToken);
+
+    internal Task<KeyboardControlResult> KeyDownAsync(
+        string keyName,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        KeyDownCoreAsync(keyName, expectedForegroundWindow, cancellationToken);
+
+    private Task<KeyboardControlResult> KeyDownCoreAsync(
+        string keyName,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Validate key name
         if (string.IsNullOrWhiteSpace(keyName))
@@ -510,6 +531,13 @@ public sealed class KeyboardInputService : IDisposable
             CreateKeyboardInput((ushort)virtualKeyCode, 0, extendedFlag)
         };
 
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return Task.FromResult(KeyboardControlResult.CreateFailure(
+                KeyboardControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before the key-down event was sent."));
+        }
+
         var result = NativeMethods.SendInput(1, inputs, INPUT.Size);
 
         if (result != 1)
@@ -529,7 +557,21 @@ public sealed class KeyboardInputService : IDisposable
     }
 
     /// <inheritdoc />
-    public Task<KeyboardControlResult> KeyUpAsync(string keyName, CancellationToken cancellationToken = default)
+    public Task<KeyboardControlResult> KeyUpAsync(
+        string keyName,
+        CancellationToken cancellationToken = default) =>
+        KeyUpCoreAsync(keyName, expectedForegroundWindow: null, cancellationToken);
+
+    internal Task<KeyboardControlResult> KeyUpAsync(
+        string keyName,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        KeyUpCoreAsync(keyName, expectedForegroundWindow, cancellationToken);
+
+    private Task<KeyboardControlResult> KeyUpCoreAsync(
+        string keyName,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Validate key name
         if (string.IsNullOrWhiteSpace(keyName))
@@ -559,6 +601,13 @@ public sealed class KeyboardInputService : IDisposable
         {
             CreateKeyboardInput((ushort)heldKeyState.VirtualKeyCode, 0, extendedFlag | NativeConstants.KEYEVENTF_KEYUP)
         };
+
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return Task.FromResult(KeyboardControlResult.CreateFailure(
+                KeyboardControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before the key-up event was sent."));
+        }
 
         var result = NativeMethods.SendInput(1, inputs, INPUT.Size);
 
@@ -617,7 +666,32 @@ public sealed class KeyboardInputService : IDisposable
     }
 
     /// <inheritdoc />
-    public async Task<KeyboardControlResult> ExecuteSequenceAsync(IReadOnlyList<KeySequenceItem> sequence, int? interKeyDelayMs = null, CancellationToken cancellationToken = default)
+    public Task<KeyboardControlResult> ExecuteSequenceAsync(
+        IReadOnlyList<KeySequenceItem> sequence,
+        int? interKeyDelayMs = null,
+        CancellationToken cancellationToken = default) =>
+        ExecuteSequenceCoreAsync(
+            sequence,
+            interKeyDelayMs,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    internal Task<KeyboardControlResult> ExecuteSequenceAsync(
+        IReadOnlyList<KeySequenceItem> sequence,
+        int? interKeyDelayMs,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        ExecuteSequenceCoreAsync(
+            sequence,
+            interKeyDelayMs,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private async Task<KeyboardControlResult> ExecuteSequenceCoreAsync(
+        IReadOnlyList<KeySequenceItem> sequence,
+        int? interKeyDelayMs,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (sequence == null || sequence.Count == 0)
         {
@@ -635,7 +709,18 @@ public sealed class KeyboardInputService : IDisposable
             var itemDelay = item.DelayMs ?? delay;
 
             // Press the key with modifiers
-            var result = await PressKeyAsync(item.Key, item.Modifiers, 1, cancellationToken).ConfigureAwait(false);
+            var result = expectedForegroundWindow.HasValue
+                ? await PressKeyAsync(
+                    item.Key,
+                    item.Modifiers,
+                    1,
+                    expectedForegroundWindow.Value,
+                    cancellationToken).ConfigureAwait(false)
+                : await PressKeyAsync(
+                    item.Key,
+                    item.Modifiers,
+                    1,
+                    cancellationToken).ConfigureAwait(false);
 
             if (!result.Success)
             {

--- a/src/Sbroenne.WindowsMcp/Input/KeyboardInputService.cs
+++ b/src/Sbroenne.WindowsMcp/Input/KeyboardInputService.cs
@@ -48,7 +48,25 @@ public sealed class KeyboardInputService : IDisposable
     }
 
     /// <inheritdoc />
-    public async Task<KeyboardControlResult> TypeTextAsync(string text, CancellationToken cancellationToken = default)
+    public Task<KeyboardControlResult> TypeTextAsync(
+        string text,
+        CancellationToken cancellationToken = default) =>
+        TypeTextCoreAsync(text, expectedForegroundWindow: null, cancellationToken);
+
+    /// <summary>
+    /// Types text only while the specified top-level window remains foreground.
+    /// The guard is checked immediately before every SendInput chunk.
+    /// </summary>
+    internal Task<KeyboardControlResult> TypeTextAsync(
+        string text,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        TypeTextCoreAsync(text, expectedForegroundWindow, cancellationToken);
+
+    private async Task<KeyboardControlResult> TypeTextCoreAsync(
+        string text,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Handle null or empty text
         if (string.IsNullOrEmpty(text))
@@ -69,7 +87,7 @@ public sealed class KeyboardInputService : IDisposable
             var chunk = text.Substring(offset, currentChunkSize);
 
             // Type the chunk
-            var chunkResult = TypeChunk(chunk);
+            var chunkResult = TypeChunk(chunk, expectedForegroundWindow);
             if (!chunkResult.Success)
             {
                 return chunkResult;
@@ -94,8 +112,13 @@ public sealed class KeyboardInputService : IDisposable
     /// Types a single chunk of text using KEYEVENTF_UNICODE.
     /// </summary>
     /// <param name="chunk">The text chunk to type.</param>
+    /// <param name="expectedForegroundWindow">
+    /// Optional top-level window that must remain foreground.
+    /// </param>
     /// <returns>The result of the operation.</returns>
-    private static KeyboardControlResult TypeChunk(string chunk)
+    private static KeyboardControlResult TypeChunk(
+        string chunk,
+        nint? expectedForegroundWindow)
     {
         var inputs = new List<INPUT>();
 
@@ -146,6 +169,13 @@ public sealed class KeyboardInputService : IDisposable
         if (inputs.Count == 0)
         {
             return KeyboardControlResult.CreateTypeSuccess(0);
+        }
+
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return KeyboardControlResult.CreateFailure(
+                KeyboardControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before text input was sent.");
         }
 
         // Send all inputs at once
@@ -210,7 +240,41 @@ public sealed class KeyboardInputService : IDisposable
     }
 
     /// <inheritdoc />
-    public Task<KeyboardControlResult> PressKeyAsync(string keyName, ModifierKey modifiers = ModifierKey.None, int repeat = 1, CancellationToken cancellationToken = default)
+    public Task<KeyboardControlResult> PressKeyAsync(
+        string keyName,
+        ModifierKey modifiers = ModifierKey.None,
+        int repeat = 1,
+        CancellationToken cancellationToken = default) =>
+        PressKeyCoreAsync(
+            keyName,
+            modifiers,
+            repeat,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    /// <summary>
+    /// Presses a key only if the specified top-level window is still foreground immediately
+    /// before the atomic SendInput call.
+    /// </summary>
+    internal Task<KeyboardControlResult> PressKeyAsync(
+        string keyName,
+        ModifierKey modifiers,
+        int repeat,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        PressKeyCoreAsync(
+            keyName,
+            modifiers,
+            repeat,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private Task<KeyboardControlResult> PressKeyCoreAsync(
+        string keyName,
+        ModifierKey modifiers,
+        int repeat,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Validate key name
         if (string.IsNullOrWhiteSpace(keyName))
@@ -237,6 +301,17 @@ public sealed class KeyboardInputService : IDisposable
         if (repeat < 1)
         {
             repeat = 1;
+        }
+
+        if (expectedForegroundWindow.HasValue)
+        {
+            return Task.FromResult(PressKeyGuarded(
+                keyName,
+                virtualKeyCode,
+                modifiers,
+                repeat,
+                expectedForegroundWindow.Value,
+                cancellationToken));
         }
 
         // Determine if this is an extended key
@@ -277,6 +352,124 @@ public sealed class KeyboardInputService : IDisposable
             // Always release modifiers that we pressed
             _modifierKeyManager.ReleaseModifiers(pressedModifiers);
         }
+    }
+
+    private KeyboardControlResult PressKeyGuarded(
+        string keyName,
+        int virtualKeyCode,
+        ModifierKey modifiers,
+        int repeat,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
+    {
+        var inputs = new List<INPUT>();
+        var pressedModifiers = new List<int>();
+
+        AddGuardedModifierInput(
+            inputs,
+            pressedModifiers,
+            modifiers,
+            ModifierKey.Ctrl,
+            NativeConstants.VK_CONTROL);
+        AddGuardedModifierInput(
+            inputs,
+            pressedModifiers,
+            modifiers,
+            ModifierKey.Shift,
+            NativeConstants.VK_SHIFT);
+        AddGuardedModifierInput(
+            inputs,
+            pressedModifiers,
+            modifiers,
+            ModifierKey.Alt,
+            NativeConstants.VK_MENU);
+        AddGuardedModifierInput(
+            inputs,
+            pressedModifiers,
+            modifiers,
+            ModifierKey.Win,
+            NativeConstants.VK_LWIN);
+
+        var isExtended = VirtualKeyMapper.IsExtendedKey(virtualKeyCode);
+        var extendedFlag = isExtended ? NativeConstants.KEYEVENTF_EXTENDEDKEY : 0u;
+        for (var index = 0; index < repeat; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            inputs.Add(CreateKeyboardInput((ushort)virtualKeyCode, 0, extendedFlag));
+            inputs.Add(CreateKeyboardInput(
+                (ushort)virtualKeyCode,
+                0,
+                extendedFlag | NativeConstants.KEYEVENTF_KEYUP));
+        }
+
+        for (var index = pressedModifiers.Count - 1; index >= 0; index--)
+        {
+            inputs.Add(CreateKeyboardInput(
+                (ushort)pressedModifiers[index],
+                0,
+                NativeConstants.KEYEVENTF_KEYUP));
+        }
+
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return KeyboardControlResult.CreateFailure(
+                KeyboardControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before the key press was sent.");
+        }
+
+        var inputArray = inputs.ToArray();
+        var result = NativeMethods.SendInput(
+            (uint)inputArray.Length,
+            inputArray,
+            INPUT.Size);
+        if (result != inputArray.Length)
+        {
+            var error = Marshal.GetLastWin32Error();
+            var (errorCode, errorMessage) = MapSendInputError(error);
+            return KeyboardControlResult.CreateFailure(errorCode, errorMessage);
+        }
+
+        return KeyboardControlResult.CreatePressSuccess(
+            keyName.ToLowerInvariant());
+    }
+
+    private void AddGuardedModifierInput(
+        List<INPUT> inputs,
+        List<int> pressedModifiers,
+        ModifierKey requestedModifiers,
+        ModifierKey modifier,
+        int virtualKeyCode)
+    {
+        if (!requestedModifiers.HasFlag(modifier) ||
+            _modifierKeyManager.IsKeyPressed(virtualKeyCode))
+        {
+            return;
+        }
+
+        inputs.Add(CreateKeyboardInput((ushort)virtualKeyCode, 0, 0));
+        pressedModifiers.Add(virtualKeyCode);
+    }
+
+    private static bool IsExpectedForegroundWindow(
+        nint? expectedForegroundWindow)
+    {
+        if (!expectedForegroundWindow.HasValue)
+        {
+            return true;
+        }
+
+        var expectedRoot = NativeMethods.GetAncestor(
+            expectedForegroundWindow.Value,
+            NativeConstants.GA_ROOT);
+        var foreground = NativeMethods.GetForegroundWindow();
+        var foregroundRoot = NativeMethods.GetAncestor(
+            foreground,
+            NativeConstants.GA_ROOT);
+        return foreground != IntPtr.Zero &&
+            (expectedRoot != IntPtr.Zero
+                ? expectedRoot
+                : expectedForegroundWindow.Value) ==
+            (foregroundRoot != IntPtr.Zero ? foregroundRoot : foreground);
     }
 
     /// <inheritdoc />

--- a/src/Sbroenne.WindowsMcp/Input/ModifierKeyManager.cs
+++ b/src/Sbroenne.WindowsMcp/Input/ModifierKeyManager.cs
@@ -10,7 +10,12 @@ namespace Sbroenne.WindowsMcp.Input;
 public class ModifierKeyManager
 {
     /// <inheritdoc/>
-    public IReadOnlyList<int> PressModifiers(ModifierKey modifiers)
+    public IReadOnlyList<int> PressModifiers(ModifierKey modifiers) =>
+        PressModifiers(modifiers, expectedForegroundWindow: null);
+
+    internal IReadOnlyList<int> PressModifiers(
+        ModifierKey modifiers,
+        nint? expectedForegroundWindow)
     {
         var pressedKeys = new List<int>();
 
@@ -19,7 +24,9 @@ public class ModifierKeyManager
             return pressedKeys;
         }
 
-        if (modifiers.HasFlag(ModifierKey.Ctrl) && !IsKeyPressed(NativeConstants.VK_CONTROL))
+        if (modifiers.HasFlag(ModifierKey.Ctrl) &&
+            !IsKeyPressed(NativeConstants.VK_CONTROL) &&
+            IsExpectedForegroundWindow(expectedForegroundWindow))
         {
             if (SendKeyInput(NativeConstants.VK_CONTROL, keyUp: false))
             {
@@ -27,7 +34,9 @@ public class ModifierKeyManager
             }
         }
 
-        if (modifiers.HasFlag(ModifierKey.Shift) && !IsKeyPressed(NativeConstants.VK_SHIFT))
+        if (modifiers.HasFlag(ModifierKey.Shift) &&
+            !IsKeyPressed(NativeConstants.VK_SHIFT) &&
+            IsExpectedForegroundWindow(expectedForegroundWindow))
         {
             if (SendKeyInput(NativeConstants.VK_SHIFT, keyUp: false))
             {
@@ -35,7 +44,9 @@ public class ModifierKeyManager
             }
         }
 
-        if (modifiers.HasFlag(ModifierKey.Alt) && !IsKeyPressed(NativeConstants.VK_MENU))
+        if (modifiers.HasFlag(ModifierKey.Alt) &&
+            !IsKeyPressed(NativeConstants.VK_MENU) &&
+            IsExpectedForegroundWindow(expectedForegroundWindow))
         {
             if (SendKeyInput(NativeConstants.VK_MENU, keyUp: false))
             {
@@ -43,7 +54,9 @@ public class ModifierKeyManager
             }
         }
 
-        if (modifiers.HasFlag(ModifierKey.Win) && !IsKeyPressed(NativeConstants.VK_LWIN))
+        if (modifiers.HasFlag(ModifierKey.Win) &&
+            !IsKeyPressed(NativeConstants.VK_LWIN) &&
+            IsExpectedForegroundWindow(expectedForegroundWindow))
         {
             if (SendKeyInput(NativeConstants.VK_LWIN, keyUp: false))
             {
@@ -52,6 +65,25 @@ public class ModifierKeyManager
         }
 
         return pressedKeys;
+    }
+
+    private static bool IsExpectedForegroundWindow(nint? expectedForegroundWindow)
+    {
+        if (!expectedForegroundWindow.HasValue)
+        {
+            return true;
+        }
+
+        var expectedRoot = NativeMethods.GetAncestor(
+            expectedForegroundWindow.Value,
+            NativeConstants.GA_ROOT);
+        var foreground = NativeMethods.GetForegroundWindow();
+        var foregroundRoot = NativeMethods.GetAncestor(
+            foreground,
+            NativeConstants.GA_ROOT);
+        return foreground != IntPtr.Zero &&
+            (expectedRoot != IntPtr.Zero ? expectedRoot : expectedForegroundWindow.Value) ==
+            (foregroundRoot != IntPtr.Zero ? foregroundRoot : foreground);
     }
 
     /// <inheritdoc/>

--- a/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
+++ b/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
@@ -19,17 +19,33 @@ public sealed class MouseInputService
             expectedForegroundWindow: null,
             cancellationToken);
 
+    internal Task<MouseControlResult> MoveAsync(
+        int x,
+        int y,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        MoveCoreAsync(
+            x,
+            y,
+            extraFlags: 0,
+            expectedForegroundWindow,
+            cancellationToken);
+
     /// <summary>
     /// Moves the cursor as part of a held-button stroke. Sets <c>MOUSEEVENTF_MOVE_NOCOALESCE</c> so Windows
     /// delivers this vertex to the target even when the target thread is busy; a plain move may be coalesced
     /// with the next one, which would cut across the corner between them.
     /// </summary>
-    private Task<MouseControlResult> MoveForStrokeAsync(int x, int y, CancellationToken cancellationToken) =>
+    private Task<MouseControlResult> MoveForStrokeAsync(
+        int x,
+        int y,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken) =>
         MoveCoreAsync(
             x,
             y,
             NativeConstants.MOUSEEVENTF_MOVE_NOCOALESCE,
-            expectedForegroundWindow: null,
+            expectedForegroundWindow,
             cancellationToken);
 
     private static Task<MouseControlResult> MoveCoreAsync(
@@ -185,7 +201,17 @@ public sealed class MouseInputService
                     screenBounds));
             }
 
-            pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+            pressedModifiers = _modifierKeyManager.PressModifiers(
+                modifiers,
+                expectedForegroundWindow);
+
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return Task.FromResult(MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed while preparing the click.",
+                    screenBounds));
+            }
 
             // Build the INPUT structures for mouse down and mouse up
             var inputs = new INPUT[]
@@ -447,7 +473,17 @@ public sealed class MouseInputService
                     screenBounds);
             }
 
-            pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+            pressedModifiers = _modifierKeyManager.PressModifiers(
+                modifiers,
+                expectedForegroundWindow);
+
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed while preparing the double-click.",
+                    screenBounds);
+            }
 
             // Build the INPUT structures for double-click (4 events: down, up, down, up)
             // Windows recognizes a double-click when two clicks occur within GetDoubleClickTime() milliseconds
@@ -549,7 +585,37 @@ public sealed class MouseInputService
     }
 
     /// <inheritdoc />
-    public Task<MouseControlResult> RightClickAsync(int? x, int? y, ModifierKey modifiers = ModifierKey.None, CancellationToken cancellationToken = default)
+    public Task<MouseControlResult> RightClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers = ModifierKey.None,
+        CancellationToken cancellationToken = default) =>
+        RightClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    internal Task<MouseControlResult> RightClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        RightClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private Task<MouseControlResult> RightClickCoreAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         ScreenBounds? screenBounds = null;
 
@@ -568,7 +634,12 @@ public sealed class MouseInputService
             }
 
             // Move to the coordinates first
-            var moveResult = MoveAsync(x.Value, y.Value, cancellationToken).GetAwaiter().GetResult();
+            var moveResult = MoveCoreAsync(
+                x.Value,
+                y.Value,
+                extraFlags: 0,
+                expectedForegroundWindow,
+                cancellationToken).GetAwaiter().GetResult();
             if (!moveResult.Success)
             {
                 return Task.FromResult(moveResult);
@@ -583,10 +654,28 @@ public sealed class MouseInputService
         var targetWindowInfo = GetTargetWindowInfoAtPoint(currentPos.X, currentPos.Y);
 
         // Press modifier keys before the click
-        var pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+        var pressedModifiers = _modifierKeyManager.PressModifiers(
+            modifiers,
+            expectedForegroundWindow);
 
         try
         {
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return Task.FromResult(MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed before the right-click was sent.",
+                    screenBounds));
+            }
+
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return Task.FromResult(MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed while preparing the right-click.",
+                    screenBounds));
+            }
+
             // Build the INPUT structures for right mouse down and right mouse up
             var inputs = new INPUT[]
             {
@@ -652,7 +741,32 @@ public sealed class MouseInputService
     }
 
     /// <inheritdoc />
-    public Task<MouseControlResult> MiddleClickAsync(int? x, int? y, CancellationToken cancellationToken = default)
+    public Task<MouseControlResult> MiddleClickAsync(
+        int? x,
+        int? y,
+        CancellationToken cancellationToken = default) =>
+        MiddleClickCoreAsync(
+            x,
+            y,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    internal Task<MouseControlResult> MiddleClickAsync(
+        int? x,
+        int? y,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        MiddleClickCoreAsync(
+            x,
+            y,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private Task<MouseControlResult> MiddleClickCoreAsync(
+        int? x,
+        int? y,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         ScreenBounds? screenBounds = null;
 
@@ -671,7 +785,12 @@ public sealed class MouseInputService
             }
 
             // Move to the coordinates first
-            var moveResult = MoveAsync(x.Value, y.Value, cancellationToken).GetAwaiter().GetResult();
+            var moveResult = MoveCoreAsync(
+                x.Value,
+                y.Value,
+                extraFlags: 0,
+                expectedForegroundWindow,
+                cancellationToken).GetAwaiter().GetResult();
             if (!moveResult.Success)
             {
                 return Task.FromResult(moveResult);
@@ -722,6 +841,14 @@ public sealed class MouseInputService
             },
         };
 
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return Task.FromResult(MouseControlResult.CreateFailure(
+                MouseControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before the middle-click was sent.",
+                screenBounds));
+        }
+
         // Send the input
         var result = NativeMethods.SendInput(2, inputs, INPUT.Size);
 
@@ -745,7 +872,27 @@ public sealed class MouseInputService
 
     /// <inheritdoc />
     public Task<MouseControlResult> DragAsync(int startX, int startY, int endX, int endY, MouseButton button = MouseButton.Left, CancellationToken cancellationToken = default) =>
-        StrokeAsync([new Coordinates(startX, startY), new Coordinates(endX, endY)], button, ModifierKey.None, cancellationToken);
+        StrokeCoreAsync(
+            [new Coordinates(startX, startY), new Coordinates(endX, endY)],
+            button,
+            ModifierKey.None,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    internal Task<MouseControlResult> DragAsync(
+        int startX,
+        int startY,
+        int endX,
+        int endY,
+        MouseButton button,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        StrokeCoreAsync(
+            [new Coordinates(startX, startY), new Coordinates(endX, endY)],
+            button,
+            ModifierKey.None,
+            expectedForegroundWindow,
+            cancellationToken);
 
     /// <summary>
     /// Presses a mouse button at the first point, moves through every remaining point, and releases at the last -
@@ -757,7 +904,8 @@ public sealed class MouseInputService
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A result whose final position is the last point, with target window info sampled at the first point.</returns>
     /// <remarks>
-    /// <see cref="DragAsync"/> is the two-point case of this method, so drag and stroke can never diverge.
+    /// <see cref="DragAsync(int, int, int, int, MouseButton, CancellationToken)"/> is the two-point
+    /// case of this method, so drag and stroke can never diverge.
     /// Every move after the press is sent with <c>MOUSEEVENTF_MOVE_NOCOALESCE</c> so no vertex is dropped when the
     /// target thread is busy. The button is always released in a <c>finally</c> block, even when a move fails partway through.
     /// </remarks>
@@ -765,7 +913,33 @@ public sealed class MouseInputService
         IReadOnlyList<Coordinates> points,
         MouseButton button = MouseButton.Left,
         ModifierKey modifiers = ModifierKey.None,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        await StrokeCoreAsync(
+            points,
+            button,
+            modifiers,
+            expectedForegroundWindow: null,
+            cancellationToken).ConfigureAwait(false);
+
+    internal Task<MouseControlResult> StrokeAsync(
+        IReadOnlyList<Coordinates> points,
+        MouseButton button,
+        ModifierKey modifiers,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        StrokeCoreAsync(
+            points,
+            button,
+            modifiers,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private async Task<MouseControlResult> StrokeCoreAsync(
+        IReadOnlyList<Coordinates> points,
+        MouseButton button,
+        ModifierKey modifiers,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (points is null || points.Count < 2)
         {
@@ -791,7 +965,12 @@ public sealed class MouseInputService
         }
 
         // Step 1: Move to the first point
-        var moveToStartResult = await MoveAsync(points[0].X, points[0].Y, cancellationToken);
+        var moveToStartResult = await MoveCoreAsync(
+            points[0].X,
+            points[0].Y,
+            extraFlags: 0,
+            expectedForegroundWindow,
+            cancellationToken).ConfigureAwait(false);
         if (!moveToStartResult.Success)
         {
             return moveToStartResult;
@@ -819,7 +998,9 @@ public sealed class MouseInputService
                 break;
         }
 
-        var pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+        var pressedModifiers = _modifierKeyManager.PressModifiers(
+            modifiers,
+            expectedForegroundWindow);
         var result = MouseControlResult.CreateFailure(
             MouseControlErrorCode.UnexpectedError,
             "Stroke could not complete.",
@@ -828,6 +1009,15 @@ public sealed class MouseInputService
 
         try
         {
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                result = MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed before the stroke was sent.",
+                    screenBounds);
+                goto Finish;
+            }
+
             // Step 2: Press the mouse button down
             var buttonDownInput = new INPUT[]
             {
@@ -866,7 +1056,11 @@ public sealed class MouseInputService
             // Step 3: Trace through the remaining points with the button held
             for (var i = 1; i < points.Count; i++)
             {
-                var moveResult = await MoveForStrokeAsync(points[i].X, points[i].Y, cancellationToken);
+                var moveResult = await MoveForStrokeAsync(
+                    points[i].X,
+                    points[i].Y,
+                    expectedForegroundWindow,
+                    cancellationToken);
                 if (!moveResult.Success)
                 {
                     result = moveResult;
@@ -928,7 +1122,42 @@ public sealed class MouseInputService
     }
 
     /// <inheritdoc />
-    public Task<MouseControlResult> ScrollAsync(ScrollDirection direction, int amount, int? x, int? y, CancellationToken cancellationToken = default)
+    public Task<MouseControlResult> ScrollAsync(
+        ScrollDirection direction,
+        int amount,
+        int? x,
+        int? y,
+        CancellationToken cancellationToken = default) =>
+        ScrollCoreAsync(
+            direction,
+            amount,
+            x,
+            y,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    internal Task<MouseControlResult> ScrollAsync(
+        ScrollDirection direction,
+        int amount,
+        int? x,
+        int? y,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        ScrollCoreAsync(
+            direction,
+            amount,
+            x,
+            y,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private Task<MouseControlResult> ScrollCoreAsync(
+        ScrollDirection direction,
+        int amount,
+        int? x,
+        int? y,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         ScreenBounds? screenBounds = null;
 
@@ -947,7 +1176,12 @@ public sealed class MouseInputService
             }
 
             // Move to the coordinates first
-            var moveResult = MoveAsync(x.Value, y.Value, cancellationToken).GetAwaiter().GetResult();
+            var moveResult = MoveCoreAsync(
+                x.Value,
+                y.Value,
+                extraFlags: 0,
+                expectedForegroundWindow,
+                cancellationToken).GetAwaiter().GetResult();
             if (!moveResult.Success)
             {
                 return Task.FromResult(moveResult);
@@ -1017,6 +1251,14 @@ public sealed class MouseInputService
                 },
             },
         };
+
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return Task.FromResult(MouseControlResult.CreateFailure(
+                MouseControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before scrolling was sent.",
+                screenBounds));
+        }
 
         // Send the input
         var result = NativeMethods.SendInput(1, inputs, INPUT.Size);

--- a/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
+++ b/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
@@ -362,7 +362,41 @@ public sealed class MouseInputService
     }
 
     /// <inheritdoc />
-    public async Task<MouseControlResult> DoubleClickAsync(int? x, int? y, ModifierKey modifiers = ModifierKey.None, CancellationToken cancellationToken = default)
+    public Task<MouseControlResult> DoubleClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers = ModifierKey.None,
+        CancellationToken cancellationToken = default) =>
+        DoubleClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    /// <summary>
+    /// Double-clicks only while the specified top-level window remains foreground.
+    /// The guard is checked immediately before pointer movement and double-click injection.
+    /// </summary>
+    internal Task<MouseControlResult> DoubleClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        DoubleClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private async Task<MouseControlResult> DoubleClickCoreAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         ScreenBounds? screenBounds = null;
 
@@ -381,7 +415,12 @@ public sealed class MouseInputService
             }
 
             // Move to the coordinates first
-            var moveResult = await MoveAsync(x.Value, y.Value, cancellationToken).ConfigureAwait(false);
+            var moveResult = await MoveCoreAsync(
+                x.Value,
+                y.Value,
+                extraFlags: 0,
+                expectedForegroundWindow,
+                cancellationToken).ConfigureAwait(false);
             if (!moveResult.Success)
             {
                 return moveResult;
@@ -396,10 +435,20 @@ public sealed class MouseInputService
         var targetWindowInfo = GetTargetWindowInfoAtPoint(currentPos.X, currentPos.Y);
 
         // Press modifier keys before the double-click
-        var pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+        IReadOnlyList<int> pressedModifiers = [];
 
         try
         {
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed before the double-click was sent.",
+                    screenBounds);
+            }
+
+            pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
+
             // Build the INPUT structures for double-click (4 events: down, up, down, up)
             // Windows recognizes a double-click when two clicks occur within GetDoubleClickTime() milliseconds
             // at the same location. When events are queued in a single SendInput batch, they need a short settle

--- a/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
+++ b/src/Sbroenne.WindowsMcp/Input/MouseInputService.cs
@@ -12,7 +12,12 @@ public sealed class MouseInputService
     private readonly ModifierKeyManager _modifierKeyManager = new();
     /// <inheritdoc />
     public Task<MouseControlResult> MoveAsync(int x, int y, CancellationToken cancellationToken = default) =>
-        MoveCoreAsync(x, y, extraFlags: 0, cancellationToken);
+        MoveCoreAsync(
+            x,
+            y,
+            extraFlags: 0,
+            expectedForegroundWindow: null,
+            cancellationToken);
 
     /// <summary>
     /// Moves the cursor as part of a held-button stroke. Sets <c>MOUSEEVENTF_MOVE_NOCOALESCE</c> so Windows
@@ -20,9 +25,19 @@ public sealed class MouseInputService
     /// with the next one, which would cut across the corner between them.
     /// </summary>
     private Task<MouseControlResult> MoveForStrokeAsync(int x, int y, CancellationToken cancellationToken) =>
-        MoveCoreAsync(x, y, NativeConstants.MOUSEEVENTF_MOVE_NOCOALESCE, cancellationToken);
+        MoveCoreAsync(
+            x,
+            y,
+            NativeConstants.MOUSEEVENTF_MOVE_NOCOALESCE,
+            expectedForegroundWindow: null,
+            cancellationToken);
 
-    private static Task<MouseControlResult> MoveCoreAsync(int x, int y, uint extraFlags, CancellationToken cancellationToken)
+    private static Task<MouseControlResult> MoveCoreAsync(
+        int x,
+        int y,
+        uint extraFlags,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Validate coordinates against virtual screen bounds
         var (isValid, screenBounds) = CoordinateNormalizer.ValidateCoordinates(x, y);
@@ -56,6 +71,14 @@ public sealed class MouseInputService
             },
         };
 
+        if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+        {
+            return Task.FromResult(MouseControlResult.CreateFailure(
+                MouseControlErrorCode.WrongTargetWindow,
+                "The foreground window changed before the pointer move was sent.",
+                screenBounds));
+        }
+
         // Send the input
         var inputSpan = new INPUT[] { input };
         var result = NativeMethods.SendInput(1, inputSpan, INPUT.Size);
@@ -78,7 +101,41 @@ public sealed class MouseInputService
     }
 
     /// <inheritdoc />
-    public Task<MouseControlResult> ClickAsync(int? x, int? y, ModifierKey modifiers = ModifierKey.None, CancellationToken cancellationToken = default)
+    public Task<MouseControlResult> ClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers = ModifierKey.None,
+        CancellationToken cancellationToken = default) =>
+        ClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow: null,
+            cancellationToken);
+
+    /// <summary>
+    /// Clicks only while the specified top-level window remains foreground.
+    /// The guard is checked immediately before pointer movement and click SendInput calls.
+    /// </summary>
+    internal Task<MouseControlResult> ClickAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken = default) =>
+        ClickCoreAsync(
+            x,
+            y,
+            modifiers,
+            expectedForegroundWindow,
+            cancellationToken);
+
+    private Task<MouseControlResult> ClickCoreAsync(
+        int? x,
+        int? y,
+        ModifierKey modifiers,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         ScreenBounds? screenBounds = null;
 
@@ -97,7 +154,12 @@ public sealed class MouseInputService
             }
 
             // Move to the coordinates first
-            var moveResult = MoveAsync(x.Value, y.Value, cancellationToken).GetAwaiter().GetResult();
+            var moveResult = MoveCoreAsync(
+                x.Value,
+                y.Value,
+                extraFlags: 0,
+                expectedForegroundWindow,
+                cancellationToken).GetAwaiter().GetResult();
             if (!moveResult.Success)
             {
                 return Task.FromResult(moveResult);
@@ -115,6 +177,14 @@ public sealed class MouseInputService
         IReadOnlyList<int> pressedModifiers = [];
         try
         {
+            if (!IsExpectedForegroundWindow(expectedForegroundWindow))
+            {
+                return Task.FromResult(MouseControlResult.CreateFailure(
+                    MouseControlErrorCode.WrongTargetWindow,
+                    "The foreground window changed before the click was sent.",
+                    screenBounds));
+            }
+
             pressedModifiers = _modifierKeyManager.PressModifiers(modifiers);
 
             // Build the INPUT structures for mouse down and mouse up
@@ -179,6 +249,28 @@ public sealed class MouseInputService
             // Always release modifiers that we pressed, even on failure
             _modifierKeyManager.ReleaseModifiers(pressedModifiers);
         }
+    }
+
+    private static bool IsExpectedForegroundWindow(
+        nint? expectedForegroundWindow)
+    {
+        if (!expectedForegroundWindow.HasValue)
+        {
+            return true;
+        }
+
+        var expectedRoot = NativeMethods.GetAncestor(
+            expectedForegroundWindow.Value,
+            NativeConstants.GA_ROOT);
+        var foreground = NativeMethods.GetForegroundWindow();
+        var foregroundRoot = NativeMethods.GetAncestor(
+            foreground,
+            NativeConstants.GA_ROOT);
+        return foreground != IntPtr.Zero &&
+            (expectedRoot != IntPtr.Zero
+                ? expectedRoot
+                : expectedForegroundWindow.Value) ==
+            (foregroundRoot != IntPtr.Zero ? foregroundRoot : foreground);
     }
 
     /// <summary>

--- a/src/Sbroenne.WindowsMcp/Models/BatchModels.cs
+++ b/src/Sbroenne.WindowsMcp/Models/BatchModels.cs
@@ -60,6 +60,30 @@ public sealed class BatchStep
     [JsonPropertyName("clearFirst")]
     public bool ClearFirst { get; set; }
 
+    /// <summary>Text input path for action=type: auto, keyboard, or value.</summary>
+    [JsonPropertyName("inputMode")]
+    public string? InputMode { get; set; }
+
+    /// <summary>Limit selector search to a known parent element.</summary>
+    [JsonPropertyName("parentElementId")]
+    public string? ParentElementId { get; set; }
+
+    /// <summary>Search root: window or active_dialog.</summary>
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    /// <summary>Fail when more than one element matches.</summary>
+    [JsonPropertyName("requireUnique")]
+    public bool RequireUnique { get; set; }
+
+    /// <summary>Exclude disabled elements when true.</summary>
+    [JsonPropertyName("enabledOnly")]
+    public bool? EnabledOnly { get; set; }
+
+    /// <summary>Exclude off-screen elements when true.</summary>
+    [JsonPropertyName("visibleOnly")]
+    public bool? VisibleOnly { get; set; }
+
     /// <summary>Key to press (action=key), e.g. enter, tab, f5, a.</summary>
     [JsonPropertyName("key")]
     public string? Key { get; set; }

--- a/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
+++ b/src/Sbroenne.WindowsMcp/Models/UIAutomationDiagnostics.cs
@@ -38,7 +38,7 @@ public sealed record UIAutomationDiagnostics
     /// <summary>
     /// Multiple matches when exactly one expected.
     /// </summary>
-    public UIElementInfo[]? MultipleMatches { get; init; }
+    public UIAutomationTargetDiagnostics[]? MultipleMatches { get; init; }
 
     /// <summary>
     /// Warnings about potential issues (e.g., Chromium app without accessibility flag).
@@ -55,6 +55,41 @@ public sealed record UIAutomationDiagnostics
     /// view (false). Null when not applicable. Used to observe the R5 content-view optimization.
     /// </summary>
     public bool? UsedContentView { get; init; }
+
+    /// <summary>
+    /// Concrete action path used, such as semantic invoke, physical click, value pattern,
+    /// keyboard input, shortcut, or wait.
+    /// </summary>
+    public string? ActionPath { get; init; }
+
+    /// <summary>
+    /// Element that was selected for the action. Values typed into the element are never included.
+    /// </summary>
+    public UIAutomationTargetDiagnostics? TargetElement { get; init; }
+}
+
+/// <summary>
+/// Privacy-safe details about the element selected for an action.
+/// </summary>
+public sealed record UIAutomationTargetDiagnostics
+{
+    /// <summary>Opaque element ID that can be used for a subsequent action.</summary>
+    public string? ElementId { get; init; }
+
+    /// <summary>Accessible name of the selected target.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Automation ID of the selected target.</summary>
+    public string? AutomationId { get; init; }
+
+    /// <summary>UI Automation control type of the selected target.</summary>
+    public string? ControlType { get; init; }
+
+    /// <summary>Whether the selected target was enabled when inspected.</summary>
+    public bool? IsEnabled { get; init; }
+
+    /// <summary>Whether UI Automation reported the selected target as off-screen.</summary>
+    public bool? IsOffscreen { get; init; }
 }
 
 /// <summary>
@@ -170,4 +205,21 @@ public sealed record ElementQuery
     /// the search automatically falls back to the control view if the content-view scan finds nothing.
     /// </summary>
     public bool? ContentViewOnly { get; init; }
+
+    /// <summary>
+    /// Search root: "window" (default) or "active_dialog". Active dialog resolves the enabled
+    /// popup owned by <see cref="WindowHandle"/>, which avoids matching duplicate controls behind
+    /// a modal dialog.
+    /// </summary>
+    public string? Scope { get; init; }
+
+    /// <summary>
+    /// Fail with multiple_matches when more than one element matches after filtering.
+    /// </summary>
+    public bool RequireUnique { get; init; }
+
+    /// <summary>
+    /// When true, exclude disabled elements from results.
+    /// </summary>
+    public bool? EnabledOnly { get; init; }
 }

--- a/src/Sbroenne.WindowsMcp/Native/NativeConstants.cs
+++ b/src/Sbroenne.WindowsMcp/Native/NativeConstants.cs
@@ -656,6 +656,9 @@ internal static class NativeConstants
 
     #region GetWindow Commands (GW_*)
 
+    /// <summary>Retrieves the owner window.</summary>
+    public const uint GW_OWNER = 4;
+
     /// <summary>Retrieves the enabled popup window owned by the specified window.</summary>
     public const uint GW_ENABLEDPOPUP = 6;
 

--- a/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/KeyboardControlTool.cs
@@ -104,23 +104,23 @@ public static partial class KeyboardControlTool
             switch (action)
             {
                 case KeyboardAction.Type:
-                    operationResult = await HandleTypeAsync(text, clearFirst, linkedToken);
+                    operationResult = await HandleTypeAsync(text, clearFirst, handle, linkedToken);
                     break;
 
                 case KeyboardAction.Press:
-                    operationResult = await HandlePressAsync(key, modifiers, repeat, linkedToken);
+                    operationResult = await HandlePressAsync(key, modifiers, repeat, handle, linkedToken);
                     break;
 
                 case KeyboardAction.KeyDown:
-                    operationResult = await HandleKeyDownAsync(key, linkedToken);
+                    operationResult = await HandleKeyDownAsync(key, handle, linkedToken);
                     break;
 
                 case KeyboardAction.KeyUp:
-                    operationResult = await HandleKeyUpAsync(key, linkedToken);
+                    operationResult = await HandleKeyUpAsync(key, handle, linkedToken);
                     break;
 
                 case KeyboardAction.Sequence:
-                    operationResult = await HandleSequenceAsync(sequence, interKeyDelayMs, linkedToken);
+                    operationResult = await HandleSequenceAsync(sequence, interKeyDelayMs, handle, linkedToken);
                     break;
 
                 case KeyboardAction.ReleaseAll:
@@ -184,7 +184,11 @@ public static partial class KeyboardControlTool
             IsError = true
         };
 
-    private static async Task<KeyboardControlResult> HandleTypeAsync(string? text, bool clearFirst, CancellationToken cancellationToken)
+    private static async Task<KeyboardControlResult> HandleTypeAsync(
+        string? text,
+        bool clearFirst,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         // Check for secure desktop
         if (WindowsToolsBase.SecureDesktopDetector.IsSecureDesktopActive())
@@ -205,11 +209,16 @@ public static partial class KeyboardControlTool
         // If clearFirst is true, select all existing content first (Ctrl+A)
         if (clearFirst)
         {
-            var selectAllResult = await WindowsToolsBase.KeyboardInputService.PressKeyAsync("a", ModifierKey.Ctrl, 1, cancellationToken);
+            var selectAllResult = await WindowsToolsBase.KeyboardInputService.PressKeyAsync(
+                "a",
+                ModifierKey.Ctrl,
+                1,
+                expectedForegroundWindow,
+                cancellationToken);
             if (!selectAllResult.Success)
             {
                 return KeyboardControlResult.CreateFailure(
-                    KeyboardControlErrorCode.SendInputFailed,
+                    selectAllResult.ErrorCode,
                     $"Failed to select all before typing: {selectAllResult.Error}");
             }
 
@@ -219,10 +228,18 @@ public static partial class KeyboardControlTool
         // Normalize Windows file paths: convert forward slashes to backslashes
         var normalizedText = PathNormalizer.NormalizeWindowsPath(text);
 
-        return await WindowsToolsBase.KeyboardInputService.TypeTextAsync(normalizedText, cancellationToken);
+        return await WindowsToolsBase.KeyboardInputService.TypeTextAsync(
+            normalizedText,
+            expectedForegroundWindow,
+            cancellationToken);
     }
 
-    private static async Task<KeyboardControlResult> HandlePressAsync(string? key, string? modifiers, int repeat, CancellationToken cancellationToken)
+    private static async Task<KeyboardControlResult> HandlePressAsync(
+        string? key,
+        string? modifiers,
+        int repeat,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(key))
         {
@@ -246,7 +263,12 @@ public static partial class KeyboardControlTool
         }
 
         var modifierKey = ParseModifiers(modifiers);
-        var result = await WindowsToolsBase.KeyboardInputService.PressKeyAsync(key, modifierKey, repeat, cancellationToken);
+        var result = await WindowsToolsBase.KeyboardInputService.PressKeyAsync(
+            key,
+            modifierKey,
+            repeat,
+            expectedForegroundWindow,
+            cancellationToken);
 
         if (result.Success)
         {
@@ -281,7 +303,10 @@ public static partial class KeyboardControlTool
         return result;
     }
 
-    private static async Task<KeyboardControlResult> HandleKeyDownAsync(string? key, CancellationToken cancellationToken)
+    private static async Task<KeyboardControlResult> HandleKeyDownAsync(
+        string? key,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(key))
         {
@@ -304,10 +329,16 @@ public static partial class KeyboardControlTool
                 "Cannot send keyboard input to an elevated (administrator) window. Run this tool as administrator or interact with a non-elevated window.");
         }
 
-        return await WindowsToolsBase.KeyboardInputService.KeyDownAsync(key, cancellationToken);
+        return await WindowsToolsBase.KeyboardInputService.KeyDownAsync(
+            key,
+            expectedForegroundWindow,
+            cancellationToken);
     }
 
-    private static async Task<KeyboardControlResult> HandleKeyUpAsync(string? key, CancellationToken cancellationToken)
+    private static async Task<KeyboardControlResult> HandleKeyUpAsync(
+        string? key,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(key))
         {
@@ -316,10 +347,17 @@ public static partial class KeyboardControlTool
                 "The 'key' parameter is required for key_up action");
         }
 
-        return await WindowsToolsBase.KeyboardInputService.KeyUpAsync(key, cancellationToken);
+        return await WindowsToolsBase.KeyboardInputService.KeyUpAsync(
+            key,
+            expectedForegroundWindow,
+            cancellationToken);
     }
 
-    private static async Task<KeyboardControlResult> HandleSequenceAsync(string? sequenceJson, int? interKeyDelayMs, CancellationToken cancellationToken)
+    private static async Task<KeyboardControlResult> HandleSequenceAsync(
+        string? sequenceJson,
+        int? interKeyDelayMs,
+        nint expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(sequenceJson))
         {
@@ -354,7 +392,11 @@ public static partial class KeyboardControlTool
                 $"Invalid sequence JSON: {ex.Message}. CORRECT FORMAT: JSON array with 'key' property.");
         }
 
-        var result = await WindowsToolsBase.KeyboardInputService.ExecuteSequenceAsync(sequence, interKeyDelayMs, cancellationToken);
+        var result = await WindowsToolsBase.KeyboardInputService.ExecuteSequenceAsync(
+            sequence,
+            interKeyDelayMs,
+            expectedForegroundWindow,
+            cancellationToken);
 
         if (result.Success)
         {

--- a/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
+++ b/src/Sbroenne.WindowsMcp/Tools/MouseControlTool.cs
@@ -50,7 +50,7 @@ public static partial class MouseControlTool
     /// <param name="monitorIndex">Monitor index (0-based). Alternative to target for 3+ monitor setups. Use screenshot_control action='list_monitors' to find indices.</param>
     /// <param name="expectedWindowTitle">Expected window title (partial match). If specified, operation fails if foreground window title doesn't match.</param>
     /// <param name="expectedProcessName">Expected process name. If specified, operation fails if foreground window's process doesn't match.</param>
-    /// <param name="windowHandle">Window handle for window-relative coordinates. When provided, x/y are relative to the window's top-left corner.</param>
+    /// <param name="windowHandle">Window handle for window-relative coordinates and foreground safety. When provided, x/y are relative to the window's top-left corner and input is aborted if that window loses foreground ownership.</param>
     /// <param name="points">JSON array of [x,y] pairs for action='polyline', e.g. '[[650,430],[750,480],[750,620]]'. At least 2 points. Drawn as ONE continuous stroke.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A call result containing a text content block with the JSON payload including success status, cursor position, monitor context, and 'target_window' for click actions. <c>IsError</c> reflects operation success.</returns>
@@ -79,6 +79,22 @@ public static partial class MouseControlTool
             using var timeoutCts = new CancellationTokenSource(WindowsToolsBase.TimeoutMs);
             using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
             var linkedToken = linkedCts.Token;
+            nint? expectedForegroundWindow = null;
+            nint? requestedWindowHandle = null;
+
+            if (!string.IsNullOrWhiteSpace(windowHandle))
+            {
+                if (!WindowHandleParser.TryParse(windowHandle, out var parsedWindowHandle) ||
+                    parsedWindowHandle == IntPtr.Zero)
+                {
+                    return ToCallToolResult(MouseControlResult.CreateFailure(
+                        MouseControlErrorCode.InvalidCoordinates,
+                        $"Invalid windowHandle: '{windowHandle}'. Expected decimal string from window_management."));
+                }
+
+                requestedWindowHandle = parsedWindowHandle;
+                expectedForegroundWindow = parsedWindowHandle;
+            }
 
             // Pre-flight check: verify target window if expected values are specified
             if (!string.IsNullOrEmpty(expectedWindowTitle) || !string.IsNullOrEmpty(expectedProcessName))
@@ -88,6 +104,8 @@ public static partial class MouseControlTool
                 {
                     return ToCallToolResult(targetCheckResult);
                 }
+
+                expectedForegroundWindow ??= NativeMethods.GetForegroundWindow();
             }
 
             // Parse the polyline point list up front so a malformed list fails before anything moves
@@ -111,13 +129,7 @@ public static partial class MouseControlTool
 
             if (isWindowRelativeMode)
             {
-                if (!WindowHandleParser.TryParse(windowHandle, out nint parsedWindowHandle) || parsedWindowHandle == nint.Zero)
-                {
-                    var result = MouseControlResult.CreateFailure(
-                        MouseControlErrorCode.InvalidCoordinates,
-                        $"Invalid windowHandle: '{windowHandle}'. Expected decimal string from window_management.");
-                    return ToCallToolResult(result);
-                }
+                var parsedWindowHandle = requestedWindowHandle!.Value;
 
                 // Get window rect
                 if (!NativeMethods.GetWindowRect(parsedWindowHandle, out var windowRect))
@@ -358,35 +370,35 @@ public static partial class MouseControlTool
             switch (action)
             {
                 case MouseAction.Move:
-                    operationResult = await HandleMoveAsync(absoluteX, absoluteY, linkedToken);
+                    operationResult = await HandleMoveAsync(absoluteX, absoluteY, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.Click:
-                    operationResult = await HandleClickAsync(absoluteX, absoluteY, modifiers, linkedToken);
+                    operationResult = await HandleClickAsync(absoluteX, absoluteY, modifiers, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.DoubleClick:
-                    operationResult = await HandleDoubleClickAsync(absoluteX, absoluteY, modifiers, linkedToken);
+                    operationResult = await HandleDoubleClickAsync(absoluteX, absoluteY, modifiers, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.RightClick:
-                    operationResult = await HandleRightClickAsync(absoluteX, absoluteY, modifiers, linkedToken);
+                    operationResult = await HandleRightClickAsync(absoluteX, absoluteY, modifiers, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.MiddleClick:
-                    operationResult = await HandleMiddleClickAsync(absoluteX, absoluteY, linkedToken);
+                    operationResult = await HandleMiddleClickAsync(absoluteX, absoluteY, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.Drag:
-                    operationResult = await HandleDragAsync(absoluteX, absoluteY, absoluteEndX, absoluteEndY, button, linkedToken);
+                    operationResult = await HandleDragAsync(absoluteX, absoluteY, absoluteEndX, absoluteEndY, button, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.Polyline:
-                    operationResult = await HandlePolylineAsync(absolutePoints, button, modifiers, linkedToken);
+                    operationResult = await HandlePolylineAsync(absolutePoints, button, modifiers, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.Scroll:
-                    operationResult = await HandleScrollAsync(absoluteX, absoluteY, direction, amount, linkedToken);
+                    operationResult = await HandleScrollAsync(absoluteX, absoluteY, direction, amount, expectedForegroundWindow, linkedToken);
                     break;
 
                 case MouseAction.GetPosition:
@@ -467,7 +479,11 @@ public static partial class MouseControlTool
             IsError = true
         };
 
-    private static async Task<MouseControlResult> HandleMoveAsync(int? x, int? y, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleMoveAsync(
+        int? x,
+        int? y,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (!x.HasValue || !y.HasValue)
         {
@@ -476,10 +492,21 @@ public static partial class MouseControlTool
                 "Move action requires both x and y coordinates");
         }
 
-        return await WindowsToolsBase.MouseInputService.MoveAsync(x.Value, y.Value, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.MoveAsync(
+                x.Value,
+                y.Value,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.MoveAsync(x.Value, y.Value, cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandleClickAsync(int? x, int? y, string? modifiersString, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleClickAsync(
+        int? x,
+        int? y,
+        string? modifiersString,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (WindowsToolsBase.SecureDesktopDetector.IsSecureDesktopActive())
         {
@@ -509,10 +536,22 @@ public static partial class MouseControlTool
         }
 
         var modifierKeys = ParseModifiers(modifiersString);
-        return await WindowsToolsBase.MouseInputService.ClickAsync(x, y, modifierKeys, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.ClickAsync(
+                x,
+                y,
+                modifierKeys,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.ClickAsync(x, y, modifierKeys, cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandleDoubleClickAsync(int? x, int? y, string? modifiersString, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleDoubleClickAsync(
+        int? x,
+        int? y,
+        string? modifiersString,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (WindowsToolsBase.SecureDesktopDetector.IsSecureDesktopActive())
         {
@@ -542,10 +581,22 @@ public static partial class MouseControlTool
         }
 
         var modifierKeys = ParseModifiers(modifiersString);
-        return await WindowsToolsBase.MouseInputService.DoubleClickAsync(x, y, modifierKeys, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.DoubleClickAsync(
+                x,
+                y,
+                modifierKeys,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.DoubleClickAsync(x, y, modifierKeys, cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandleRightClickAsync(int? x, int? y, string? modifiersString, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleRightClickAsync(
+        int? x,
+        int? y,
+        string? modifiersString,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (WindowsToolsBase.SecureDesktopDetector.IsSecureDesktopActive())
         {
@@ -575,10 +626,21 @@ public static partial class MouseControlTool
         }
 
         var modifierKeys = ParseModifiers(modifiersString);
-        return await WindowsToolsBase.MouseInputService.RightClickAsync(x, y, modifierKeys, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.RightClickAsync(
+                x,
+                y,
+                modifierKeys,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.RightClickAsync(x, y, modifierKeys, cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandleMiddleClickAsync(int? x, int? y, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleMiddleClickAsync(
+        int? x,
+        int? y,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (WindowsToolsBase.SecureDesktopDetector.IsSecureDesktopActive())
         {
@@ -607,10 +669,23 @@ public static partial class MouseControlTool
                 "Cannot middle-click on elevated (administrator) window. The target window requires elevated privileges that this tool does not have.");
         }
 
-        return await WindowsToolsBase.MouseInputService.MiddleClickAsync(x, y, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.MiddleClickAsync(
+                x,
+                y,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.MiddleClickAsync(x, y, cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandleDragAsync(int? startX, int? startY, int? endX, int? endY, string? buttonString, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleDragAsync(
+        int? startX,
+        int? startY,
+        int? endX,
+        int? endY,
+        string? buttonString,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (!startX.HasValue || !startY.HasValue)
         {
@@ -641,10 +716,30 @@ public static partial class MouseControlTool
         }
 
         var mouseButton = ParseMouseButton(buttonString);
-        return await WindowsToolsBase.MouseInputService.DragAsync(startX.Value, startY.Value, endX.Value, endY.Value, mouseButton, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.DragAsync(
+                startX.Value,
+                startY.Value,
+                endX.Value,
+                endY.Value,
+                mouseButton,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.DragAsync(
+                startX.Value,
+                startY.Value,
+                endX.Value,
+                endY.Value,
+                mouseButton,
+                cancellationToken);
     }
 
-    private static async Task<MouseControlResult> HandlePolylineAsync(List<Coordinates>? points, string? buttonString, string? modifiersString, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandlePolylineAsync(
+        List<Coordinates>? points,
+        string? buttonString,
+        string? modifiersString,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (points is null || points.Count < 2)
         {
@@ -669,7 +764,18 @@ public static partial class MouseControlTool
 
         var mouseButton = ParseMouseButton(buttonString);
         var modifierKeys = ParseModifiers(modifiersString);
-        return await WindowsToolsBase.MouseInputService.StrokeAsync(points, mouseButton, modifierKeys, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.StrokeAsync(
+                points,
+                mouseButton,
+                modifierKeys,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.StrokeAsync(
+                points,
+                mouseButton,
+                modifierKeys,
+                cancellationToken);
     }
 
     /// <summary>
@@ -714,7 +820,13 @@ public static partial class MouseControlTool
         return true;
     }
 
-    private static async Task<MouseControlResult> HandleScrollAsync(int? x, int? y, string? directionString, int amount, CancellationToken cancellationToken)
+    private static async Task<MouseControlResult> HandleScrollAsync(
+        int? x,
+        int? y,
+        string? directionString,
+        int amount,
+        nint? expectedForegroundWindow,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(directionString))
         {
@@ -758,7 +870,20 @@ public static partial class MouseControlTool
                 "Cannot scroll in elevated (administrator) window. The target window requires elevated privileges that this tool does not have.");
         }
 
-        return await WindowsToolsBase.MouseInputService.ScrollAsync(scrollDirection.Value, amount, x, y, cancellationToken);
+        return expectedForegroundWindow.HasValue
+            ? await WindowsToolsBase.MouseInputService.ScrollAsync(
+                scrollDirection.Value,
+                amount,
+                x,
+                y,
+                expectedForegroundWindow.Value,
+                cancellationToken)
+            : await WindowsToolsBase.MouseInputService.ScrollAsync(
+                scrollDirection.Value,
+                amount,
+                x,
+                y,
+                cancellationToken);
     }
 
     private static MouseControlResult GetCurrentPosition()

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSession.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSession.cs
@@ -114,7 +114,8 @@ internal sealed class ChromiumBrowserSession : IDisposable
     }
 
     internal static ChromiumBrowserSession LaunchLocalPageForReadinessFailureTest(
-        ChromiumBrowserKind browser)
+        ChromiumBrowserKind browser,
+        Action<int>? processStarted = null)
     {
         var pagePath = FindLocalPagePath();
         return Launch(browser, new BrowserTarget(
@@ -122,11 +123,13 @@ internal sealed class ChromiumBrowserSession : IDisposable
             new Uri(pagePath).AbsoluteUri,
             "MCP Chromium Browser Test Page",
             TimeSpan.FromMilliseconds(500),
-            [new ReadyElement("Control that does not exist")]));
+            [new ReadyElement("Control that does not exist")]),
+            processStarted);
     }
 
     internal static ChromiumBrowserSession LaunchLocalPageForWindowFailureTest(
-        ChromiumBrowserKind browser)
+        ChromiumBrowserKind browser,
+        Action<int>? processStarted = null)
     {
         var pagePath = FindLocalPagePath();
         return Launch(browser, new BrowserTarget(
@@ -135,7 +138,8 @@ internal sealed class ChromiumBrowserSession : IDisposable
             "Window title that does not exist",
             TimeSpan.FromMilliseconds(500),
             [],
-            WindowTimeout: TimeSpan.FromMilliseconds(500)));
+            WindowTimeout: TimeSpan.FromMilliseconds(500)),
+            processStarted);
     }
 
     public static ChromiumBrowserSession LaunchPublicSite(ChromiumBrowserKind browser, ChromiumPublicSite site)
@@ -169,7 +173,10 @@ internal sealed class ChromiumBrowserSession : IDisposable
         return LaunchLocalPage();
     }
 
-    private static ChromiumBrowserSession Launch(ChromiumBrowserKind browser, BrowserTarget target)
+    private static ChromiumBrowserSession Launch(
+        ChromiumBrowserKind browser,
+        BrowserTarget target,
+        Action<int>? processStarted = null)
     {
         var browserExecutable = FindBrowserExecutable(browser)
             ?? throw new InvalidOperationException($"{GetBrowserDisplayName(browser)} executable was not found.");
@@ -197,6 +204,7 @@ internal sealed class ChromiumBrowserSession : IDisposable
             {
                 throw new InvalidOperationException($"Failed to start {browserDescriptor.DisplayName} for Chromium browser smoke tests.");
             }
+            processStarted?.Invoke(process.Id);
 
             var windowHandle = WaitForWindow(
                 process.Id,

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSessionCleanupTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ChromiumBrowser/ChromiumBrowserSessionCleanupTests.cs
@@ -12,14 +12,17 @@ public sealed class ChromiumBrowserSessionCleanupTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(ChromiumBrowserKind.Edge);
         var before = BrowserProcessIds();
+        var launchedProcessId = 0;
 
         Assert.Throws<InvalidOperationException>(
             () => ChromiumBrowserSession.LaunchLocalPageForReadinessFailureTest(
-                ChromiumBrowserKind.Edge));
+                ChromiumBrowserKind.Edge,
+                processId => launchedProcessId = processId));
 
-        AssertBrowserProcessesRestored(
+        AssertLaunchedBrowserProcessesExited(
             before,
-            "A failed Chromium readiness check changed the pre-existing browser processes.");
+            launchedProcessId,
+            "A failed Chromium readiness check left a test-owned browser process running.");
     }
 
     [SkippableFact]
@@ -27,14 +30,17 @@ public sealed class ChromiumBrowserSessionCleanupTests
     {
         ChromiumBrowserSession.SkipUnlessSupported(ChromiumBrowserKind.Edge);
         var before = BrowserProcessIds();
+        var launchedProcessId = 0;
 
         Assert.Throws<InvalidOperationException>(
             () => ChromiumBrowserSession.LaunchLocalPageForWindowFailureTest(
-                ChromiumBrowserKind.Edge));
+                ChromiumBrowserKind.Edge,
+                processId => launchedProcessId = processId));
 
-        AssertBrowserProcessesRestored(
+        AssertLaunchedBrowserProcessesExited(
             before,
-            "A failed Chromium window search changed the pre-existing browser processes.");
+            launchedProcessId,
+            "A failed Chromium window search left a test-owned browser process running.");
     }
 
     [Fact]
@@ -46,12 +52,18 @@ public sealed class ChromiumBrowserSessionCleanupTests
         Assert.True(ChromiumBrowserSession.IsTestOwnedProcess(43, 43, existingProcessIds));
     }
 
-    private static void AssertBrowserProcessesRestored(
+    private static void AssertLaunchedBrowserProcessesExited(
         HashSet<int> before,
+        int launchedProcessId,
         string failureMessage)
     {
+        Assert.NotEqual(0, launchedProcessId);
         var restored = TestWait.Until(
-            condition: () => BrowserProcessIds().SetEquals(before),
+            condition: () => BrowserProcessIds().All(processId =>
+                !ChromiumBrowserSession.IsTestOwnedProcess(
+                    processId,
+                    launchedProcessId,
+                    before)),
             timeout: TimeSpan.FromSeconds(10),
             pollInterval: TimeSpan.FromMilliseconds(200));
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/CliIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/CliIntegrationTests.cs
@@ -290,9 +290,11 @@ public sealed class CliIntegrationTests
     }
 
     [Trait("Category", "RequiresDesktop")]
-    [Fact]
+    [SkippableFact]
     public async Task Cli_FileOpen_DrivesOpenDialog()
     {
+        DesktopInputTests.SkipUnlessEnabled();
+
         var testFilePath = Path.Combine(Path.GetTempPath(), $"wincli-open-{Guid.NewGuid():N}.txt");
         await File.WriteAllTextAsync(testFilePath, "cli open content");
         try

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
@@ -123,6 +123,17 @@ public sealed class UIAutomationElectronTests : IDisposable
         });
         Assert.True(click.Success, click.ErrorMessage);
 
+        var formsReady = await _automationService.WaitForElementAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                Name = "Username Input",
+                ControlType = "Edit",
+                VisibleOnly = true,
+            },
+            timeoutMs: 5000);
+        Assert.True(formsReady.Success, $"Forms viewport did not become ready: {formsReady.ErrorMessage}");
+
         var result = await state.CaptureAsync(
             key,
             SnapshotMode.Auto,

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
@@ -123,17 +123,6 @@ public sealed class UIAutomationElectronTests : IDisposable
         });
         Assert.True(click.Success, click.ErrorMessage);
 
-        var formsReady = await _automationService.WaitForElementAsync(
-            new ElementQuery
-            {
-                WindowHandle = _windowHandle,
-                Name = "Username Input",
-                ControlType = "Edit",
-                VisibleOnly = true,
-            },
-            timeoutMs: 5000);
-        Assert.True(formsReady.Success, $"Forms viewport did not become ready: {formsReady.ErrorMessage}");
-
         var result = await state.CaptureAsync(
             key,
             SnapshotMode.Auto,

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
@@ -102,9 +102,15 @@ public sealed class UIAutomationElectronTests : IDisposable
         Assert.True(hasDocument, "Electron window should contain a Document element for web content");
     }
 
-    [Fact]
-    public async Task AutoSnapshot_AfterSmallRendererChange_ReturnsDiff()
+    [Theory]
+    [InlineData("Home")]
+    [InlineData("Forms")]
+    public async Task AutoSnapshot_AfterSmallRendererChange_ReturnsDiff(string initialDestination)
     {
+        await NavigateAndWaitForStatusAsync(initialDestination);
+        // Fixture.Reset restores the viewport, but leaves the previous renderer status intact.
+        await NavigateAndWaitForStatusAsync("Home");
+
         using var state = new SnapshotStateService();
         var key = SnapshotRequestKey.Create(_windowHandle, null, 5, null);
         var baseline = await state.CaptureAsync(
@@ -112,16 +118,12 @@ public sealed class UIAutomationElectronTests : IDisposable
             SnapshotMode.Reset,
             token => _automationService.GetTreeAsync(_windowHandle, null, 5, null, token),
             CancellationToken.None);
+        Assert.True(baseline.Success, baseline.ErrorMessage);
         Assert.Equal("full", baseline.Kind);
+        Assert.True(ContainsNameInTree(baseline.Tree, "Navigated to Home"));
 
-        var click = await _automationService.FindAndClickAsync(new ElementQuery
-        {
-            WindowHandle = _windowHandle,
-            Name = "Navigate Forms",
-            ControlType = "Button",
-            TimeoutMs = 10000
-        });
-        Assert.True(click.Success, click.ErrorMessage);
+        // Poll raw trees so waiting for Chromium does not advance the remembered snapshot.
+        await NavigateAndWaitForStatusAsync("Forms");
 
         var result = await state.CaptureAsync(
             key,
@@ -129,9 +131,43 @@ public sealed class UIAutomationElectronTests : IDisposable
             token => _automationService.GetTreeAsync(_windowHandle, null, 5, null, token),
             CancellationToken.None);
 
+        Assert.True(result.Success, result.ErrorMessage);
         Assert.Equal("diff", result.Kind);
-        Assert.NotEmpty(result.Changes ?? []);
+        Assert.Contains(result.Changes ?? [], change =>
+            (change.Set is not null &&
+             change.Set.TryGetValue("name", out var name) &&
+             Equals(name, "Navigated to Forms")) ||
+            ContainsNameInTree(change.Node is null ? null : [change.Node], "Navigated to Forms"));
     }
+
+    private async Task NavigateAndWaitForStatusAsync(string destination)
+    {
+        var expectedStatus = $"Navigated to {destination}";
+        var click = await _automationService.FindAndClickAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            Name = $"Navigate {destination}",
+            ControlType = "Button",
+            TimeoutMs = 10000
+        });
+        Assert.True(click.Success, click.ErrorMessage);
+
+        UIAutomationResult? observed = null;
+        var ready = await TestWait.RetryUntilAsync(
+            attempt: async () =>
+            {
+                observed = await _automationService.GetTreeAsync(_windowHandle, null, 5, null);
+                Assert.True(observed.Success, observed.ErrorMessage);
+            },
+            condition: () => ContainsNameInTree(observed?.Tree, expectedStatus),
+            timeout: TimeSpan.FromSeconds(10));
+        Assert.True(ready, $"Electron snapshot did not contain status '{expectedStatus}'.");
+    }
+
+    private static bool ContainsNameInTree(UIElementCompactTree[]? elements, string name) =>
+        elements?.Any(element =>
+            string.Equals(element.Name, name, StringComparison.Ordinal) ||
+            ContainsNameInTree(element.Children, name)) == true;
 
     #endregion
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
@@ -332,6 +332,42 @@ public sealed class UIAutomationElectronTests : IDisposable
         Assert.Equal(testText, getTextResult.Text);
     }
 
+    [Fact]
+    public async Task FindAndType_AutoMode_EmitsBrowserInputEvent()
+    {
+        const string testText = "react-style-input";
+
+        var typeResult = await _automationService.FindAndTypeAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                Name = "Username Input",
+                ControlType = "Edit",
+            },
+            text: testText,
+            clearFirst: true);
+
+        Assert.True(typeResult.Success, $"FindAndType failed: {typeResult.ErrorMessage}");
+        Assert.Equal("keyboard", typeResult.Diagnostics?.ActionPath);
+        Assert.Equal("Username Input", typeResult.Diagnostics?.TargetElement?.Name);
+
+        UIAutomationResult? status = null;
+        var eventObserved = await TestWait.RetryUntilAsync(
+            async () =>
+            {
+                status = await _automationService.FindElementsAsync(new ElementQuery
+                {
+                    WindowHandle = _windowHandle,
+                    Name = $"Username input observed: {testText}",
+                    ControlType = "Text",
+                });
+            },
+            () => status?.Success == true,
+            TimeSpan.FromSeconds(3));
+
+        Assert.True(eventObserved, "Browser input event was not observed after ui_type.");
+    }
+
     #endregion
 
     #region Toggle Tests

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/index.html
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/index.html
@@ -485,6 +485,9 @@
         document.getElementById('nav-settings').addEventListener('click', () => updateStatus('Navigated to Settings'));
 
         // Form buttons
+        document.getElementById('username').addEventListener('input', (e) => {
+            updateStatus(`Username input observed: ${e.target.value}`);
+        });
         document.getElementById('submit-btn').addEventListener('click', () => {
             const username = document.getElementById('username').value;
             const email = document.getElementById('email').value;

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/MouseScrollTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/MouseScrollTests.cs
@@ -216,12 +216,19 @@ public sealed class MouseScrollTests : DesktopInputTestBase, IDisposable
         // Focus the scroll panel first
         await _fixture.MouseInputService.ClickAsync(panelCenter.X, panelCenter.Y);
         await Task.Delay(50);
-        _fixture.Reset();
 
         async Task ScrollAndWaitAsync(ScrollDirection direction, int expectedScrollEventCount)
         {
+            _fixture.EnsureTestWindowForeground();
+
             // First attempt
-            await _fixture.MouseInputService.ScrollAsync(direction, 1, panelCenter.X, panelCenter.Y);
+            var result = await _fixture.MouseInputService.ScrollAsync(
+                direction,
+                1,
+                panelCenter.X,
+                panelCenter.Y,
+                _fixture.TestWindowHandle);
+            Assert.True(result.Success, $"Initial {direction} scroll failed: {result.ErrorCode}: {result.ErrorMessage}");
 
             if (await _fixture.WaitForScrollEventAsync(expectedScrollEventCount, TimeSpan.FromSeconds(2)))
             {
@@ -232,7 +239,13 @@ public sealed class MouseScrollTests : DesktopInputTestBase, IDisposable
             _fixture.EnsureTestWindowForeground();
             await _fixture.MouseInputService.MoveAsync(panelCenter.X, panelCenter.Y);
             await Task.Delay(50);
-            await _fixture.MouseInputService.ScrollAsync(direction, 1, panelCenter.X, panelCenter.Y);
+            result = await _fixture.MouseInputService.ScrollAsync(
+                direction,
+                1,
+                panelCenter.X,
+                panelCenter.Y,
+                _fixture.TestWindowHandle);
+            Assert.True(result.Success, $"Retried {direction} scroll failed: {result.ErrorCode}: {result.ErrorMessage}");
 
             var ok = await _fixture.WaitForScrollEventAsync(expectedScrollEventCount, TimeSpan.FromSeconds(2));
             if (!ok)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
@@ -2,13 +2,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Sbroenne.WindowsMcp.Automation;
 using Sbroenne.WindowsMcp.Capture;
 using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
 using Sbroenne.WindowsMcp.Window;
 
 namespace Sbroenne.WindowsMcp.Tests.Integration;
 
 /// <summary>
-/// Integration tests for the generalized Open dialog handling (<see cref="UIAutomationService.OpenFileAsync"/>).
+/// Integration tests for the generalized Open dialog handling.
 /// The test harness shows a standard Open dialog on Ctrl+O, mirroring the Save flow.
 /// </summary>
 [Collection("UITestHarness")]
@@ -60,9 +61,11 @@ public sealed class OpenFileTests : IDisposable
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Open_StandardWindowsDialog_SelectsFile()
     {
+        DesktopInputTests.SkipUnlessEnabled();
+
         await TestRetry.RunAsync(async _ =>
         {
             var testFilePath = Path.Combine(_testOutputDir, $"open-{Guid.NewGuid()}.txt");
@@ -88,6 +91,86 @@ public sealed class OpenFileTests : IDisposable
             // Assert on the observed value rather than on the wait result: if the wait times out this
             // reports the expected and actual paths, which is more actionable than "the wait expired".
             Assert.Equal(testFilePath, lastOpened, ignoreCase: true);
+        });
+    }
+
+    [Fact]
+    public async Task Open_WaitForExistingDialog_SelectsFileOpenedByPriorAction()
+    {
+        var testFilePath = Path.Combine(_testOutputDir, $"handoff-{Guid.NewGuid()}.txt");
+        await File.WriteAllTextAsync(testFilePath, "content to open");
+
+        _fixture.Form!.BeginInvoke(_fixture.Form.ShowOpenDialogForTesting);
+
+        var result = await _automationService.OpenFileAsync(
+            _windowHandle,
+            testFilePath,
+            triggerMode: "wait",
+            timeoutMs: 5000);
+
+        Assert.True(
+            result.Success,
+            $"Open handoff failed: {result.ErrorMessage} Diagnostics: {string.Join("; ", result.Diagnostics?.Warnings ?? [])}");
+        Assert.Equal("wait+semantic", result.Diagnostics?.ActionPath);
+
+        Assert.True(await TestWait.UntilAsync(
+            () => string.Equals(
+                testFilePath,
+                _fixture.Form!.Invoke(new Func<string?>(() => _fixture.Form.LastOpenPath)),
+                StringComparison.OrdinalIgnoreCase),
+            TimeSpan.FromSeconds(5)));
+    }
+
+    [Fact]
+    public async Task Open_WaitMode_DoesNotSubmitOwnedSaveDialog()
+    {
+        var testFilePath = Path.Combine(_testOutputDir, $"not-for-save-{Guid.NewGuid()}.txt");
+        await File.WriteAllTextAsync(testFilePath, "must not be saved");
+
+        _fixture.Form!.BeginInvoke(_fixture.Form.ShowSaveDialogForTesting);
+        try
+        {
+            var result = await _automationService.OpenFileAsync(
+                _windowHandle,
+                testFilePath,
+                triggerMode: "wait",
+                timeoutMs: 500);
+
+            Assert.False(result.Success);
+            Assert.Equal(UIAutomationErrorType.Timeout, result.ErrorType);
+            Assert.Null(_fixture.Form.LastSavePath);
+        }
+        finally
+        {
+            _fixture.CloseOwnedDialogs();
+        }
+    }
+
+    [Fact]
+    public async Task Find_ActiveDialogScope_TargetsNativeOpenDialog()
+    {
+        _fixture.Form!.BeginInvoke(_fixture.Form.ShowOpenDialogForTesting);
+
+        var result = await _automationService.WaitForElementAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                Scope = "active_dialog",
+                ControlType = "Edit",
+                VisibleOnly = true,
+            },
+            timeoutMs: 5000);
+
+        Assert.True(result.Success, $"Active dialog search failed: {result.ErrorMessage}");
+        Assert.NotEmpty(result.Items!);
+
+        await _automationService.FindAndClickAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            Scope = "active_dialog",
+            Name = "Cancel",
+            ControlType = "Button",
+            RequireUnique = true,
         });
     }
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/OpenFileTests.cs
@@ -94,9 +94,11 @@ public sealed class OpenFileTests : IDisposable
         });
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task Open_WaitForExistingDialog_SelectsFileOpenedByPriorAction()
     {
+        DesktopInputTests.SkipUnlessEnabled();
+
         var testFilePath = Path.Combine(_testOutputDir, $"handoff-{Guid.NewGuid()}.txt");
         await File.WriteAllTextAsync(testFilePath, "content to open");
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
@@ -708,6 +708,7 @@ public sealed class UITestHarnessForm : Form
         SemanticControlMouseInputCount = 0;
         _physicalFallbackClickCount = 0;
         _physicalFallbackTarget.AccessibleName = "Physical fallback";
+        _submitButton.Name = "SubmitButton";
         _submitMouseInputLabel.Text = "0";
         CancelClickCount = 0;
         _usernameInput.Clear();
@@ -772,6 +773,9 @@ public sealed class UITestHarnessForm : Form
 
     public void SetSubmitButtonVisibleForTesting(bool visible) =>
         _submitButton.Visible = visible;
+
+    public void SetSubmitButtonAutomationIdForTesting(string automationId) =>
+        _submitButton.Name = automationId;
 
     private void WireSubmitButton(Button button)
     {

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
@@ -12,7 +12,7 @@ public sealed class UITestHarnessForm : Form
     // Form Controls Tab
     private readonly TextBox _usernameInput;
     private readonly TextBox _passwordInput;
-    private readonly Button _submitButton;
+    private Button _submitButton;
     private readonly Button _cancelButton;
     private readonly Label _submitMouseInputLabel;
     private readonly CheckBox _checkBox1;
@@ -742,6 +742,38 @@ public sealed class UITestHarnessForm : Form
     /// <see cref="Control.BeginInvoke(Delegate)"/> rather than <c>Invoke</c>.
     /// </summary>
     public void ShowSaveDialogForTesting() => ShowSaveDialog();
+
+    /// <summary>
+    /// Opens the Open dialog directly so tests can exercise browser-to-native-dialog handoff.
+    /// </summary>
+    public void ShowOpenDialogForTesting() => ShowOpenDialog();
+
+    /// <summary>
+    /// Replaces the Submit control with a new control that has the same accessible selector.
+    /// Used to prove that an old element id is rejected instead of silently retargeted.
+    /// </summary>
+    public void ReplaceSubmitButtonForTesting()
+    {
+        var parent = _submitButton.Parent;
+        if (parent == null)
+        {
+            return;
+        }
+
+        var replacement = new Button
+        {
+            Text = _submitButton.Text,
+            Location = _submitButton.Location,
+            Size = _submitButton.Size,
+            Name = _submitButton.Name,
+        };
+        replacement.Click += (_, _) => SubmitClickCount++;
+
+        parent.Controls.Remove(_submitButton);
+        _submitButton.Dispose();
+        _submitButton = replacement;
+        parent.Controls.Add(replacement);
+    }
 
     private void UpdateStatus(string message)
     {

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/TestHarness/UITestHarnessForm.cs
@@ -255,12 +255,7 @@ public sealed class UITestHarnessForm : Form
             Name = "SubmitMouseInputLabel",
         };
         buttonsGroup.Controls.Add(_submitMouseInputLabel);
-        _submitButton.Click += (_, _) => { SubmitClickCount++; UpdateStatus($"Submit clicked ({SubmitClickCount} times)"); };
-        _submitButton.MouseUp += (_, _) =>
-        {
-            SubmitMouseInputCount++;
-            _submitMouseInputLabel.Text = SubmitMouseInputCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        };
+        WireSubmitButton(_submitButton);
         buttonsGroup.Controls.Add(_submitButton);
 
         _physicalFallbackTarget = new Panel
@@ -767,12 +762,29 @@ public sealed class UITestHarnessForm : Form
             Size = _submitButton.Size,
             Name = _submitButton.Name,
         };
-        replacement.Click += (_, _) => SubmitClickCount++;
+        WireSubmitButton(replacement);
 
         parent.Controls.Remove(_submitButton);
         _submitButton.Dispose();
         _submitButton = replacement;
         parent.Controls.Add(replacement);
+    }
+
+    public void SetSubmitButtonVisibleForTesting(bool visible) =>
+        _submitButton.Visible = visible;
+
+    private void WireSubmitButton(Button button)
+    {
+        button.Click += (_, _) =>
+        {
+            SubmitClickCount++;
+            UpdateStatus($"Submit clicked ({SubmitClickCount} times)");
+        };
+        button.MouseUp += (_, _) =>
+        {
+            SubmitMouseInputCount++;
+            _submitMouseInputLabel.Text = SubmitMouseInputCount.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        };
     }
 
     private void UpdateStatus(string message)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -74,6 +74,36 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
     #region FoundIndex Tests
 
     [Fact]
+    public async Task Find_WithTimeout_WaitsForElementToAppear()
+    {
+        _fixture.Form!.Invoke(() => _fixture.Form.SetSubmitButtonVisibleForTesting(false));
+
+        try
+        {
+            var reveal = Task.Run(async () =>
+            {
+                await Task.Delay(250);
+                _fixture.Form.Invoke(() => _fixture.Form.SetSubmitButtonVisibleForTesting(true));
+            });
+
+            var result = await _automationService.FindElementsAsync(new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                AutomationId = "SubmitButton",
+                TimeoutMs = 2000,
+            });
+
+            await reveal;
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.NotEmpty(result.Items ?? []);
+        }
+        finally
+        {
+            _fixture.Form.Invoke(() => _fixture.Form.SetSubmitButtonVisibleForTesting(true));
+        }
+    }
+
+    [Fact]
     public async Task WaitForAppear_RequireUnique_PropagatesAmbiguity()
     {
         var result = await _automationService.WaitForElementAsync(

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -104,6 +104,38 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
     }
 
     [Fact]
+    public async Task Find_WithTimeout_PerformsFinalProbeAtDeadline()
+    {
+        const string DelayedAutomationId = "DelayedSubmitButton";
+
+        var rename = Task.Run(async () =>
+        {
+            await Task.Delay(1850);
+            _fixture.Form!.Invoke(() =>
+                _fixture.Form.SetSubmitButtonAutomationIdForTesting(DelayedAutomationId));
+        });
+
+        try
+        {
+            var result = await _automationService.FindElementsAsync(new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                AutomationId = DelayedAutomationId,
+                TimeoutMs = 2000,
+            });
+
+            await rename;
+            Assert.True(result.Success, result.ErrorMessage);
+            Assert.Single(result.Items!);
+        }
+        finally
+        {
+            _fixture.Form!.Invoke(() =>
+                _fixture.Form.SetSubmitButtonAutomationIdForTesting("SubmitButton"));
+        }
+    }
+
+    [Fact]
     public async Task WaitForAppear_RequireUnique_PropagatesAmbiguity()
     {
         var result = await _automationService.WaitForElementAsync(

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -136,6 +136,38 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
     }
 
     [Fact]
+    public async Task Find_RequireUniqueWithFoundIndex_ReturnsInvalidParameter()
+    {
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ControlType = "Button",
+            RequireUnique = true,
+            FoundIndex = 2,
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.InvalidParameter, result.ErrorType);
+    }
+
+    [Fact]
+    public async Task Select_RequireUnique_PropagatesAmbiguity()
+    {
+        var result = await _automationService.FindAndSelectAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                ControlType = "Button",
+                RequireUnique = true,
+            },
+            "unused");
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, result.ErrorType);
+        Assert.NotNull(result.Diagnostics?.MultipleMatches);
+    }
+
+    [Fact]
     public async Task Find_WithFoundIndex1_ReturnsAllButtons()
     {
         // FoundIndex=1 means "start from first match" which returns all matching elements

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIAutomationAdvancedSearchTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
 using Sbroenne.WindowsMcp.Automation;
 using Sbroenne.WindowsMcp.Capture;
 using Sbroenne.WindowsMcp.Input;
@@ -71,6 +72,38 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
     }
 
     #region FoundIndex Tests
+
+    [Fact]
+    public async Task WaitForAppear_RequireUnique_PropagatesAmbiguity()
+    {
+        var result = await _automationService.WaitForElementAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                ControlType = "Button",
+                RequireUnique = true,
+            },
+            timeoutMs: 1000);
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, result.ErrorType);
+    }
+
+    [Fact]
+    public async Task WaitForDisappear_RequireUnique_DoesNotTreatAmbiguityAsGone()
+    {
+        var result = await _automationService.WaitForElementDisappearAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                ControlType = "Button",
+                RequireUnique = true,
+            },
+            timeoutMs: 1000);
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, result.ErrorType);
+    }
 
     [Fact]
     public async Task Find_WithFoundIndex1_ReturnsAllButtons()
@@ -158,6 +191,58 @@ public sealed class UIAutomationAdvancedSearchTests : IDisposable
         // Assert - Should fail with ElementNotFound
         Assert.False(result.Success);
         Assert.Equal(UIAutomationErrorType.ElementNotFound, result.ErrorType);
+    }
+
+    [Fact]
+    public async Task Find_RequireUnique_ReturnsAmbiguityDetails()
+    {
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ControlType = "Button",
+            RequireUnique = true,
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, result.ErrorType);
+        Assert.NotNull(result.Diagnostics?.MultipleMatches);
+        Assert.True(result.Diagnostics!.MultipleMatches!.Length > 1);
+        Assert.All(result.Diagnostics.MultipleMatches, item =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(item.ControlType));
+            Assert.NotNull(item.Name);
+        });
+    }
+
+    [Fact]
+    public async Task Find_RequireUnique_RedactsTextFieldValuesFromDiagnostics()
+    {
+        const string SensitiveValue = "private-field-value";
+        var typed = await _automationService.FindAndTypeAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                AutomationId = "UsernameInput",
+                ControlType = "Edit",
+            },
+            SensitiveValue,
+            clearFirst: true,
+            inputMode: "value");
+        Assert.True(typed.Success, typed.ErrorMessage);
+
+        var result = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ControlType = "Edit",
+            RequireUnique = true,
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, result.ErrorType);
+        Assert.DoesNotContain(
+            SensitiveValue,
+            JsonSerializer.Serialize(result.Diagnostics),
+            StringComparison.Ordinal);
     }
 
     #endregion

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIBatchAndFusionIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIBatchAndFusionIntegrationTests.cs
@@ -81,6 +81,35 @@ public sealed class UIBatchAndFusionIntegrationTests
     }
 
     [Fact]
+    public async Task Batch_WaitDisappear_RequireUnique_ReportsAmbiguity()
+    {
+        var steps = JsonSerializer.Serialize(new object[]
+        {
+            new
+            {
+                action = "wait",
+                mode = "disappear",
+                controlType = "Button",
+                requireUnique = true,
+                timeoutMs = 1000,
+            },
+        });
+
+        var result = await UIBatchTool.ExecuteAsync(
+            _windowHandle,
+            steps,
+            stopOnError: true,
+            withSnapshot: false,
+            includeDiagnostics: false,
+            CancellationToken.None);
+
+        var batch = ParseBatch(result);
+        Assert.False(batch.Success);
+        Assert.True(result.IsError);
+        Assert.Contains("matching elements", Assert.Single(batch.Steps).Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Batch_ContinueOnError_RunsEveryStep()
     {
         var steps = JsonSerializer.Serialize(new object[]

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
@@ -263,4 +263,49 @@ public sealed class UIClickToolIntegrationTests : IDisposable
         await Task.Delay(100);
         Assert.True((_fixture.Form?.SubmitClickCount ?? 0) > initialCount);
     }
+
+    [Fact]
+    public async Task ClickElement_StaleId_DoesNotRetargetReplacementWithSameName()
+    {
+        var found = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            AutomationId = "SubmitButton",
+            ControlType = "Button",
+        });
+        var oldElementId = Assert.Single(found.Items!).Id;
+
+        _fixture.Form!.Invoke(_fixture.Form.ReplaceSubmitButtonForTesting);
+
+        var result = await _automationService.ClickElementAsync(oldElementId, _windowHandle);
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.ElementStale, result.ErrorType);
+        Assert.Equal(0, _fixture.Form.SubmitClickCount);
+    }
+
+    [Fact]
+    public async Task FindAndClick_StaleParentId_DoesNotRetargetReplacementContainer()
+    {
+        var found = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            AutomationId = "SubmitButton",
+            ControlType = "Button",
+        });
+        var oldParentId = Assert.Single(found.Items!).Id;
+
+        _fixture.Form!.Invoke(_fixture.Form.ReplaceSubmitButtonForTesting);
+
+        var result = await _automationService.FindAndClickAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            ParentElementId = oldParentId,
+            ControlType = "Button",
+        });
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.ElementStale, result.ErrorType);
+        Assert.Equal(0, _fixture.Form.SubmitClickCount);
+    }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UIClickToolIntegrationTests.cs
@@ -5,6 +5,7 @@ using Sbroenne.WindowsMcp.Input;
 using Sbroenne.WindowsMcp.Models;
 using Sbroenne.WindowsMcp.Tests.Integration.TestHarness;
 using Sbroenne.WindowsMcp.Window;
+using System.Text.RegularExpressions;
 
 namespace Sbroenne.WindowsMcp.Tests.Integration;
 
@@ -282,6 +283,38 @@ public sealed class UIClickToolIntegrationTests : IDisposable
         Assert.False(result.Success);
         Assert.Equal(UIAutomationErrorType.ElementStale, result.ErrorType);
         Assert.Equal(0, _fixture.Form.SubmitClickCount);
+    }
+
+    [Fact]
+    public async Task ClickElement_PositionOnlyId_FailsClosed()
+    {
+        var found = await _automationService.FindElementsAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            AutomationId = "SubmitButton",
+            ControlType = "Button",
+        });
+        var elementId = Assert.Single(found.Items!).Id;
+        var pathBasedElementId = await _staThread.ExecuteAsync(() =>
+        {
+            var element = ElementIdGenerator.ResolveToAutomationElement(
+                elementId,
+                allowSelectorFallback: false);
+            Assert.NotNull(element);
+            var root = UIA3Automation.Instance.ElementFromHandle(
+                nint.Parse(_windowHandle, System.Globalization.CultureInfo.InvariantCulture));
+            Assert.NotNull(root);
+            return ElementIdGenerator.GenerateId(element, root);
+        });
+        var fullId = Assert.IsType<string>(ElementIdGenerator.ResolveFullId(pathBasedElementId));
+        var positionOnlyId = ElementIdGenerator.RegisterFullId(
+            Regex.Replace(fullId, @"(?<=\|runtime:)[^|]+", "0"));
+
+        var result = await _automationService.ClickElementAsync(positionOnlyId, _windowHandle);
+
+        Assert.False(result.Success);
+        Assert.Equal(UIAutomationErrorType.ElementStale, result.ErrorType);
+        Assert.Equal(0, _fixture.Form!.SubmitClickCount);
     }
 
     [Fact]

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/UITypeToolIntegrationTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/UITypeToolIntegrationTests.cs
@@ -118,6 +118,25 @@ public sealed class UITypeToolIntegrationTests : IDisposable
     }
 
     [Fact]
+    public async Task FindAndType_RequireUnique_DoesNotFallThroughAfterAmbiguousEditSearch()
+    {
+        var typeResult = await _automationService.FindAndTypeAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                RequireUnique = true,
+            },
+            text: "must-not-be-typed",
+            clearFirst: true,
+            inputMode: "value");
+
+        Assert.False(typeResult.Success);
+        Assert.Equal(UIAutomationErrorType.MultipleMatches, typeResult.ErrorType);
+        Assert.Equal(string.Empty, _fixture.Form?.UsernameText);
+        Assert.Equal(string.Empty, _fixture.Form?.PasswordText);
+    }
+
+    [Fact]
     public async Task FindAndType_ClearFirst_ReplacesExistingText()
     {
         // Arrange - type initial text

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
@@ -187,6 +187,12 @@ public sealed class WinUIClickTests : IDisposable
             },
             timeoutMs: 5000);
         Assert.True(editorReady.Success, $"Editor page did not become ready: {editorReady.ErrorMessage}");
+        var clickTarget = Assert.Single(editorReady.Items!);
+        var scrollResult = await _automationService.ScrollIntoViewAsync(
+            clickTarget.Id,
+            query: null,
+            timeoutMs: 5000);
+        Assert.True(scrollResult.Success, $"Click test button could not be scrolled into view: {scrollResult.ErrorMessage}");
 
         // Act - Click the ClickTestButton multiple times
         for (int i = 0; i < 3; i++)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
@@ -177,7 +177,15 @@ public sealed class WinUIClickTests : IDisposable
             WindowHandle = _windowHandle,
             AutomationId = "NavEditor",
         });
-        await Task.Delay(200);
+
+        var editorReady = await _automationService.WaitForElementAsync(
+            new ElementQuery
+            {
+                WindowHandle = _windowHandle,
+                AutomationId = "ClickTestButton",
+            },
+            timeoutMs: 5000);
+        Assert.True(editorReady.Success, $"Editor page did not become ready: {editorReady.ErrorMessage}");
 
         // Act - Click the ClickTestButton multiple times
         for (int i = 0; i < 3; i++)

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/WinUI/WinUIClickTests.cs
@@ -172,11 +172,12 @@ public sealed class WinUIClickTests : IDisposable
     public async Task FindAndClick_ClickTestButton_IncrementsCount()
     {
         // Navigate to Editor page
-        await _automationService.FindAndClickAsync(new ElementQuery
+        var navigation = await _automationService.FindAndClickAsync(new ElementQuery
         {
             WindowHandle = _windowHandle,
             AutomationId = "NavEditor",
         });
+        Assert.True(navigation.Success, $"Editor navigation failed: {navigation.ErrorMessage}");
 
         var editorReady = await _automationService.WaitForElementAsync(
             new ElementQuery
@@ -194,6 +195,7 @@ public sealed class WinUIClickTests : IDisposable
             {
                 WindowHandle = _windowHandle,
                 AutomationId = "ClickTestButton",
+                TimeoutMs = 5000,
             });
             Assert.True(result.Success, $"Click test button click failed: {result.ErrorMessage}");
             await Task.Delay(50);

--- a/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Tools/MouseControlToolMonitorIndexTests.cs
@@ -29,6 +29,32 @@ public sealed class MouseControlToolMonitorIndexTests : IClassFixture<MultiMonit
     }
 
     [Fact]
+    public async Task ExecuteAsync_ClickWithNonForegroundWindowHandle_ReturnsGuardFailure()
+    {
+        var callResult = await MouseControlTool.ExecuteAsync(
+            action: MouseAction.Click,
+            target: null,
+            x: null,
+            y: null,
+            endX: null,
+            endY: null,
+            direction: null,
+            amount: 1,
+            modifiers: null,
+            button: null,
+            monitorIndex: null,
+            expectedWindowTitle: null,
+            expectedProcessName: null,
+            windowHandle: "999999",
+            points: null,
+            cancellationToken: CancellationToken.None);
+
+        var result = DeserializeResult(callResult);
+        Assert.False(result.Success);
+        Assert.Contains("foreground window changed", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ClickWithCoordinatesNoMonitorIndex_ReturnsMissingParameterError()
     {
         // Arrange
@@ -428,5 +454,3 @@ public sealed class MouseControlToolMonitorIndexTests : IClassFixture<MultiMonit
         Assert.InRange(result.FinalPosition.Y, 0, identifiedMonitor.Height - 1);
     }
 }
-
-

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/KeyboardInputServiceTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/KeyboardInputServiceTests.cs
@@ -1,9 +1,41 @@
 using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
 
 namespace Sbroenne.WindowsMcp.Tests.Unit;
 
 public sealed class KeyboardInputServiceTests
 {
+    [Fact]
+    public async Task TypeTextAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        using var service = new KeyboardInputService();
+
+        var result = await service.TypeTextAsync(
+            "must-not-be-typed",
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(KeyboardControlErrorCode.WrongTargetWindow, result.ErrorCode);
+        Assert.Equal(0, result.CharactersTyped ?? 0);
+    }
+
+    [Fact]
+    public async Task PressKeyAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        using var service = new KeyboardInputService();
+
+        var result = await service.PressKeyAsync(
+            "A",
+            ModifierKey.Ctrl,
+            repeat: 1,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(KeyboardControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
     [Fact]
     public async Task WaitForIdleAsync_WithCancelledToken_ThrowsOperationCanceled()
     {

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/KeyboardInputServiceTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/KeyboardInputServiceTests.cs
@@ -6,6 +6,35 @@ namespace Sbroenne.WindowsMcp.Tests.Unit;
 public sealed class KeyboardInputServiceTests
 {
     [Fact]
+    public async Task KeyDownAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        using var service = new KeyboardInputService();
+
+        var result = await service.KeyDownAsync(
+            "a",
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(KeyboardControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ExecuteSequenceAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        using var service = new KeyboardInputService();
+
+        var result = await service.ExecuteSequenceAsync(
+            [new KeySequenceItem { Key = "a" }],
+            interKeyDelayMs: 0,
+            expectedForegroundWindow: new nint(-1),
+            cancellationToken: CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(KeyboardControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
     public async Task TypeTextAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
     {
         using var service = new KeyboardInputService();

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
@@ -1,0 +1,23 @@
+using Sbroenne.WindowsMcp.Input;
+using Sbroenne.WindowsMcp.Models;
+
+namespace Sbroenne.WindowsMcp.Tests.Unit;
+
+public sealed class MouseInputServiceTests
+{
+    [Fact]
+    public async Task ClickAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.ClickAsync(
+            x: null,
+            y: null,
+            ModifierKey.None,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+}

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
@@ -36,4 +36,85 @@ public sealed class MouseInputServiceTests
         Assert.False(result.Success);
         Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
     }
+
+    [Fact]
+    public async Task MoveAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.MoveAsync(
+            0,
+            0,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task RightClickAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.RightClickAsync(
+            x: null,
+            y: null,
+            ModifierKey.None,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task MiddleClickAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.MiddleClickAsync(
+            x: null,
+            y: null,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task DragAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.DragAsync(
+            0,
+            0,
+            1,
+            1,
+            MouseButton.Left,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task ScrollAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.ScrollAsync(
+            ScrollDirection.Down,
+            1,
+            x: null,
+            y: null,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/MouseInputServiceTests.cs
@@ -20,4 +20,20 @@ public sealed class MouseInputServiceTests
         Assert.False(result.Success);
         Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
     }
+
+    [Fact]
+    public async Task DoubleClickAsync_WithWrongForegroundWindow_ReturnsGuardFailure()
+    {
+        var service = new MouseInputService();
+
+        var result = await service.DoubleClickAsync(
+            x: null,
+            y: null,
+            ModifierKey.None,
+            new nint(-1),
+            CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.Equal(MouseControlErrorCode.WrongTargetWindow, result.ErrorCode);
+    }
 }

--- a/tests/Sbroenne.WindowsMcp.Tests/Unit/ToolCatalogTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Unit/ToolCatalogTests.cs
@@ -48,6 +48,10 @@ public sealed class ToolCatalogTests
         Assert.Contains("mode", ParameterNames(tools["ui_snapshot"]));
         Assert.Contains("snapshotMode", ParameterNames(tools["ui_click"]));
         Assert.Contains("snapshotMode", ParameterNames(tools["ui_batch"]));
+        Assert.Contains("scope", ParameterNames(tools["ui_find"]));
+        Assert.Contains("requireUnique", ParameterNames(tools["ui_click"]));
+        Assert.Contains("inputMode", ParameterNames(tools["ui_type"]));
+        Assert.Contains("triggerMode", ParameterNames(tools["file_open"]));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add active-dialog and parent-element scoping, enabled/visible filtering, unique-match enforcement, and detailed ambiguity diagnostics
- reject stale element IDs for state-changing actions instead of retargeting same-name replacements
- add `ui_type` input modes; `auto` uses real keyboard input for Chromium/Electron so normal focus/input/change/keyboard events fire, with observable-change verification
- guard physical keyboard and mouse input inside the input layer immediately before each `SendInput` call
- add owner-aware native Open-dialog handoff with `triggerMode=wait`, exact path verification, standard default-button targeting, and explicit timeout/wrong-window errors
- expose the same options through MCP tools, batch actions, CLI help, and documentation
- keep diagnostics privacy-safe by redacting field values and typed content

## Validation

- `dotnet build Sbroenne.WindowsMcp.sln --no-restore --nologo --verbosity quiet`
- 574 unit tests passed
- 38 non-desktop integration tests passed
- 8 focused atomic input/dialog/privacy regressions passed
- 56 affected integration tests passed; 8 physical-desktop tests skipped by the repository's opt-in policy
- final code-review blocker check: READY

## Remaining limitations

- `triggerMode=wait` requires a recognizable Open-dialog title because title-independent shell-dialog structure cannot safely distinguish Open from Save As. Shortcut mode can use locale-independent structure because Ctrl+O provides provenance.
- physical-input tests still require the repository's dedicated interactive desktop environment; this shared session cannot safely take over the active user desktop.