### PR TITLE
deps: update dependencies while preserving VS Code compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
   # VS Code extension npm dependencies
   - package-ecosystem: "npm"
     directory: "/vscode-extension"
+    # Keep API types aligned with engines.vscode; update both together.
+    ignore:
+      - dependency-name: "@types/vscode"
+        versions: [">1.125.0"]
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/workflows/llm-tests.yml
+++ b/.github/workflows/llm-tests.yml
@@ -42,7 +42,7 @@ jobs:
         dotnet-version: 10.0.x
 
     - name: Setup Python & uv
-      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      uses: astral-sh/setup-uv@bec219d24cd3e171d82865faccec33120bb574f4 # v10.1.0
       with:
         python-version: '3.12'
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,17 @@
   <ItemGroup>
     <!-- Main application packages -->
     <PackageVersion Include="ModelContextProtocol" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.10.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.12" />
     <PackageVersion Include="Interop.UIAutomationClient" Version="10.19041.0" />
     <!-- Test packages -->
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="SharpToken" Version="2.0.6" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.10.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.analyzers" Version="2.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
@@ -24,8 +24,8 @@
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2705" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.260610101" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4129.50" />
-    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.2.12" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4191.47" />
+    <PackageVersion Include="Microsoft.Windows.AI.MachineLearning" Version="2.3.42" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.12" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.400",
+    "version": "10.0.401",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
+++ b/tests/Sbroenne.WindowsMcp.LLM.Tests/pyproject.toml
@@ -5,7 +5,7 @@ description = "LLM integration tests for Windows MCP Server using pytest-skill-e
 requires-python = ">=3.12"
 dependencies = [
     "pytest-skill-engineering",
-    "anyio==4.14.2",
+    "anyio==4.15.0",
     "pytest-asyncio",
     "socksio",
     "trio",

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/UIAutomationElectronTests.cs
@@ -102,9 +102,15 @@ public sealed class UIAutomationElectronTests : IDisposable
         Assert.True(hasDocument, "Electron window should contain a Document element for web content");
     }
 
-    [Fact]
-    public async Task AutoSnapshot_AfterSmallRendererChange_ReturnsDiff()
+    [Theory]
+    [InlineData("Home")]
+    [InlineData("Forms")]
+    public async Task AutoSnapshot_AfterSmallRendererChange_ReturnsDiff(string initialDestination)
     {
+        await NavigateAndWaitForStatusAsync(initialDestination);
+        // Fixture.Reset restores the viewport, but leaves the previous renderer status intact.
+        await NavigateAndWaitForStatusAsync("Home");
+
         using var state = new SnapshotStateService();
         var key = SnapshotRequestKey.Create(_windowHandle, null, 5, null);
         var baseline = await state.CaptureAsync(
@@ -112,16 +118,12 @@ public sealed class UIAutomationElectronTests : IDisposable
             SnapshotMode.Reset,
             token => _automationService.GetTreeAsync(_windowHandle, null, 5, null, token),
             CancellationToken.None);
+        Assert.True(baseline.Success, baseline.ErrorMessage);
         Assert.Equal("full", baseline.Kind);
+        Assert.True(ContainsNameInTree(baseline.Tree, "Navigated to Home"));
 
-        var click = await _automationService.FindAndClickAsync(new ElementQuery
-        {
-            WindowHandle = _windowHandle,
-            Name = "Navigate Forms",
-            ControlType = "Button",
-            TimeoutMs = 10000
-        });
-        Assert.True(click.Success, click.ErrorMessage);
+        // Poll raw trees so waiting for Chromium does not advance the remembered snapshot.
+        await NavigateAndWaitForStatusAsync("Forms");
 
         var result = await state.CaptureAsync(
             key,
@@ -129,9 +131,43 @@ public sealed class UIAutomationElectronTests : IDisposable
             token => _automationService.GetTreeAsync(_windowHandle, null, 5, null, token),
             CancellationToken.None);
 
+        Assert.True(result.Success, result.ErrorMessage);
         Assert.Equal("diff", result.Kind);
-        Assert.NotEmpty(result.Changes ?? []);
+        Assert.Contains(result.Changes ?? [], change =>
+            (change.Set is not null &&
+             change.Set.TryGetValue("name", out var name) &&
+             Equals(name, "Navigated to Forms")) ||
+            ContainsNameInTree(change.Node is null ? null : [change.Node], "Navigated to Forms"));
     }
+
+    private async Task NavigateAndWaitForStatusAsync(string destination)
+    {
+        var expectedStatus = $"Navigated to {destination}";
+        var click = await _automationService.FindAndClickAsync(new ElementQuery
+        {
+            WindowHandle = _windowHandle,
+            Name = $"Navigate {destination}",
+            ControlType = "Button",
+            TimeoutMs = 10000
+        });
+        Assert.True(click.Success, click.ErrorMessage);
+
+        UIAutomationResult? observed = null;
+        var ready = await TestWait.RetryUntilAsync(
+            attempt: async () =>
+            {
+                observed = await _automationService.GetTreeAsync(_windowHandle, null, 5, null);
+                Assert.True(observed.Success, observed.ErrorMessage);
+            },
+            condition: () => ContainsNameInTree(observed?.Tree, expectedStatus),
+            timeout: TimeSpan.FromSeconds(10));
+        Assert.True(ready, $"Electron snapshot did not contain status '{expectedStatus}'.");
+    }
+
+    private static bool ContainsNameInTree(UIElementCompactTree[]? elements, string name) =>
+        elements?.Any(element =>
+            string.Equals(element.Name, name, StringComparison.Ordinal) ||
+            ContainsNameInTree(element.Children, name)) == true;
 
     #endregion
 

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
@@ -8,8 +8,8 @@
       "name": "mcp-electron-test-harness",
       "version": "1.0.0",
       "devDependencies": {
-        "@types/node": "^26.4.0",
-        "electron": "^44.0.0",
+        "@types/node": "^26.4.1",
+        "electron": "^44.2.0",
         "typescript": "^7.0.2"
       }
     },
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha1-PY3IBRWJSVhEjuJmz11rw+UgW9U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "44.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-44.0.0.tgz",
-      "integrity": "sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==",
+      "version": "44.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.2.0.tgz",
+      "integrity": "sha1-19L9UO6G5id340i1UcRQ5NS6YBQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -547,9 +547,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha1-d0HG/Is+GkjjAyODNkK/voQUQ60=",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package-lock.json
@@ -44,7 +44,7 @@
     },
     "node_modules/@types/node": {
       "version": "26.4.1",
-      "integrity": "sha1-PY3IBRWJSVhEjuJmz11rw+UgW9U=",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -390,7 +390,7 @@
     },
     "node_modules/electron": {
       "version": "44.2.0",
-      "integrity": "sha1-19L9UO6G5id340i1UcRQ5NS6YBQ=",
+      "integrity": "sha512-oK1icjhapp3xsUZycO9WZaLmd3hJnA7ieobC4mpdtO1pEN+PPGWpA3m1Mgzzuc1wzSD2Wai4zcH4yfpGJqxFMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -514,7 +514,7 @@
     },
     "node_modules/undici": {
       "version": "7.29.1",
-      "integrity": "sha1-d0HG/Is+GkjjAyODNkK/voQUQ60=",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package.json
+++ b/tests/Sbroenne.WindowsMcp.Tests/Integration/ElectronHarness/package.json
@@ -9,8 +9,8 @@
     "dev": "tsc && electron ."
   },
   "devDependencies": {
-    "@types/node": "^26.4.0",
-    "electron": "^44.0.0",
+    "@types/node": "^26.4.1",
+    "electron": "^44.2.0",
     "typescript": "^7.0.2"
   }
 }

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -12,10 +12,10 @@
         "win32"
       ],
       "devDependencies": {
-        "@types/node": "^26.4.0",
+        "@types/node": "^26.4.1",
         "@types/vscode": "1.125.0",
         "@vscode/vsce": "^3.9.2",
-        "oxlint": "^1.80.0",
+        "oxlint": "^1.81.0",
         "typescript": "^7.0.2"
       },
       "engines": {
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.0.tgz",
-      "integrity": "sha512-JjQWO6akOck45PH/XBrxzsQGAiKrfFl4m5iggJ0ItMIz5omRufOXWpqCPpdjKN3vKDzlSUvFjaMb7Zwf0gvAdA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.11.1.tgz",
+      "integrity": "sha1-2ZCHiohXdQerETGTW0c0sppjfVg=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -82,6 +82,16 @@
         "@azure/logger": "^1.3.0",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-process": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-process/-/core-process-1.0.0.tgz",
+      "integrity": "sha1-w68cFyI9ZTjhs2ln3clM2uUyy4M=",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
       }
@@ -134,26 +144,27 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
-      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "version": "4.13.2",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.2.tgz",
+      "integrity": "sha1-zq1+af9YbcKL67rqIgG2u2lguE8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.9.0",
         "@azure/core-client": "^1.9.2",
+        "@azure/core-process": "^1.0.0",
         "@azure/core-rest-pipeline": "^1.17.0",
         "@azure/core-tracing": "^1.0.0",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
         "@azure/msal-browser": "^5.5.0",
-        "@azure/msal-node": "^5.1.0",
+        "@azure/msal-node": "^5.1.5",
         "open": "^10.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@azure/logger": {
@@ -171,22 +182,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
-      "integrity": "sha512-SPTeHYZghdEdRddJzNjhH+CI5MSQtquNYwGJnYXfOHIBRXCmrWimBS85OhwXpXFIlrCtNTbBPm5mPAWRNEoktA==",
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.21.0.tgz",
+      "integrity": "sha1-2xXEl12SHz/scS4VnJaWwHUdhTw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.12.0"
+        "@azure/msal-common": "16.14.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.12.0.tgz",
-      "integrity": "sha512-hgLgfRdbG2AmhXPygebf1KYJEvse86+ZZLWufdiTKaGRYEUqOzHdlf6AS1IiuUCHWbynkgbHc451jSNkbfhWlg==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.14.0.tgz",
+      "integrity": "sha1-zd2zjYMr4OG+YifqZNTrEZmXInw=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -194,17 +205,27 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.5.0.tgz",
-      "integrity": "sha512-A/2WIsuH0vsC6JVkkafjS4kHpi2LDR4AzDT0kJ+oIRtXYeYtvGQ2pwN2X88thQPhSek+82ela3MprsKXWQRrhQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.6.0.tgz",
+      "integrity": "sha1-jL/v8CG20vPQZKOvuCJirZhehDQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.12.0",
+        "@azure/msal-common": "16.13.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.13.0.tgz",
+      "integrity": "sha1-YuQkxrIeFD6O9DdKZNv4dy3+Ggc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -271,9 +292,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.80.0.tgz",
-      "integrity": "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.81.0.tgz",
+      "integrity": "sha1-hqAwVIDmgEMUKcglnFcBrFWS5Kc=",
       "cpu": [
         "arm"
       ],
@@ -288,9 +309,9 @@
       }
     },
     "node_modules/@oxlint/binding-android-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.80.0.tgz",
-      "integrity": "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.81.0.tgz",
+      "integrity": "sha1-26UcsqEljzfqyhWk501dbuGfI4w=",
       "cpu": [
         "arm64"
       ],
@@ -305,9 +326,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.80.0.tgz",
-      "integrity": "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.81.0.tgz",
+      "integrity": "sha1-84SuHt3TmUKSgfiKAHNynih+wLE=",
       "cpu": [
         "arm64"
       ],
@@ -322,9 +343,9 @@
       }
     },
     "node_modules/@oxlint/binding-darwin-x64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.80.0.tgz",
-      "integrity": "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.81.0.tgz",
+      "integrity": "sha1-cWfjtMGIUvzR3a3lNtIy1z1V0ww=",
       "cpu": [
         "x64"
       ],
@@ -339,9 +360,9 @@
       }
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.80.0.tgz",
-      "integrity": "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.81.0.tgz",
+      "integrity": "sha1-ZPIwdlNDv+fiKAsHG7GRu2ZjA6w=",
       "cpu": [
         "x64"
       ],
@@ -356,9 +377,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.80.0.tgz",
-      "integrity": "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.81.0.tgz",
+      "integrity": "sha1-UJXwIaKACRRvdTanzNUYzfy/w78=",
       "cpu": [
         "arm"
       ],
@@ -373,9 +394,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.80.0.tgz",
-      "integrity": "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.81.0.tgz",
+      "integrity": "sha1-2JTc+2+xuLIkt55s4HsXQD9BN0k=",
       "cpu": [
         "arm"
       ],
@@ -390,9 +411,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.80.0.tgz",
-      "integrity": "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.81.0.tgz",
+      "integrity": "sha1-v442LIfngouijC7Da65zrYKYnvE=",
       "cpu": [
         "arm64"
       ],
@@ -410,9 +431,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.80.0.tgz",
-      "integrity": "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.81.0.tgz",
+      "integrity": "sha1-KqUhTrWwMuj3fZSifJvT9tvERvM=",
       "cpu": [
         "arm64"
       ],
@@ -430,9 +451,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.80.0.tgz",
-      "integrity": "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.81.0.tgz",
+      "integrity": "sha1-oK8a9v0wkhRVXzO0+gQy8+xF8kI=",
       "cpu": [
         "ppc64"
       ],
@@ -450,9 +471,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.80.0.tgz",
-      "integrity": "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.81.0.tgz",
+      "integrity": "sha1-YEE6M1pj4JEaYl0EdpDkHAPyqDM=",
       "cpu": [
         "riscv64"
       ],
@@ -470,9 +491,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.80.0.tgz",
-      "integrity": "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.81.0.tgz",
+      "integrity": "sha1-Xx3XvCvb6S+lRU3wge6R+ixJmUg=",
       "cpu": [
         "riscv64"
       ],
@@ -490,9 +511,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.80.0.tgz",
-      "integrity": "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.81.0.tgz",
+      "integrity": "sha1-gwxb3RRa05ybU3HjIU0Kn5wfRrE=",
       "cpu": [
         "s390x"
       ],
@@ -510,9 +531,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.80.0.tgz",
-      "integrity": "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.81.0.tgz",
+      "integrity": "sha1-f3LqPJrnCnbBqS5WpXVYafM151Y=",
       "cpu": [
         "x64"
       ],
@@ -530,9 +551,9 @@
       }
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.80.0.tgz",
-      "integrity": "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.81.0.tgz",
+      "integrity": "sha1-dY/W6mkSPG9MG6Fgv8KPa4RUjBE=",
       "cpu": [
         "x64"
       ],
@@ -550,9 +571,9 @@
       }
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.80.0.tgz",
-      "integrity": "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.81.0.tgz",
+      "integrity": "sha1-5JK3oYdbcOpV/+E/aF1DAuaxkA4=",
       "cpu": [
         "arm64"
       ],
@@ -567,9 +588,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.80.0.tgz",
-      "integrity": "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.81.0.tgz",
+      "integrity": "sha1-kkf9wbTIbsxxh0fF+MaJApaWd9E=",
       "cpu": [
         "arm64"
       ],
@@ -584,9 +605,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.80.0.tgz",
-      "integrity": "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.81.0.tgz",
+      "integrity": "sha1-36Tu14YSxfTfeI6wVv1dGwWnW7E=",
       "cpu": [
         "ia32"
       ],
@@ -601,9 +622,9 @@
       }
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.80.0.tgz",
-      "integrity": "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.81.0.tgz",
+      "integrity": "sha1-J6R0zCiOR6DlwtnJIr7mTeDP1hQ=",
       "cpu": [
         "x64"
       ],
@@ -891,9 +912,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
-      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha1-PY3IBRWJSVhEjuJmz11rw+UgW9U=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1262,9 +1283,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
-      "integrity": "sha512-bLMpVcWZNzq6lYOybwFwOAR1IXKcHnhUNqYeHjl1bET/qE3jFPFH+p8Wrh3rU4xwdnifPxmKNESBYnvnmc75aA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.9.tgz",
+      "integrity": "sha1-MyhVu9cpqzbgd5st/CTtySDRJGE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1324,9 +1345,9 @@
       }
     },
     "node_modules/@vscode/vsce-sign": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
-      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.1.0.tgz",
+      "integrity": "sha1-b5f4SFOm1TZINhV+LlmeKBDNwSE=",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
@@ -1965,9 +1986,9 @@
       }
     },
     "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha1-F5Cv/FJoD7sR4XyrJ1LWmqKjfSw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2272,9 +2293,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha1-dDFX2Vfzy7TGUxDgM9wq1K19xgo=",
       "dev": true,
       "funding": [
         {
@@ -2289,9 +2310,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.3.tgz",
+      "integrity": "sha1-erhzHmR7VqvP7umX2uMzyj7h0E0=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2642,9 +2663,9 @@
       "optional": true
     },
     "node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+      "integrity": "sha1-hNhGaJmVhFjuMLQZDIOe4URsyI0=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2800,9 +2821,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
       "dev": true,
       "funding": [
         {
@@ -3028,9 +3049,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
-      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "version": "14.3.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+      "integrity": "sha1-iXTiRzd5Nj7VaC6jd/MVZO5R4pI=",
       "dev": true,
       "funding": [
         {
@@ -3214,9 +3235,9 @@
       "optional": true
     },
     "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha1-iwOLxsypfWzsLpqv24G5ANof+A0=",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3341,9 +3362,9 @@
       }
     },
     "node_modules/oxlint": {
-      "version": "1.80.0",
-      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.80.0.tgz",
-      "integrity": "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.81.0.tgz",
+      "integrity": "sha1-eyCtopoXGIPeRRfQQepbBX+0irU=",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3353,28 +3374,28 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "url": "https://github.com/sponsors/oxc-project"
       },
       "optionalDependencies": {
-        "@oxlint/binding-android-arm-eabi": "1.80.0",
-        "@oxlint/binding-android-arm64": "1.80.0",
-        "@oxlint/binding-darwin-arm64": "1.80.0",
-        "@oxlint/binding-darwin-x64": "1.80.0",
-        "@oxlint/binding-freebsd-x64": "1.80.0",
-        "@oxlint/binding-linux-arm-gnueabihf": "1.80.0",
-        "@oxlint/binding-linux-arm-musleabihf": "1.80.0",
-        "@oxlint/binding-linux-arm64-gnu": "1.80.0",
-        "@oxlint/binding-linux-arm64-musl": "1.80.0",
-        "@oxlint/binding-linux-ppc64-gnu": "1.80.0",
-        "@oxlint/binding-linux-riscv64-gnu": "1.80.0",
-        "@oxlint/binding-linux-riscv64-musl": "1.80.0",
-        "@oxlint/binding-linux-s390x-gnu": "1.80.0",
-        "@oxlint/binding-linux-x64-gnu": "1.80.0",
-        "@oxlint/binding-linux-x64-musl": "1.80.0",
-        "@oxlint/binding-openharmony-arm64": "1.80.0",
-        "@oxlint/binding-win32-arm64-msvc": "1.80.0",
-        "@oxlint/binding-win32-ia32-msvc": "1.80.0",
-        "@oxlint/binding-win32-x64-msvc": "1.80.0"
+        "@oxlint/binding-android-arm-eabi": "1.81.0",
+        "@oxlint/binding-android-arm64": "1.81.0",
+        "@oxlint/binding-darwin-arm64": "1.81.0",
+        "@oxlint/binding-darwin-x64": "1.81.0",
+        "@oxlint/binding-freebsd-x64": "1.81.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.81.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.81.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.81.0",
+        "@oxlint/binding-linux-arm64-musl": "1.81.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.81.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.81.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.81.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.81.0",
+        "@oxlint/binding-linux-x64-gnu": "1.81.0",
+        "@oxlint/binding-linux-x64-musl": "1.81.0",
+        "@oxlint/binding-openharmony-arm64": "1.81.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.81.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.81.0",
+        "@oxlint/binding-win32-x64-msvc": "1.81.0"
       },
       "peerDependencies": {
         "oxlint-tsgolint": ">=7.0.2001",
@@ -3390,9 +3411,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
-      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.7.tgz",
+      "integrity": "sha1-qCF13WkEaKkwua5FwrmCnFv2D6M=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3622,9 +3643,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4431,9 +4452,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha1-d0HG/Is+GkjjAyODNkK/voQUQ60=",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -65,7 +65,7 @@
     },
     "node_modules/@azure/core-client": {
       "version": "1.11.1",
-      "integrity": "sha1-2ZCHiohXdQerETGTW0c0sppjfVg=",
+      "integrity": "sha512-2QygG2F76ZpMP2eMztiJvAiFMu71M9rDeU7vO/QKg5Css7MgM4frUOslFjhVjRhbGaCNPtz/S8M6y46/fFKVuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -83,7 +83,7 @@
     },
     "node_modules/@azure/core-process": {
       "version": "1.0.0",
-      "integrity": "sha1-w68cFyI9ZTjhs2ln3clM2uUyy4M=",
+      "integrity": "sha512-/shnJ+ooO8WPxDhPEeI/2oRQuubn16gZ6CvlbpWbEswZfzwI9tI/sMAHmF3x1LuQ9yZYXfLW3TjzGMLEC5blKg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -136,7 +136,7 @@
     },
     "node_modules/@azure/identity": {
       "version": "4.13.2",
-      "integrity": "sha1-zq1+af9YbcKL67rqIgG2u2lguE8=",
+      "integrity": "sha512-NXL2/pCJctLxgw8bvrwwgge743kEq8LBT+O1pmV0vyUwetzFPH9auP6jhkU/cgZCPPtWoewAe3ncaGCgPo07fA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -172,7 +172,7 @@
     },
     "node_modules/@azure/msal-browser": {
       "version": "5.21.0",
-      "integrity": "sha1-2xXEl12SHz/scS4VnJaWwHUdhTw=",
+      "integrity": "sha512-80OcuXDErmcEDAIH9pBtSqBsed2sPT/IWmbG3xHLoPMl5zc8TINd6SlJAbVSmN5huGa3xGAg5qR7VnpaIEK0Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -184,7 +184,7 @@
     },
     "node_modules/@azure/msal-common": {
       "version": "16.14.0",
-      "integrity": "sha1-zd2zjYMr4OG+YifqZNTrEZmXInw=",
+      "integrity": "sha512-A4rb55hI86Q9tBl/+jBj7TMz7iX2RFgQs/nExFzcAtoI/BFRVdaH5SL/MivrYD7qvweMpN8AgVvVMHV8UBYxew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -193,7 +193,7 @@
     },
     "node_modules/@azure/msal-node": {
       "version": "5.6.0",
-      "integrity": "sha1-jL/v8CG20vPQZKOvuCJirZhehDQ=",
+      "integrity": "sha512-uFY9NxrWHw8PwZx7gAX6PDn+9vdfS05+levc/kwkx77IkjfaldnQbbcQzzDIZ5Hq5Zdr6/z92oAIoRWKp6MnOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -206,7 +206,7 @@
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
       "version": "16.13.0",
-      "integrity": "sha1-YuQkxrIeFD6O9DdKZNv4dy3+Ggc=",
+      "integrity": "sha512-rOAy0KUcyBbdwVJ+f3uPpthXatFLLZN+/KWAsTLzk1aB23Xl9DRmmXYwSvBFOZyXj4jUQQ5FKxxRkhAFW1fOow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -273,7 +273,7 @@
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.81.0",
-      "integrity": "sha1-hqAwVIDmgEMUKcglnFcBrFWS5Kc=",
+      "integrity": "sha512-IcCRsXiedJoJopY6mpZUBEeVFsUrutmrG7dZ87zMuKJlhg70Ora9bBl1WcCxZQtyI10YpnVdEso5oCg7YcfSHw==",
       "cpu": [
         "arm"
       ],
@@ -289,7 +289,7 @@
     },
     "node_modules/@oxlint/binding-android-arm64": {
       "version": "1.81.0",
-      "integrity": "sha1-26UcsqEljzfqyhWk501dbuGfI4w=",
+      "integrity": "sha512-GRrIPyTGVhx3L3h+0T5xT2A0jFAcdPv4+IfuXpGDLIdl6XeYhgg/zw72A5ILZoUgRqZuM8F1y+V/gfDriXSxzQ==",
       "cpu": [
         "arm64"
       ],
@@ -305,7 +305,7 @@
     },
     "node_modules/@oxlint/binding-darwin-arm64": {
       "version": "1.81.0",
-      "integrity": "sha1-84SuHt3TmUKSgfiKAHNynih+wLE=",
+      "integrity": "sha512-qNQ9tXRgLuKbqSV1S2h9h4KPHjbovO7RRR2/enUOtHzTkFZ7B9X5zqqHJua8dRyc7dBy7Aoyq5pqTSLFVcAzGQ==",
       "cpu": [
         "arm64"
       ],
@@ -321,7 +321,7 @@
     },
     "node_modules/@oxlint/binding-darwin-x64": {
       "version": "1.81.0",
-      "integrity": "sha1-cWfjtMGIUvzR3a3lNtIy1z1V0ww=",
+      "integrity": "sha512-q0QTm32jWga2Gv4j7IaVZN0jYMi9UV73sWVgFtDA4iIfqwMCLLZ3ve+9KwfYtsaKZSgQhmPaogeZWqDZpcY1Pw==",
       "cpu": [
         "x64"
       ],
@@ -337,7 +337,7 @@
     },
     "node_modules/@oxlint/binding-freebsd-x64": {
       "version": "1.81.0",
-      "integrity": "sha1-ZPIwdlNDv+fiKAsHG7GRu2ZjA6w=",
+      "integrity": "sha512-/+8wVWDXEC7wHVAhOc59Fw/SkMc1arLkFD8iQCaSsmzenK1X4doFqquL9H1wrtGUzaiycVqkf/sSpcILK6W1UA==",
       "cpu": [
         "x64"
       ],
@@ -353,7 +353,7 @@
     },
     "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
       "version": "1.81.0",
-      "integrity": "sha1-UJXwIaKACRRvdTanzNUYzfy/w78=",
+      "integrity": "sha512-4xt422FEgioRq9hAL4Tq7fujGUWnc8z1BJ+Oi8RN8vB8axaP+sdK6a2xdlcQCCYnJg9QMuMFS0AucuIFx/EacA==",
       "cpu": [
         "arm"
       ],
@@ -369,7 +369,7 @@
     },
     "node_modules/@oxlint/binding-linux-arm-musleabihf": {
       "version": "1.81.0",
-      "integrity": "sha1-2JTc+2+xuLIkt55s4HsXQD9BN0k=",
+      "integrity": "sha512-u3vna8KdGplH4DRCW9K54D68fcMo7IxVrkCJWwXnIhwtBdnDnYrmzOUA/XjmBlPpcLsgw9Z5BNdY4za9+Dj+MQ==",
       "cpu": [
         "arm"
       ],
@@ -385,7 +385,7 @@
     },
     "node_modules/@oxlint/binding-linux-arm64-gnu": {
       "version": "1.81.0",
-      "integrity": "sha1-v442LIfngouijC7Da65zrYKYnvE=",
+      "integrity": "sha512-3j9k+gsYsE7nv71GWotXsqsa2l9/aJenD7dVHNt/CBvsb0SgRjSMnHFeP59IXUAl1wvVFhqGl2wJNMwWU3UBlA==",
       "cpu": [
         "arm64"
       ],
@@ -404,7 +404,7 @@
     },
     "node_modules/@oxlint/binding-linux-arm64-musl": {
       "version": "1.81.0",
-      "integrity": "sha1-KqUhTrWwMuj3fZSifJvT9tvERvM=",
+      "integrity": "sha512-k5iAp3dNxW0/uDCBY+WSm8jKB2szu7SkEQZdgRRpDXvuDd69vvDcqhB3A/pWCfCwXyenjNjFn9Td1fVoyAc+Yg==",
       "cpu": [
         "arm64"
       ],
@@ -423,7 +423,7 @@
     },
     "node_modules/@oxlint/binding-linux-ppc64-gnu": {
       "version": "1.81.0",
-      "integrity": "sha1-oK8a9v0wkhRVXzO0+gQy8+xF8kI=",
+      "integrity": "sha512-TFqLja3uYmVSte6nof9GWrex9Z8WgdZrNiLC6Te5rXGDqXB2y4j/26iFhwosXiAFqDhE9JJVuuCkDKLwptTn1g==",
       "cpu": [
         "ppc64"
       ],
@@ -442,7 +442,7 @@
     },
     "node_modules/@oxlint/binding-linux-riscv64-gnu": {
       "version": "1.81.0",
-      "integrity": "sha1-YEE6M1pj4JEaYl0EdpDkHAPyqDM=",
+      "integrity": "sha512-UEcySvGS0NOVo7h7n7CYyJL9+6gFAh7Zc/ToDXVScFvzHSTIxtzkMVU30rmQ6+nQ1LF+UdiRDdJajpDu+OylLg==",
       "cpu": [
         "riscv64"
       ],
@@ -461,7 +461,7 @@
     },
     "node_modules/@oxlint/binding-linux-riscv64-musl": {
       "version": "1.81.0",
-      "integrity": "sha1-Xx3XvCvb6S+lRU3wge6R+ixJmUg=",
+      "integrity": "sha512-H+diDbhD00+wI1IRP8Kz88x/lat+DgtoBJzoTthS16xkTJGNaEkfb8gzmd1rzc/2uDQQMl7GNl+JFUacVeWxIA==",
       "cpu": [
         "riscv64"
       ],
@@ -480,7 +480,7 @@
     },
     "node_modules/@oxlint/binding-linux-s390x-gnu": {
       "version": "1.81.0",
-      "integrity": "sha1-gwxb3RRa05ybU3HjIU0Kn5wfRrE=",
+      "integrity": "sha512-8znJ/5TekjOKg1j1Acho4PJMdiAHLtlcXuWEiipOhAMV6rQcXdmDdXCbheyDczN6TjBwiNfjcP81k4AthrKRzw==",
       "cpu": [
         "s390x"
       ],
@@ -499,7 +499,7 @@
     },
     "node_modules/@oxlint/binding-linux-x64-gnu": {
       "version": "1.81.0",
-      "integrity": "sha1-f3LqPJrnCnbBqS5WpXVYafM151Y=",
+      "integrity": "sha512-Q2Wj70yFsvn5QjlmifFzbj4H+kJy53bwqc41o1fzoM7MpLV1NIbhg/LpWXRfC6KOkSAdUx1Wd8VJsdPmhp/HRA==",
       "cpu": [
         "x64"
       ],
@@ -518,7 +518,7 @@
     },
     "node_modules/@oxlint/binding-linux-x64-musl": {
       "version": "1.81.0",
-      "integrity": "sha1-dY/W6mkSPG9MG6Fgv8KPa4RUjBE=",
+      "integrity": "sha512-cPInHp/ddEe5qkyK2IiyQ8Q3Mp2oLLEhhsGgTK2oZx4L6+llGam1H1yBvJZ7qHfOXj8N3hxBS8sj4tO+gtFlIg==",
       "cpu": [
         "x64"
       ],
@@ -537,7 +537,7 @@
     },
     "node_modules/@oxlint/binding-openharmony-arm64": {
       "version": "1.81.0",
-      "integrity": "sha1-5JK3oYdbcOpV/+E/aF1DAuaxkA4=",
+      "integrity": "sha512-0CQxSX4ajqm07AHBf5U33qQzXKdd7wtq/oTL/7vpY6RNNuxrRi8W4bqUV1Jyu/vj+9KmxQyDhxfeVX1nQL6kfg==",
       "cpu": [
         "arm64"
       ],
@@ -553,7 +553,7 @@
     },
     "node_modules/@oxlint/binding-win32-arm64-msvc": {
       "version": "1.81.0",
-      "integrity": "sha1-kkf9wbTIbsxxh0fF+MaJApaWd9E=",
+      "integrity": "sha512-l0hbeISm9673hVrrQU8j/p2M7YH9Ouoj7p7E/QM55NTrKVLP+P3PF8hLu+OY+x0VtGRW+ggiQKZqmdYps9H+TA==",
       "cpu": [
         "arm64"
       ],
@@ -569,7 +569,7 @@
     },
     "node_modules/@oxlint/binding-win32-ia32-msvc": {
       "version": "1.81.0",
-      "integrity": "sha1-36Tu14YSxfTfeI6wVv1dGwWnW7E=",
+      "integrity": "sha512-ksqPP5jbFXcYreEQ7zdJh06rJQBymCTyGRCdaXjfcf2aG4f8KxUWY5wcgYHmaTK+FJ4bPG5sUAdOX+6trnH1JA==",
       "cpu": [
         "ia32"
       ],
@@ -585,7 +585,7 @@
     },
     "node_modules/@oxlint/binding-win32-x64-msvc": {
       "version": "1.81.0",
-      "integrity": "sha1-J6R0zCiOR6DlwtnJIr7mTeDP1hQ=",
+      "integrity": "sha512-IZuUCwGw9emG5JtCp+fYGB+Z4OWEoeEcM8R5BA1pYw63/ieYFVdcU2ylxTpHbVHSenZnsYE+ZZ20uHAJszQ4cA==",
       "cpu": [
         "x64"
       ],
@@ -852,7 +852,7 @@
     },
     "node_modules/@types/node": {
       "version": "26.4.1",
-      "integrity": "sha1-PY3IBRWJSVhEjuJmz11rw+UgW9U=",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1199,7 +1199,7 @@
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.9",
-      "integrity": "sha1-MyhVu9cpqzbgd5st/CTtySDRJGE=",
+      "integrity": "sha512-edSdeAqkdxBVzA1yL1LrLCml1YjyCVvPMtMqJpbF+6K609tHe8V6sQUzFQSGcYNhcuhOceZtjvN32+mpIth30A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1259,7 +1259,7 @@
     },
     "node_modules/@vscode/vsce-sign": {
       "version": "2.1.0",
-      "integrity": "sha1-b5f4SFOm1TZINhV+LlmeKBDNwSE=",
+      "integrity": "sha512-9AQrqazrBgTgRSuwleLVXUrIUphY02/SFCh2TKYoLV/xifJAdblhdmEmw5gUrYSPQ3sRwNs9iyCMD14sATEE6g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.txt",
@@ -1853,7 +1853,7 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.1",
-      "integrity": "sha1-F5Cv/FJoD7sR4XyrJ1LWmqKjfSw=",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2136,7 +2136,7 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.7",
-      "integrity": "sha1-dDFX2Vfzy7TGUxDgM9wq1K19xgo=",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -2152,7 +2152,7 @@
     },
     "node_modules/fastq": {
       "version": "1.20.3",
-      "integrity": "sha1-erhzHmR7VqvP7umX2uMzyj7h0E0=",
+      "integrity": "sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2480,7 +2480,7 @@
     },
     "node_modules/ignore": {
       "version": "7.0.8",
-      "integrity": "sha1-hNhGaJmVhFjuMLQZDIOe4URsyI0=",
+      "integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2625,7 +2625,7 @@
     },
     "node_modules/js-yaml": {
       "version": "4.3.2",
-      "integrity": "sha1-jkT7FKJkPFlya7FXh7XxUSyz0/s=",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -2832,7 +2832,7 @@
     },
     "node_modules/markdown-it": {
       "version": "14.3.1",
-      "integrity": "sha1-iXTiRzd5Nj7VaC6jd/MVZO5R4pI=",
+      "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
       "dev": true,
       "funding": [
         {
@@ -3002,7 +3002,7 @@
     },
     "node_modules/node-abi": {
       "version": "3.96.0",
-      "integrity": "sha1-iwOLxsypfWzsLpqv24G5ANof+A0=",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3119,7 +3119,7 @@
     },
     "node_modules/oxlint": {
       "version": "1.81.0",
-      "integrity": "sha1-eyCtopoXGIPeRRfQQepbBX+0irU=",
+      "integrity": "sha512-HyrJYqeoOCL0iqaLEzGewGT48ZX99P3hxYh8udAF9RGGIghSamkXE4ClUyBpEDNqasamThgmlPbuMOe7SAZmHg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3167,7 +3167,7 @@
     },
     "node_modules/p-map": {
       "version": "7.0.7",
-      "integrity": "sha1-qCF13WkEaKkwua5FwrmCnFv2D6M=",
+      "integrity": "sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3381,7 +3381,7 @@
     },
     "node_modules/qs": {
       "version": "6.16.0",
-      "integrity": "sha1-wixyOiipIPOqzc6Cifq9Q+zLef0=",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4134,7 +4134,7 @@
     },
     "node_modules/undici": {
       "version": "7.29.1",
-      "integrity": "sha1-d0HG/Is+GkjjAyODNkK/voQUQ60=",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -67,10 +67,10 @@
     "lint": "oxlint src"
   },
   "devDependencies": {
-    "@types/node": "^26.4.0",
+    "@types/node": "^26.4.1",
     "@types/vscode": "1.125.0",
     "@vscode/vsce": "^3.9.2",
-    "oxlint": "^1.80.0",
+    "oxlint": "^1.81.0",
     "typescript": "^7.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- Update .NET packages and SDK, npm direct and indirect dependencies, Electron, AnyIO, and the pinned setup-uv action.
- Keep VS Code 1.125 support and prevent incompatible @types/vscode updates from Dependabot.
- Merge current main and preserve #213's tracked project .npmrc files, portable lockfiles without fixed download URLs, and pre-install validation. Machine-level NuGet, pip, and npm configuration is unchanged.
- Includes the original updates proposed in #206, #207, #209, and #210; Dependabot may subsequently propose newer versions. Intentionally retains the compatibility pin instead of applying #208.
- AnyIO 4.15.0 is the latest available through the configured pip source; 4.15.1 was unavailable there during this update.

## Electron regression fix
The shared fixture resets the viewport but preserves renderer status. The old snapshot test could click Forms while Forms was already displayed, producing no change. Added Home/Forms initial-state cases that reproduced this failure before the fix. The test now establishes and verifies Home before capturing its baseline, waits for Forms using raw trees (without advancing snapshot state), and asserts the actual Forms change rather than any nonempty diff. No production behavior was changed.

## Validation
- Release build completed without warnings or errors.
- Both snapshot regression cases passed five consecutive runs (10/10).
- Related Electron and snapshot tests: 75 passed.
- Non-desktop .NET suite: 935 passed, 318 skipped; full desktop suite runs on the dedicated CI runner.
- Lockfile portability validator and all 17 configuration tests passed after merging main.
- Clean npm installs, extension compatibility test, lint, TypeScript compilation, and Electron harness compilation passed for the dependency update.
- Python requirements installed through existing pip configuration; pip check passed and all 139 tests collected. Paid LLM tests were not run.
